### PR TITLE
Streamable HTTP transport implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,10 +57,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "bumpalo"
+version = "3.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cc"
+version = "1.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -69,7 +90,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "example-client"
+version = "0.1.0"
+dependencies = [
+ "neva",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "example-http"
 version = "0.1.0"
 dependencies = [
  "neva",
@@ -134,6 +171,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,10 +225,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "h2"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "inventory"
@@ -183,6 +372,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -219,6 +418,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.0.9"
+version = "0.1.0"
 dependencies = [
  "base64",
  "futures-util",
@@ -253,12 +468,14 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
+ "volga",
  "windows",
 ]
 
 [[package]]
 name = "neva_macros"
-version = "0.0.9"
+version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -332,6 +549,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,10 +594,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustls"
+version = "0.23.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -427,6 +695,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,12 +716,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -459,6 +754,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -511,6 +812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +833,12 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -594,10 +911,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -606,10 +945,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "volga"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1b4740bc14398fe8a6ee5c84ec02e3cd5972a5e782cf4af354ca3153371142"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body-util",
+ "httpdate",
+ "hyper",
+ "hyper-util",
+ "indexmap",
+ "itoa",
+ "memchr",
+ "mime",
+ "mime_guess",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "winapi"
@@ -806,3 +1230,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,7 +252,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -259,6 +291,12 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -355,7 +393,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -449,7 +487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -458,13 +496,16 @@ name = "neva"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "dashmap",
  "futures-util",
  "inventory",
  "neva_macros",
  "nix",
+ "once_cell",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -585,6 +626,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,7 +648,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted",
  "windows-sys",
@@ -822,6 +869,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +992,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
+ "getrandom 0.3.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -976,6 +1035,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1230,6 +1298,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "zeroize"

--- a/examples/http/Cargo.toml
+++ b/examples/http/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example-http"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+neva = { path = "../../neva", features = ["server-full", "macros"] }
+tokio = { version = "1.44.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.19"

--- a/examples/http/src/main.rs
+++ b/examples/http/src/main.rs
@@ -26,7 +26,7 @@ async fn main() {
         .with_options(|opt| opt
             .with_http(|http| http
                 .bind("127.0.0.1:3000")
-                .with_prefix("/mcp")
+                .with_endpoint("/mcp")
             )
             .with_logging(handle))
         .run()

--- a/examples/http/src/main.rs
+++ b/examples/http/src/main.rs
@@ -1,0 +1,34 @@
+//! Run with:
+//!
+//! ```no_rust
+//! npx @modelcontextprotocol/inspector cargo run -p example-http
+//! ```
+use neva::{App, tool};
+use tracing_subscriber::{filter, reload, prelude::*};
+use neva::types::notification::NotificationFormatter;
+
+#[tool]
+async fn remote_tool(name: String) {
+    tracing::debug!("running remote tool: {}", name);
+}
+
+#[tokio::main]
+async fn main() {
+    let (filter, handle) = reload::Layer::new(filter::LevelFilter::DEBUG);
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(tracing_subscriber::fmt::layer()
+            .event_format(NotificationFormatter))
+        .init();
+    
+    App::new()
+        .with_options(|opt| opt
+            .with_http(|http| http
+                .bind("127.0.0.1:3000")
+                .with_prefix("/mcp")
+            )
+            .with_logging(handle))
+        .run()
+        .await;
+}

--- a/examples/http/src/main.rs
+++ b/examples/http/src/main.rs
@@ -3,31 +3,30 @@
 //! ```no_rust
 //! npx @modelcontextprotocol/inspector cargo run -p example-http
 //! ```
-use neva::{App, tool};
+use neva::{App, Context, tool};
 use tracing_subscriber::{filter, reload, prelude::*};
-use neva::types::notification::NotificationFormatter;
+use neva::types::notification;
 
 #[tool]
-async fn remote_tool(name: String) {
+async fn remote_tool(name: String, mut ctx: Context) {
     tracing::debug!("running remote tool: {}", name);
+    let roots = ctx.list_roots().await.unwrap();
+    tracing::debug!("roots: {:?}", roots.roots);
 }
 
 #[tokio::main]
 async fn main() {
     let (filter, handle) = reload::Layer::new(filter::LevelFilter::DEBUG);
-
     tracing_subscriber::registry()
         .with(filter)
-        .with(tracing_subscriber::fmt::layer()
-            .event_format(NotificationFormatter))
+        .with(notification::fmt::layer())
         .init();
     
     App::new()
         .with_options(|opt| opt
             .with_http(|http| http
                 .bind("127.0.0.1:3000")
-                .with_endpoint("/mcp")
-            )
+                .with_endpoint("/mcp"))
             .with_logging(handle))
         .run()
         .await;

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -14,16 +14,19 @@ keywords = ["neva", "mcp", "server", "ai", "framework"]
 
 [dependencies]
 base64 = "0.22.1"
+dashmap = "6.1.0"
 futures-util = { version = "0.3.31", default-features = false, features = ["alloc"] }
 inventory = { version = "0.3.20", optional = true }
+once_cell = { version = "1.21.3", features = ["std"], optional = true }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 tokio = { version = "1.45.1", features = ["sync", "io-std", "io-util", "rt", "time", "macros"] }
+tokio-stream = { version = "0.1.17", optional = true }
 tokio-util = "0.7.15"
 tracing = { version = "0.1.41", optional = true }
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "json"], optional = true }
-volga = { version = "0.5.8", optional = true }
-uuid = { version = "1.17.0", optional = true }
+volga = { version = "0.5.8", features = ["di"], optional = true }
+uuid = { version = "1.17.0", features = ["v4"], optional = true }
 neva_macros = { path = "../neva_macros", version = "0.1.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -40,13 +43,13 @@ default = []
 full = ["macros", "tracing", "server-full", "client-full"]
 server-full = ["server", "macros", "tracing", "http-server"]
 client-full = ["client", "tracing", "http-client"]
-http-server = ["dep:volga", "dep:uuid"]
+http-server = ["dep:volga", "dep:uuid", "dep:tokio-stream"]
 http-client = ["dep:uuid"]
 tls = ["http-server", "volga/tls"]
 macros = ["dep:neva_macros", "dep:inventory"]
 client = ["dep:windows", "dep:nix", "tokio/process", "tokio/signal"]
 server = ["tokio/signal"]
-tracing = ["dep:tracing", "dep:tracing-subscriber", "volga?/tracing"]
+tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:once_cell", "volga?/tracing"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -26,7 +26,7 @@ tokio-util = "0.7.15"
 tracing = { version = "0.1.41", optional = true }
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "json"], optional = true }
 volga = { version = "0.5.8", features = ["di"], optional = true }
-uuid = { version = "1.17.0", features = ["v4"], optional = true }
+uuid = { version = "1.17.0", features = ["v4"] }
 neva_macros = { path = "../neva_macros", version = "0.1.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
@@ -43,8 +43,8 @@ default = []
 full = ["macros", "tracing", "server-full", "client-full"]
 server-full = ["server", "macros", "tracing", "http-server"]
 client-full = ["client", "tracing", "http-client"]
-http-server = ["dep:volga", "dep:uuid", "dep:tokio-stream"]
-http-client = ["dep:uuid"]
+http-server = ["dep:volga", "dep:tokio-stream"]
+http-client = []
 tls = ["http-server", "volga/tls"]
 macros = ["dep:neva_macros", "dep:inventory"]
 client = ["dep:windows", "dep:nix", "tokio/process", "tokio/signal"]

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neva"
-version = "0.0.9"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.85.0"
 authors = ["Roman Emreis <roman.emreis@outlook.com>"]
@@ -22,7 +22,9 @@ tokio = { version = "1.45.1", features = ["sync", "io-std", "io-util", "rt", "ti
 tokio-util = "0.7.15"
 tracing = { version = "0.1.41", optional = true }
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "json"], optional = true }
-neva_macros = { path = "../neva_macros", version = "0.0.9", optional = true }
+volga = { version = "0.5.8", optional = true }
+uuid = { version = "1.17.0", optional = true }
+neva_macros = { path = "../neva_macros", version = "0.1.0", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.61.1", features = ["Win32_Foundation", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_Security", "Win32_System_Diagnostics", "Win32_System_Diagnostics_ToolHelp"], optional = true }
@@ -35,13 +37,16 @@ tokio = { version = "1.45.1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]
 default = []
-full = ["macros", "tracing", "server", "client"]
-server-full = ["server", "macros", "tracing"]
-client-full = ["client", "tracing"]
+full = ["macros", "tracing", "server-full", "client-full"]
+server-full = ["server", "macros", "tracing", "http-server"]
+client-full = ["client", "tracing", "http-client"]
+http-server = ["dep:volga", "dep:uuid"]
+http-client = ["dep:uuid"]
+tls = ["http-server", "volga/tls"]
 macros = ["dep:neva_macros", "dep:inventory"]
 client = ["dep:windows", "dep:nix", "tokio/process", "tokio/signal"]
 server = []
-tracing = ["dep:tracing", "dep:tracing-subscriber"]
+tracing = ["dep:tracing", "dep:tracing-subscriber", "volga?/tracing"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -45,7 +45,7 @@ http-client = ["dep:uuid"]
 tls = ["http-server", "volga/tls"]
 macros = ["dep:neva_macros", "dep:inventory"]
 client = ["dep:windows", "dep:nix", "tokio/process", "tokio/signal"]
-server = []
+server = ["tokio/signal"]
 tracing = ["dep:tracing", "dep:tracing-subscriber", "volga?/tracing"]
 
 [package.metadata.docs.rs]

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -14,7 +14,16 @@ use crate::app::handler::{
     RequestFunc,
     RequestHandler
 };
-use crate::types::{InitializeResult, InitializeRequestParams, IntoResponse, Response, Request, Message, CompleteResult, CompleteRequestParams, ListToolsRequestParams, CallToolRequestParams, ListToolsResult, CallToolResponse, Tool, ToolHandler, ListResourceTemplatesRequestParams, ListResourceTemplatesResult, ResourceTemplate, ListResourcesRequestParams, ListResourcesResult, ReadResourceRequestParams, ReadResourceResult, SubscribeRequestParams, UnsubscribeRequestParams, Resource, resource::template::ResourceFunc, ListPromptsRequestParams, ListPromptsResult, GetPromptRequestParams, GetPromptResult, PromptHandler, Prompt, notification::{Notification, CancelledNotificationParams}, cursor::Pagination, Uri, RequestId};
+use crate::types::{
+    InitializeResult, InitializeRequestParams, IntoResponse, Response, Request, Message, 
+    CompleteResult, CompleteRequestParams, ListToolsRequestParams, CallToolRequestParams, ListToolsResult, CallToolResponse, Tool, ToolHandler, 
+    ListResourceTemplatesRequestParams, ListResourceTemplatesResult, ResourceTemplate, 
+    ListResourcesRequestParams, ListResourcesResult, ReadResourceRequestParams, ReadResourceResult, 
+    SubscribeRequestParams, UnsubscribeRequestParams, Resource, resource::template::ResourceFunc, 
+    ListPromptsRequestParams, ListPromptsResult, GetPromptRequestParams, GetPromptResult, PromptHandler, Prompt, 
+    notification::{Notification, CancelledNotificationParams}, 
+    cursor::Pagination, Uri
+};
 #[cfg(feature = "tracing")]
 use tracing::Instrument;
 #[cfg(feature = "tracing")]

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -39,6 +39,7 @@ pub(crate) struct ServerRuntime {
 /// Represents MCP Request Context
 #[derive(Clone)]
 pub struct Context {
+    pub session_id: Option<String>,
     pub(crate) options: RuntimeMcpOptions,
     pending: RequestQueue,
     sender: TransportProtoSender,
@@ -76,8 +77,9 @@ impl ServerRuntime {
     }
     
     /// Creates a new MCP request [`Context`]
-    pub(crate) fn context(&self) -> Context {
+    pub(crate) fn context(&self, session_id: Option<String>) -> Context {
         Context {
+            session_id,
             pending: self.pending.clone(),
             sender: self.sender.clone(),
             options: self.options.clone(),
@@ -313,13 +315,12 @@ impl Context {
     /// ```
     pub async fn list_roots(&mut self) -> Result<ListRootsResult, Error> {
         let method = crate::types::root::commands::LIST;
-        let id = RequestId::String(method.into());
         let req = Request::new(
-            Some(id.clone()),
+            Some(RequestId::String(method.into())),
             method,
             Some(ListRootsRequestParams::default()));
-
-        self.send_request(&id, req)
+        
+        self.send_request(req)
             .await?
             .into_result()
     }
@@ -350,28 +351,33 @@ impl Context {
     /// ```
     pub async fn sample(&mut self, params: CreateMessageRequestParams) -> Result<CreateMessageResult, Error> {
         let method = crate::types::sampling::commands::CREATE;
-        let id = RequestId::String(method.into());
         let req = Request::new(
-            Some(id.clone()),
+            Some(RequestId::String(method.into())),
             method,
             Some(params));
 
-        self.send_request(&id, req)
+        self.send_request(req)
             .await?
             .into_result()
     }
     
     /// Sends a [`Request`] to a client
     #[inline]
-    async fn send_request(&mut self, id: &RequestId, req: Request) -> Result<Response, Error> {
-        let receiver = self.pending.push(id).await;
+    async fn send_request(&mut self, mut req: Request) -> Result<Response, Error> {
+        let mut id = req.id();
+        if let Some(session_id) = &self.session_id {
+            req.session_id = Some(session_id.clone());
+            id = RequestId::String(format!("{}/{}", session_id, id));
+        }
+
+        let receiver = self.pending.push(&id).await;
         self.sender.send(req.into()).await?;
 
         match timeout(self.timeout, receiver).await {
             Ok(Ok(resp)) => Ok(resp),
             Ok(Err(_)) => Err(Error::new(ErrorCode::InternalError, "Response channel closed")),
             Err(_) => {
-                _ = self.pending.pop(id).await;
+                _ = self.pending.pop(&id).await;
                 Err(Error::new(ErrorCode::Timeout, "Request timed out"))
             }
         }

--- a/neva/src/app/options.rs
+++ b/neva/src/app/options.rs
@@ -4,6 +4,8 @@ use std::{sync::Arc, time::Duration};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 use crate::transport::{StdIoServer, TransportProto};
+#[cfg(feature = "http-server")]
+use crate::transport::HttpServer;
 use crate::app::{handler::RequestHandler, collection::Collection};
 use std::{
     borrow::Cow,
@@ -116,6 +118,13 @@ impl McpOptions {
     /// Sets stdio as a transport protocol
     pub fn with_stdio(mut self) -> Self {
         self.proto = Some(TransportProto::StdIoServer(StdIoServer::new()));
+        self
+    }
+
+    /// Sets stdio as a transport protocol
+    #[cfg(feature = "http-server")]
+    pub fn with_http<F: FnOnce(HttpServer) -> HttpServer>(mut self, config: F) -> Self {
+        self.proto = Some(TransportProto::HttpServer(config(HttpServer::default())));
         self
     }
     

--- a/neva/src/shared.rs
+++ b/neva/src/shared.rs
@@ -1,5 +1,22 @@
 ﻿//! Shared utilities for server and client
 
+use tokio_util::sync::CancellationToken;
 pub(crate) use requests_queue::RequestQueue;
 
 pub(crate) mod requests_queue;
+
+#[inline]
+pub(crate) fn wait_for_shutdown_signal(token: CancellationToken) {
+    tokio::spawn(async move {
+        match tokio::signal::ctrl_c().await {
+            Ok(_) => (),
+            #[cfg(feature = "tracing")]
+            Err(err) => tracing::error!(
+                    logger = "neva",
+                    "Unable to listen for shutdown signal: {}", err),
+            #[cfg(not(feature = "tracing"))]
+            Err(_) => ()
+        }
+        token.cancel();
+    });
+}

--- a/neva/src/shared.rs
+++ b/neva/src/shared.rs
@@ -4,6 +4,7 @@ use tokio_util::sync::CancellationToken;
 pub(crate) use requests_queue::RequestQueue;
 
 pub(crate) mod requests_queue;
+pub(crate) mod message_registry;
 
 #[inline]
 pub(crate) fn wait_for_shutdown_signal(token: CancellationToken) {

--- a/neva/src/shared/message_registry.rs
+++ b/neva/src/shared/message_registry.rs
@@ -1,0 +1,135 @@
+﻿//! Tools for binding message channels with MCP Sessions
+
+use dashmap::DashMap;
+use tokio::sync::mpsc::UnboundedSender;
+use uuid::Uuid;
+use crate::error::{Error, ErrorCode};
+use crate::types::Message;
+
+/// A concurrent message registry that bounds the MCP session ID and related message channel
+#[derive(Default)]
+pub(crate) struct MessageRegistry {
+    inner: DashMap<Uuid, UnboundedSender<Message>>
+}
+
+#[allow(dead_code)]
+impl MessageRegistry {
+    /// Creates a new [`MessageRegistry`]
+    #[inline]
+    pub(crate) fn new() -> Self {
+        Self { inner: DashMap::new() }
+    }
+    
+    /// Registers MCP session channel
+    #[inline]
+    pub(crate) fn register(&self, key: Uuid, sender: UnboundedSender<Message>) {
+        self.inner.insert(key, sender);
+    }
+
+    /// Unregisters MCP session channel
+    #[inline]
+    pub(crate) fn unregister(&self, key: &Uuid) -> Option<(Uuid, UnboundedSender<Message>)> {
+        self.inner.remove(key)
+    }
+
+    /// Sends a message into an appropriate channel
+    #[inline]
+    pub(crate) fn send(&self, message: Message) -> Result<(), Error> {
+        let session_id = message
+            .session_id()
+            .ok_or(ErrorCode::InvalidParams)?;
+        
+        if let Some(sender) = self.inner.get(session_id) {
+            sender
+                .send(message)
+                .map_err(|e| Error::new(ErrorCode::InternalError, e))
+        } else {
+            Err(Error::new(ErrorCode::InvalidParams, "Sender not found"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+    use crate::types::Message;
+    use crate::types::notification::Notification;
+
+    #[test]
+    fn it_creates_new_registry() {
+        let registry = MessageRegistry::new();
+        assert!(registry.inner.is_empty());
+    }
+
+    #[test]
+    fn it_registers_and_unregisters() {
+        let registry = MessageRegistry::new();
+        let session_id = Uuid::new_v4();
+        let (tx, _rx) = mpsc::unbounded_channel();
+
+        // Test registration
+        registry.register(session_id, tx.clone());
+        assert!(registry.inner.contains_key(&session_id));
+
+        // Test unregistration
+        let result = registry.unregister(&session_id);
+        assert!(result.is_some());
+        assert!(!registry.inner.contains_key(&session_id));
+
+        // Test unregistering non-existent session
+        let random_id = Uuid::new_v4();
+        let result = registry.unregister(&random_id);
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn it_sends_message() {
+        let registry = MessageRegistry::new();
+        let session_id = Uuid::new_v4();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        registry.register(session_id, tx);
+
+        // Create a test message
+        let test_message = Message::Notification(Notification::new("test", None))
+            .set_session_id(session_id);
+
+        // Send the message
+        let send_result = registry.send(test_message);
+        assert!(send_result.is_ok());
+
+        // Verify the message received
+        let received = rx.recv().await;
+        assert!(received.is_some());
+        assert_eq!(received.unwrap().session_id(), Some(&session_id));
+    }
+
+    #[test]
+    fn it_sends_to_nonexistent_session() {
+        let registry = MessageRegistry::new();
+        let session_id = Uuid::new_v4();
+
+        // Create a test message for a non-existent session
+        let test_message = Message::Notification(Notification::new("test", None))
+            .set_session_id(session_id);
+
+        // Attempt to send a message
+        let send_result = registry.send(test_message);
+        assert!(send_result.is_err());
+        assert_eq!(send_result.unwrap_err().code, ErrorCode::InvalidParams);
+    }
+
+    #[test]
+    fn it_sends_message_without_session_id() {
+        let registry = MessageRegistry::new();
+
+        // Create a message without session ID
+        let test_message = Message::Notification(Notification::new("test", None));
+
+        // Attempt to send a message
+        let send_result = registry.send(test_message);
+        assert!(send_result.is_err());
+        assert_eq!(send_result.unwrap_err().code, ErrorCode::InvalidParams);
+    }
+}

--- a/neva/src/shared/requests_queue.rs
+++ b/neva/src/shared/requests_queue.rs
@@ -60,7 +60,10 @@ impl RequestQueue {
     /// Takes a [`Response`] and completes the request if it's still pending
     #[inline]
     pub(crate) async fn complete(&self, resp: Response) {
-        if let Some(sender) = self.pop(resp.id()).await {
+        let id = resp.session_id()
+            .map(|session_id| RequestId::String(format!("{}/{}", session_id, resp.id())))
+            .unwrap_or_else(|| resp.id().clone());
+        if let Some(sender) = self.pop(&id).await {
             sender.send(resp)
         }
     }

--- a/neva/src/shared/requests_queue.rs
+++ b/neva/src/shared/requests_queue.rs
@@ -60,10 +60,7 @@ impl RequestQueue {
     /// Takes a [`Response`] and completes the request if it's still pending
     #[inline]
     pub(crate) async fn complete(&self, resp: Response) {
-        let id = resp.session_id()
-            .map(|session_id| RequestId::String(format!("{}/{}", session_id, resp.id())))
-            .unwrap_or_else(|| resp.id().clone());
-        if let Some(sender) = self.pop(&id).await {
+        if let Some(sender) = self.pop(&resp.full_id()).await {
             sender.send(resp)
         }
     }

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -162,11 +162,10 @@ impl Transport for HttpServer {
             tracing::error!(logger = "neva", "The HTTP writer is already in use");
             return token;
         };
-        
         tokio::spawn(server::serve(
             self.url(),
             self.receiver.tx.clone(), 
-            sender_rx, 
+            sender_rx,
             token.clone())
         );
         

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -1,0 +1,180 @@
+//! Streamable HTTP transport implementation
+
+use std::fmt::Display;
+use futures_util::TryFutureExt;
+use tokio_util::sync::CancellationToken;
+use tokio::sync::{mpsc::{self, Receiver, Sender}};
+use crate::{
+    error::{Error, ErrorCode},
+    types::Message
+};
+use super::{
+    Transport,
+    Sender as TransportSender,
+    Receiver as TransportReceiver
+};
+
+#[cfg(feature = "server")]
+pub(crate) mod server;
+
+const DEFAULT_ADDR: &str = "127.0.0.1:3000";
+const DEFAULT_PREFIX: &str = "/mcp";
+
+/// Represents HTTP server transport
+#[cfg(feature = "server")]
+pub struct HttpServer {
+    url: ServiceUrl,
+    sender: HttpSender,
+    receiver: HttpReceiver,
+}
+
+#[cfg(feature = "server")]
+#[derive(Clone)]
+pub struct ServiceUrl {
+    addr: &'static str,
+    prefix: &'static str,
+} 
+
+/// Represents HTTP sender
+pub(crate) struct HttpSender {
+    tx: Sender<Message>,
+    rx: Option<Receiver<Message>>,
+}
+
+/// Represents HTTP receiver
+pub(crate) struct HttpReceiver {
+    tx: Sender<Result<Message, Error>>,
+    rx: Receiver<Result<Message, Error>>
+}
+
+#[cfg(feature = "server")]
+impl Default for HttpServer {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            url: ServiceUrl::default(),
+            receiver: HttpReceiver::new(),
+            sender: HttpSender::new()
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl Default for ServiceUrl {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            addr: DEFAULT_ADDR,
+            prefix: DEFAULT_PREFIX,
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl Display for ServiceUrl {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(feature = "tls")]
+        let proto = "https";
+        #[cfg(not(feature = "tls"))]
+        let proto = "http";
+        write!(f, "{proto}://{}{}", self.addr, self.prefix)
+    }
+}
+
+impl Clone for HttpSender {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            rx: None,
+        }
+    }
+}
+
+impl HttpSender {
+    /// Creates a new stdio transport sender
+    pub(crate) fn new() -> Self {
+        let (tx, rx) = mpsc::channel(100);
+        Self { tx, rx: Some(rx) }
+    }
+    
+    
+}
+
+impl HttpReceiver {
+    /// Creates a new stdio transport receiver
+    pub(crate) fn new() -> Self {
+        let (tx, rx) = mpsc::channel(100);
+        Self { tx, rx }
+    }
+}
+
+#[cfg(feature = "server")]
+impl HttpServer {
+    /// Binds HTTP serve to address and port    
+    pub fn bind(mut self, addr: &'static str) -> Self {
+        self.url.addr = addr;
+        self
+    }
+    
+    /// Sets the URL prefix
+    /// 
+    /// Default: `/mcp`
+    pub fn with_prefix(mut self, prefix: &'static str) -> Self {
+        self.url.prefix = prefix;
+        self
+    }
+    
+    /// Returns service URL (IP, port and URL prefix)
+    pub(crate) fn url(&self) -> ServiceUrl {
+        self.url.clone()
+    }
+}
+
+impl TransportSender for HttpSender {
+    async fn send(&mut self, msg: Message) -> Result<(), Error> {
+        self.tx
+            .send(msg)
+            .map_err(|err| Error::new(ErrorCode::InternalError, err))
+            .await
+    }
+}
+
+impl TransportReceiver for HttpReceiver {
+    async fn recv(&mut self) -> Result<Message, Error> {
+        self.rx
+            .recv()
+            .await
+            .unwrap_or_else(|| Err(Error::new(ErrorCode::InvalidRequest, "Unexpected end of stream")))
+    }
+}
+
+#[cfg(feature = "server")]
+impl Transport for HttpServer {
+    type Sender = HttpSender;
+    type Receiver = HttpReceiver;
+
+    fn start(&mut self) -> CancellationToken {
+        let token = CancellationToken::new();
+        let Some(sender_rx) = self.sender.rx.take() else {
+            #[cfg(feature = "tracing")]
+            tracing::error!(logger = "neva", "The HTTP writer is already in use");
+            return token;
+        };
+        
+        tokio::spawn(server::serve(
+            self.url(),
+            self.receiver.tx.clone(), 
+            sender_rx, 
+            token.clone())
+        );
+        
+        token
+    }
+
+    #[inline]
+    fn split(self) -> (Self::Sender, Self::Receiver) {
+        (self.sender, self.receiver)
+    }
+}

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -18,7 +18,7 @@ use super::{
 pub(crate) mod server;
 
 const DEFAULT_ADDR: &str = "127.0.0.1:3000";
-const DEFAULT_PREFIX: &str = "/mcp";
+const DEFAULT_MCP_ENDPOINT: &str = "/mcp";
 
 /// Represents HTTP server transport
 #[cfg(feature = "server")]
@@ -32,7 +32,7 @@ pub struct HttpServer {
 #[derive(Clone)]
 pub struct ServiceUrl {
     addr: &'static str,
-    prefix: &'static str,
+    endpoint: &'static str,
 } 
 
 /// Represents HTTP sender
@@ -65,7 +65,7 @@ impl Default for ServiceUrl {
     fn default() -> Self {
         Self {
             addr: DEFAULT_ADDR,
-            prefix: DEFAULT_PREFIX,
+            endpoint: DEFAULT_MCP_ENDPOINT,
         }
     }
 }
@@ -78,7 +78,7 @@ impl Display for ServiceUrl {
         let proto = "https";
         #[cfg(not(feature = "tls"))]
         let proto = "http";
-        write!(f, "{proto}://{}{}", self.addr, self.prefix)
+        write!(f, "{proto}://{}{}", self.addr, self.endpoint)
     }
 }
 
@@ -118,11 +118,11 @@ impl HttpServer {
         self
     }
     
-    /// Sets the URL prefix
+    /// Sets the MCP endpoint
     /// 
     /// Default: `/mcp`
-    pub fn with_prefix(mut self, prefix: &'static str) -> Self {
-        self.url.prefix = prefix;
+    pub fn with_endpoint(mut self, prefix: &'static str) -> Self {
+        self.url.endpoint = prefix;
         self
     }
     

--- a/neva/src/transport/http/server.rs
+++ b/neva/src/transport/http/server.rs
@@ -70,7 +70,7 @@ async fn handle(
     
     server
         .map_err(handle_http_error)
-        .map_group(service_url.prefix)
+        .map_group(service_url.endpoint)
         .map_get("/", handle_connection)
         .map_post("/", move |msg: Json<Message>, headers: Headers| {
             handle_message(req_tx.clone(), headers, msg.into_inner())

--- a/neva/src/transport/http/server.rs
+++ b/neva/src/transport/http/server.rs
@@ -1,0 +1,138 @@
+//! HTTP server implementation
+
+use crate::{error::Error, types::Message};
+use super::ServiceUrl;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use volga::{
+    App, Json, ok, status,
+    headers::{
+        Header,
+        Headers,
+        custom_headers
+    }
+};
+
+const MCP_SESSION_ID: &str = "Mcp-Session-Id";
+custom_headers! {
+    (McpSessionId, MCP_SESSION_ID)
+}
+
+pub(super) async fn serve(
+    service_url: ServiceUrl,
+    recv_tx: mpsc::Sender<Result<Message, Error>>,
+    sender_rx: mpsc::Receiver<Message>,
+    token: CancellationToken
+) {
+    let (req_tx, req_rx) = mpsc::channel::<(Message, oneshot::Sender<Message>)>(100);
+    tokio::join!(
+        dispatch(recv_tx, sender_rx, req_rx, token.clone()),
+        handle(service_url, req_tx, token.clone())
+    );
+}
+
+async fn dispatch(
+    recv_tx: mpsc::Sender<Result<Message, Error>>,
+    mut sender_rx: mpsc::Receiver<Message>,
+    mut req_rx: mpsc::Receiver<(Message, oneshot::Sender<Message>)>,
+    token: CancellationToken
+) {
+    while let Some((msg, resp_tx)) = req_rx.recv().await {
+        let recv_tx = recv_tx.clone();
+        tokio::spawn(async move {
+            if let Err(_e) = recv_tx.send(Ok(msg)).await {
+                #[cfg(feature = "tracing")]
+                tracing::error!(logger = "neva", "Failed to send request: {:?}", _e);
+            }
+        });
+        let Some(resp) = sender_rx.recv().await else {
+            #[cfg(feature = "tracing")]
+            tracing::error!(logger = "neva", "Failed to send response");
+            token.cancel();
+            return;
+        };
+        if let Err(_e) = resp_tx.send(resp) {
+            #[cfg(feature = "tracing")]
+            tracing::error!(logger = "neva", "Failed to send response: {:?}", _e);
+            token.cancel();
+        }
+    }
+}
+
+async fn handle(
+    service_url: ServiceUrl,
+    req_tx: mpsc::Sender<(Message, oneshot::Sender<Message>)>, 
+    token: CancellationToken
+) {
+    let mut server = App::new()
+        .bind(service_url.addr);
+    
+    server
+        .map_err(handle_http_error)
+        .map_group(service_url.prefix)
+        .map_get("/", handle_connection)
+        .map_post("/", move |msg: Json<Message>, headers: Headers| {
+            handle_message(req_tx.clone(), headers, msg.into_inner())
+        });
+    
+    if let Err(_e) = server.run().await {
+        #[cfg(feature = "tracing")]
+        tracing::error!(logger = "neva", "HTTP Server was shutdown: {:?}", _e);
+        token.cancel();
+    }
+}
+
+async fn handle_connection(id: Header<McpSessionId>) {
+    println!("Connected with session-id: {id}");
+}
+
+async fn handle_message(
+    req_tx: mpsc::Sender<(Message, oneshot::Sender<Message>)>,
+    headers: Headers,
+    msg: Message
+) -> volga::HttpResult {
+    if let Message::Notification(_) = msg {
+        return status!(202);
+    }
+
+    #[cfg(feature = "tracing")]
+    let span = {
+        let id = headers
+            .get(MCP_SESSION_ID)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("unknown")
+            .to_string();
+        tracing::trace_span!("request", mcp_session_id = %id)
+    };
+    
+    //let (log_tx, log_rx) = mpsc::unbounded_channel::<String>();
+    let (resp_tx, resp_rx) = oneshot::channel::<Message>();
+
+    let fut = async move {
+        req_tx.send((msg, resp_tx))
+            .await
+            .map_err(sender_error)?;
+        resp_rx
+            .await
+            .map_err(receiver_error)  
+    };
+    
+    #[cfg(feature = "tracing")]
+    let fut = fut.instrument(span);
+    ok!(fut.await?)
+}
+
+async fn handle_http_error(err: volga::error::Error) {
+    println!("Error: {:?}", err);
+}
+
+#[inline]
+fn sender_error(err: mpsc::error::SendError<(Message, oneshot::Sender<Message>)>) -> volga::error::Error {
+    volga::error::Error::new("/", err.to_string())
+}
+
+#[inline]
+fn receiver_error(err: oneshot::error::RecvError) -> volga::error::Error {
+    volga::error::Error::new("/", err.to_string())
+}

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -265,6 +265,7 @@ impl FromHandlerParams for InitializeRequestParams {
 
 impl Message {
     /// Returns [`Message`] ID
+    #[inline]
     pub fn id(&self) -> RequestId {
         match self { 
             Message::Request(req) => req.id(),
@@ -272,18 +273,28 @@ impl Message {
             Message::Notification(_) => RequestId::default()
         }    
     }
+
+    /// Returns the full id (session_id?/message_id)
+    pub fn full_id(&self) -> RequestId {
+        match self {
+            Message::Request(req) => req.full_id(),
+            Message::Response(resp) => resp.full_id(),
+            Message::Notification(notification) => notification.full_id()
+        }
+    }
     
     /// Returns MCP Session ID
-    pub fn session_id(&self) -> Option<&str> {
+    #[inline]
+    pub fn session_id(&self) -> Option<&uuid::Uuid> {
         match self { 
-            Message::Request(req) => req.session_id.as_deref(),
+            Message::Request(req) => req.session_id.as_ref(),
             Message::Response(resp) => resp.session_id(),
-            Message::Notification(notification) => notification.session_id.as_deref()
+            Message::Notification(notification) => notification.session_id.as_ref()
         }
     }
     
     /// Sets MCP Session ID
-    pub fn set_session_id(mut self, id: String) -> Self {
+    pub fn set_session_id(mut self, id: uuid::Uuid) -> Self {
         match self { 
             Message::Request(ref mut req) => req.session_id = Some(id),
             Message::Notification(ref mut notification) => notification.session_id = Some(id),
@@ -294,7 +305,7 @@ impl Message {
 }
 
 impl Annotations {
-    /// Deserializes a new [`Annotations`] from JSON string
+    /// Deserializes a new [`Annotations`] from a JSON string
     #[inline]
     pub fn from_json_str(json: &str) -> Self {
         serde_json::from_str(json)

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -263,6 +263,36 @@ impl FromHandlerParams for InitializeRequestParams {
     }
 }
 
+impl Message {
+    /// Returns [`Message`] ID
+    pub fn id(&self) -> RequestId {
+        match self { 
+            Message::Request(req) => req.id(),
+            Message::Response(resp) => resp.id().clone(),
+            Message::Notification(_) => RequestId::default()
+        }    
+    }
+    
+    /// Returns MCP Session ID
+    pub fn session_id(&self) -> Option<&str> {
+        match self { 
+            Message::Request(req) => req.session_id.as_deref(),
+            Message::Response(resp) => resp.session_id(),
+            Message::Notification(notification) => notification.session_id.as_deref()
+        }
+    }
+    
+    /// Sets MCP Session ID
+    pub fn set_session_id(mut self, id: String) -> Self {
+        match self { 
+            Message::Request(ref mut req) => req.session_id = Some(id),
+            Message::Notification(ref mut notification) => notification.session_id = Some(id),
+            Message::Response(resp) => self = Message::Response(resp.set_session_id(id)),
+        }
+        self
+    }
+}
+
 impl Annotations {
     /// Deserializes a new [`Annotations`] from JSON string
     #[inline]

--- a/neva/src/types/notification.rs
+++ b/neva/src/types/notification.rs
@@ -24,6 +24,8 @@ pub mod progress;
 pub mod log_message;
 #[cfg(feature = "tracing")]
 pub mod formatter;
+#[cfg(feature = "tracing")]
+pub mod fmt;
 
 /// List of commands for Notifications
 pub mod commands {
@@ -49,6 +51,10 @@ pub struct Notification {
     /// Optional parameters for the notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<serde_json::Value>,
+
+    /// Current MCP Session ID
+    #[serde(skip)]
+    pub session_id: Option<String>,
 }
 
 /// This notification can be sent by either side to indicate that it is cancelling 
@@ -96,7 +102,8 @@ impl Notification {
     #[inline]
     pub fn new(method: &str, params: Option<serde_json::Value>) -> Self {
         Self { 
-            jsonrpc: JSONRPC_VERSION.into(), 
+            jsonrpc: JSONRPC_VERSION.into(),
+            session_id: None,
             method: method.into(), 
             params
         }

--- a/neva/src/types/notification.rs
+++ b/neva/src/types/notification.rs
@@ -54,7 +54,7 @@ pub struct Notification {
 
     /// Current MCP Session ID
     #[serde(skip)]
-    pub session_id: Option<String>,
+    pub session_id: Option<uuid::Uuid>,
 }
 
 /// This notification can be sent by either side to indicate that it is cancelling 
@@ -106,6 +106,16 @@ impl Notification {
             session_id: None,
             method: method.into(), 
             params
+        }
+    }
+
+    /// Returns the full id (session_id?/"(no_id)")
+    pub fn full_id(&self) -> RequestId {
+        let id = RequestId::default();
+        if let Some(session_id) = self.session_id {
+            RequestId::String(format!("{}/{}", session_id, id))
+        } else {
+            id
         }
     }
     

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -1,0 +1,145 @@
+﻿//! A generic tracing/logging formatting layer for notifications
+
+use once_cell::sync::Lazy;
+use dashmap::DashMap;
+use tokio::sync::mpsc::{channel, Sender, UnboundedSender};
+use tracing::{Event, Id, Subscriber, field::Visit};
+use tracing::field::Field;
+use tracing::span::Attributes;
+use tracing_subscriber::{layer::Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+use std::io::{self, Write};
+use crate::types::{
+    notification::{Notification, formatter::build_notification},
+    Message
+};
+
+const MCP_SESSION_ID: &str = "mcp_session_id";
+
+static LOG_REGISTRY: Lazy<DashMap<String, UnboundedSender<Message>>> =
+    Lazy::new(DashMap::new);
+
+#[inline]
+pub(crate) fn register_log_sender(key: String, sender: UnboundedSender<Message>) {
+    LOG_REGISTRY.insert(key, sender);
+}
+
+#[inline]
+pub(crate) fn unregister_log_sender(key: &str) {
+    LOG_REGISTRY.remove(key);
+}
+
+#[inline]
+pub(crate) fn send(message: Message) {
+    let Some(session_id) = message.session_id() else { return; };
+    if let Some(sender) = LOG_REGISTRY.get(session_id) {
+        let _ = sender.send(message);
+    }
+}
+
+/// Creates a custom tracing layer that delivers messages to MCP Client
+/// 
+/// # Example
+/// ```no_run
+/// use tracing_subscriber::prelude::*;
+/// use neva::types::notification;
+/// 
+/// tracing_subscriber::registry()
+///     .with(notification::fmt::layer())
+///     .init();
+/// ```
+pub fn layer() -> MpscLayer {
+    let (tx, mut rx) = channel::<Notification>(100);
+    tokio::spawn(async move {
+        while let Some(notification) = rx.recv().await {
+            send(notification.into());
+        }
+    });
+    MpscLayer {
+        sender: NotificationSender::new(tx)
+    }
+}
+
+/// Keeps a [`Sender`] 
+struct NotificationSender {
+    sender: Sender<Notification>,
+}
+
+impl NotificationSender {
+    fn new(sender: Sender<Notification>) -> Self {
+        Self { sender }
+    }
+
+    fn send_notification(&self, notification: Notification) {
+        let _ = self.sender.try_send(notification);
+    }
+}
+
+/// Represents a custom tracing layer that delivers messages to MCP Client
+///
+/// # Example
+/// ```no_run
+/// use tracing_subscriber::prelude::*;
+/// use neva::types::notification;
+///
+/// tracing_subscriber::registry()
+///     .with(notification::fmt::layer())
+///     .init();
+/// ```
+pub struct MpscLayer {
+    sender: NotificationSender
+}
+
+impl<S> Layer<S> for MpscLayer
+where
+    S: Subscriber  + for<'a> LookupSpan<'a>,
+{
+    #[inline]
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut visitor = SpanVisitor { session_id: None };
+        attrs.record(&mut visitor);
+        if let Some(span) = ctx.span(id) {
+            if let Some(mcp_session_id) = visitor.session_id {
+                span
+                    .extensions_mut()
+                    .insert(mcp_session_id);
+            }
+        }
+    }
+    
+    #[inline]
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let mut notification = build_notification(event);
+        if let Some(span) = ctx.event_span(event) {
+            notification.session_id = span
+                .extensions()
+                .get::<String>()
+                .cloned();
+            self.sender.send_notification(notification);            
+        } else {
+            let mut stderr = io::stderr();
+            let json = serde_json::to_string(&notification).unwrap();
+            let _ = writeln!(stderr, "{}", json);
+        }
+    }
+}
+
+struct SpanVisitor {
+    session_id: Option<String>,
+}
+
+impl Visit for SpanVisitor {
+    #[inline]
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == MCP_SESSION_ID {
+            self.session_id = Some(value.into());
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        // fallback if id was passed as %mcp_session_id or something else
+        if field.name() == MCP_SESSION_ID && self.session_id.is_none() {
+            self.session_id = Some(format!("{:?}", value));
+        }
+    }
+}

--- a/neva/src/types/notification/formatter.rs
+++ b/neva/src/types/notification/formatter.rs
@@ -123,7 +123,7 @@ where
         event: &Event<'_>,
     ) -> std::fmt::Result {
         use std::collections::BTreeMap;
-
+        
         let meta = event.metadata();
         let level = meta.level();
         

--- a/neva/src/types/notification/formatter.rs
+++ b/neva/src/types/notification/formatter.rs
@@ -13,6 +13,7 @@ use tracing_subscriber::{
     field::Visit,
     registry::LookupSpan,
 };
+
 use crate::types::notification::{
     LogMessage, 
     LoggingLevel, 
@@ -22,35 +23,6 @@ use crate::types::ProgressToken;
 
 /// A formatter that formats tracing events into MCP notification logs
 pub struct NotificationFormatter;
-
-struct Visitor<'a> {
-    map: BTreeMap<&'a str, serde_json::Value>,
-}
-
-impl Visit for Visitor<'_> {
-    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
-        self.map.insert(field.name(), value.into());
-    }
-
-    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
-        self.map.insert(field.name(), value.into());
-    }
-
-    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
-        self.map.insert(field.name(), value.into());
-    }
-
-    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        self.map.insert(field.name(), value.into());
-    }
-
-    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
-        // Only use this if nothing else handled it
-        if !self.map.contains_key(field.name()) {
-            self.map.insert(field.name(), serde_json::Value::String(format!("{:?}", value)));
-        }
-    }
-}
 
 impl From<&Level> for LoggingLevel {
     #[inline]
@@ -122,55 +94,90 @@ where
         mut writer: Writer<'_>,
         event: &Event<'_>,
     ) -> std::fmt::Result {
-        use std::collections::BTreeMap;
-        
-        let meta = event.metadata();
-        let level = meta.level();
-        
-        let mut visitor = Visitor {
-            map: BTreeMap::new(),
-        };
-
-        event.record(&mut visitor);
-        
-        let notification = match meta.target() { 
-            "progress" => {
-                let token = visitor.map
-                    .get("token")
-                    .map(|v| serde_json::from_value::<ProgressToken>(v.clone()).unwrap());
-                
-                let total = visitor.map
-                    .get("total")
-                    .map(|v| v.to_string().replace("\"", "").parse().unwrap());
-
-                let value = visitor.map
-                    .get("value")
-                    .map(|v| v.to_string().replace("\"", "").parse().unwrap());
-
-                token.unwrap()
-                    .notify(value.unwrap(), total)
-                    .into()
-            },
-            _ => {
-                let logger = visitor.map
-                    .get("logger")
-                    .map(|v| v.to_string().replace("\"", ""));
-
-                // Remove `logger` from data map
-                let mut data_map = visitor.map.clone();
-                data_map.remove("logger");
-
-                let log = LogMessage {
-                    level: level.into(),
-                    data: serde_json::to_value(data_map).ok(),
-                    logger,
-                };
-
-                Notification::from(log)
-            }
-        };
-        
+        let notification = build_notification(event);
         let json = serde_json::to_string(&notification).unwrap();
         writeln!(writer, "{}", json)
+    }
+}
+
+#[inline]
+pub(super) fn build_notification(event: &Event<'_>) -> Notification {
+    let meta = event.metadata();
+    let level = meta.level();
+    let fields = extract_fields(event);
+    
+    match meta.target() {
+        "progress" => {
+            let token = fields
+                .get("token")
+                .map(|v| serde_json::from_value::<ProgressToken>(v.clone()).unwrap());
+
+            let total = fields
+                .get("total")
+                .map(|v| v.to_string().replace("\"", "").parse().unwrap());
+
+            let value = fields
+                .get("value")
+                .map(|v| v.to_string().replace("\"", "").parse().unwrap());
+
+            token.unwrap()
+                .notify(value.unwrap(), total)
+                .into()
+        },
+        _ => {
+            let logger = fields
+                .get("logger")
+                .map(|v| v.to_string().replace("\"", ""));
+
+            // Remove `logger` from data map
+            let mut data_map = fields.clone();
+            data_map.remove("logger");
+
+            let log = LogMessage {
+                level: level.into(),
+                data: serde_json::to_value(data_map).ok(),
+                logger,
+            };
+
+            Notification::from(log)
+        }
+    }
+}
+
+#[inline]
+fn extract_fields<'a>(event: &Event<'a>) -> BTreeMap<&'a str, serde_json::Value> {
+    let mut visitor = Visitor {
+        map: BTreeMap::new(),
+    };
+    event.record(&mut visitor);
+    visitor.map
+}
+
+struct Visitor<'a> {
+    map: BTreeMap<&'a str, serde_json::Value>,
+}
+
+impl Visit for Visitor<'_> {
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.map.insert(field.name(), value.into());
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.map.insert(field.name(), value.into());
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.map.insert(field.name(), value.into());
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.map.insert(field.name(), value.into());
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        // Only use this if nothing else handled it
+        if !self.map.contains_key(field.name()) {
+            self.map.insert(field.name(), serde_json::Value::String(format!("{:?}", value)));
+        }
     }
 }

--- a/neva/src/types/request.rs
+++ b/neva/src/types/request.rs
@@ -57,7 +57,7 @@ pub struct Request {
     
     /// Current MCP Session ID
     #[serde(skip)]
-    pub session_id: Option<String>,
+    pub session_id: Option<uuid::Uuid>,
 }
 
 /// Provides metadata related to the request that provides additional protocol-level information.
@@ -136,19 +136,22 @@ impl Request {
             params: params.and_then(|p| serde_json::to_value(p).ok()),
         }
     }
-    
-    /// Consumes the request and returns request's id if it's specified, otherwise returns default value
-    /// 
-    /// Default: `(no id)`
-    pub fn into_id(self) -> RequestId {
-        self.id
-    }
 
     /// Returns request's id if it's specified, otherwise returns default value
     ///
     /// Default: `(no id)`
     pub fn id(&self) -> RequestId {
         self.id.clone()
+    }
+
+    /// Returns the full id (session_id?/request_id)
+    pub fn full_id(&self) -> RequestId {
+        let id = &self.id;
+        if let Some(session_id) = self.session_id {
+            RequestId::String(format!("{}/{}", session_id, id))
+        } else {
+            id.clone()
+        }
     }
     
     /// Returns [`Request`] params metadata

--- a/neva/src/types/request.rs
+++ b/neva/src/types/request.rs
@@ -54,6 +54,10 @@ pub struct Request {
     /// Optional parameters for the method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub params: Option<serde_json::Value>,
+    
+    /// Current MCP Session ID
+    #[serde(skip)]
+    pub session_id: Option<String>,
 }
 
 /// Provides metadata related to the request that provides additional protocol-level information.
@@ -126,9 +130,10 @@ impl Request {
     pub fn new<T: Serialize>(id: Option<RequestId>, method: &str, params: Option<T>) -> Self {
         Self {
             jsonrpc: JSONRPC_VERSION.into(),
+            session_id: None,
             id: id.unwrap_or_default(),
             method: method.into(),
-            params: params.and_then(|p| serde_json::to_value(p).ok())
+            params: params.and_then(|p| serde_json::to_value(p).ok()),
         }
     }
     

--- a/neva_macros/Cargo.toml
+++ b/neva_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neva_macros"
-version = "0.0.9"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.85.0"
 authors = ["Roman Emreis <roman.emreis@outlook.com>"]


### PR DESCRIPTION
# Example
```rust
use neva::{App, tool};

#[tool]
async fn remote_tool(name: String) {
    println!("running remote tool: {}", name);
}

#[tokio::main]
async fn main() {
    App::new()
        .with_options(|opt| opt
            .with_http(|http| http
                .bind("127.0.0.1:3000")
                .with_endpoint("/mcp")))    // Optional MCP endpoint (http://127.0.0.1:3000/mcp)
        .run()
        .await;
}
```