### PR TITLE
Relaxed 'static lifetime requirement for framework http request, response and SSE sevnt

### DIFF
--- a/neva/src/transport.rs
+++ b/neva/src/transport.rs
@@ -54,7 +54,7 @@ pub(crate) enum TransportProto {
     #[cfg(feature = "server")]
     StdIoServer(StdIoServer),
     #[cfg(feature = "http-server")]
-    HttpServer(Box<dyn crate::transport::http::core::engine::HttpTransport>),
+    HttpServer(Box<dyn http::core::engine::HttpTransport>),
     #[cfg(feature = "http-client")]
     HttpClient(HttpClient),
     //Ws(Websocket),

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -292,7 +292,7 @@ impl HttpReceiver {
 #[cfg(feature = "http-server")]
 impl<E> HttpServer<crate::auth::DefaultClaims, E>
 where
-    E: crate::transport::http::core::engine::HttpEngine,
+    E: HttpEngine,
 {
     /// Creates a new [`HttpServer`] bound to `addr`, running the supplied
     /// engine. This is the engine-agnostic constructor — use it when

--- a/neva/src/transport/http/core/engine.rs
+++ b/neva/src/transport/http/core/engine.rs
@@ -67,8 +67,8 @@ use super::{
 pub trait HttpEngine: Send + Sync + 'static {
     /// Engine-native inbound request type (e.g. `axum::Request<Body>`).
     ///
-    /// `Send` is intentionally not required here so engines whose native
-    /// request type holds non-`Send` state (actix-web's `HttpRequest`
+    /// `Send` is intentionally not required here, so engines whose native
+    /// request type holds a non-`Send` state (actix-web's `HttpRequest`
     /// holds `Rc<…>` internally) can still implement this trait. For
     /// engines whose request type is `Send`, [`dispatch_post`] /
     /// [`dispatch_delete`] / [`dispatch_get_sse`] produce `Send` futures
@@ -79,19 +79,19 @@ pub trait HttpEngine: Send + Sync + 'static {
     /// [`dispatch_post`]: super::handlers::dispatch_post
     /// [`dispatch_delete`]: super::handlers::dispatch_delete
     /// [`dispatch_get_sse`]: super::handlers::dispatch_get_sse
-    type Request: 'static;
+    type Request;
 
     /// Engine-native outbound response type (e.g. `axum::Response`).
     ///
     /// Same `Send` story as [`Self::Request`].
-    type Response: 'static;
+    type Response;
 
     /// Engine-native SSE event type (e.g. `volga::http::sse::Message`).
     ///
     /// `Send` is required because SSE events are yielded by an
     /// engine-agnostic `impl Stream<Item = Self::SseEvent> + Send`
     /// returned from [`super::handlers::handle_get_sse`].
-    type SseEvent: Send + 'static;
+    type SseEvent: Send;
 
     /// Convert an engine-native request into neva's neutral
     /// [`HttpRequest`]. The body must be fully buffered before return.


### PR DESCRIPTION
## Summary
Relaxed 'static lifetime requirement for framework http request, response and SSE sevnt

## Type
- [ ] Bug fix
- [ ] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
