### PR TITLE
Pluggable HTTP server abstractions improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.3.4
+
+### Changed
+* `HttpEngine::adapt_request` no longer forces engines to `.unwrap()`/`.expect()`
+* `HttpEngine::adapt_response` drops the `BytesMut` round-trip for the default Streamable HTTP implementation.
+* `parse_message` single-step decode + `Error::classify()`. Drops the `serde::Value` intermediate from the single-message hot path.
+* Removed `'static` constraint for `HttpEngine::Request`, `HttpEngine::Response` and `HttpEngine::SseEvent` 
+
 ## 0.3.3
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -27,7 +27,7 @@ categories = [
 ]
 
 [workspace.dependencies]
-neva_macros = { path = "neva_macros", version = "0.3.3" }
+neva_macros = { path = "neva_macros", version = "0.3.4" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blazingly fast and easily configurable [Model Context Protocol (MCP)](https://mo
 With simple configuration and ergonomic APIs, it provides everything you need to quickly build MCP clients and servers, 
 fully aligned with the latest MCP specification.
 
-[![latest](https://img.shields.io/badge/latest-0.3.3-d8eb34)](https://crates.io/crates/neva)
+[![latest](https://img.shields.io/badge/latest-0.3.4-d8eb34)](https://crates.io/crates/neva)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-624bd1.svg)](https://github.com/RomanEmreis/neva/blob/main/LICENSE)
 [![CI](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml)
@@ -28,7 +28,7 @@ fully aligned with the latest MCP specification.
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.3.3", features = ["client-full"] }
+neva = { version = "0.3.4", features = ["client-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Error> {
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.3.3", features = ["server-full"] }
+neva = { version = "0.3.4", features = ["server-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 #### Code

--- a/examples/actix/src/main.rs
+++ b/examples/actix/src/main.rs
@@ -40,16 +40,16 @@ impl HttpEngine for ActixEngine {
     /// in `Ok` because neva never produces SSE errors.
     type SseEvent = Result<Bytes, std::convert::Infallible>;
 
-    async fn adapt_request(req: Self::Request) -> HttpRequest {
+    async fn adapt_request(req: Self::Request) -> Result<HttpRequest, Error> {
         let (req, body) = req;
 
         let method = http::Method::from_bytes(req.method().as_str().as_bytes())
-            .unwrap_or(http::Method::POST);
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))?;
         let uri = req
             .uri()
             .to_string()
             .parse::<http::Uri>()
-            .unwrap_or_default();
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))?;
 
         let mut builder = http::Request::builder().method(method).uri(uri);
         if let Some(headers) = builder.headers_mut() {
@@ -64,7 +64,7 @@ impl HttpEngine for ActixEngine {
         }
         builder
             .body(Bytes::copy_from_slice(&body))
-            .expect("valid request")
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))
     }
 
     fn adapt_response(resp: HttpResponse) -> Self::Response {
@@ -129,7 +129,9 @@ async fn post_handler(
     req: ActixHttpRequest,
     body: ActixBytes,
 ) -> ActixHttpResponse {
-    handlers::dispatch_post::<ActixEngine>((req, body), &ctx).await
+    handlers::dispatch_post::<ActixEngine>((req, body), &ctx)
+        .await
+        .unwrap_or_else(internal_error)
 }
 
 async fn delete_handler(
@@ -137,7 +139,9 @@ async fn delete_handler(
     req: ActixHttpRequest,
     body: ActixBytes,
 ) -> ActixHttpResponse {
-    handlers::dispatch_delete::<ActixEngine>((req, body), &ctx).await
+    handlers::dispatch_delete::<ActixEngine>((req, body), &ctx)
+        .await
+        .unwrap_or_else(internal_error)
 }
 
 async fn get_handler(
@@ -145,7 +149,11 @@ async fn get_handler(
     req: ActixHttpRequest,
     body: ActixBytes,
 ) -> ActixHttpResponse {
-    match handlers::dispatch_get_sse::<ActixEngine>((req, body), &ctx).await {
+    let outcome = match handlers::dispatch_get_sse::<ActixEngine>((req, body), &ctx).await {
+        Ok(outcome) => outcome,
+        Err(e) => return internal_error(e),
+    };
+    match outcome {
         SseResponse::Stream { headers, stream } => {
             let mut builder = ActixHttpResponse::Ok();
             builder.content_type("text/event-stream");
@@ -161,6 +169,11 @@ async fn get_handler(
         }
         SseResponse::Status(resp) => ActixEngine::adapt_response(resp),
     }
+}
+
+/// Translate a neva engine-adapter `Error` into a 500 actix response.
+fn internal_error(err: Error) -> ActixHttpResponse {
+    ActixHttpResponse::InternalServerError().body(err.to_string())
 }
 
 #[tool]

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -38,13 +38,13 @@ impl HttpEngine for AxumEngine {
     type Response = Response;
     type SseEvent = Result<Event, Infallible>;
 
-    async fn adapt_request(req: Self::Request) -> HttpRequest {
+    async fn adapt_request(req: Self::Request) -> Result<HttpRequest, Error> {
         let (parts, body) = req.into_parts();
         let bytes = body
             .collect()
             .await
             .map(|c| c.to_bytes())
-            .unwrap_or_default();
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))?;
 
         let mut builder = http::Request::builder()
             .method(parts.method)
@@ -55,7 +55,9 @@ impl HttpEngine for AxumEngine {
                 headers.append(name, value.clone());
             }
         }
-        builder.body(bytes).expect("valid request")
+        builder
+            .body(bytes)
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))
     }
 
     fn adapt_response(resp: HttpResponse) -> Self::Response {
@@ -105,15 +107,23 @@ impl HttpEngine for AxumEngine {
 }
 
 async fn post_handler(State(ctx): State<HttpContext>, req: axum::http::Request<Body>) -> Response {
-    handlers::dispatch_post::<AxumEngine>(req, &ctx).await
+    handlers::dispatch_post::<AxumEngine>(req, &ctx)
+        .await
+        .unwrap_or_else(internal_error)
 }
 
 async fn delete_handler(State(ctx): State<HttpContext>, req: http::Request<Body>) -> Response {
-    handlers::dispatch_delete::<AxumEngine>(req, &ctx).await
+    handlers::dispatch_delete::<AxumEngine>(req, &ctx)
+        .await
+        .unwrap_or_else(internal_error)
 }
 
 async fn get_handler(State(ctx): State<HttpContext>, req: http::Request<Body>) -> Response {
-    match handlers::dispatch_get_sse::<AxumEngine>(req, &ctx).await {
+    let outcome = match handlers::dispatch_get_sse::<AxumEngine>(req, &ctx).await {
+        Ok(outcome) => outcome,
+        Err(e) => return internal_error(e),
+    };
+    match outcome {
         SseResponse::Stream { headers, stream } => {
             let sse = Sse::new(stream).keep_alive(KeepAlive::default());
             let mut response: Response = sse.into_response();
@@ -124,6 +134,15 @@ async fn get_handler(State(ctx): State<HttpContext>, req: http::Request<Body>) -
         }
         SseResponse::Status(resp) => AxumEngine::adapt_response(resp),
     }
+}
+
+/// Translate a neva engine-adapter `Error` into a 500 axum response.
+fn internal_error(err: Error) -> Response {
+    (
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        err.to_string(),
+    )
+        .into_response()
 }
 
 #[tool]

--- a/examples/hyper/src/main.rs
+++ b/examples/hyper/src/main.rs
@@ -49,14 +49,14 @@ impl HttpEngine for HyperEngine {
     // `Body` impl we can hand back to hyper.
     type SseEvent = Result<Frame<Bytes>, Infallible>;
 
-    async fn adapt_request(req: Self::Request) -> HttpRequest {
+    async fn adapt_request(req: Self::Request) -> Result<HttpRequest, Error> {
         let (parts, body) = req.into_parts();
         let bytes = body
             .collect()
             .await
             .map(|c| c.to_bytes())
-            .unwrap_or_default();
-        http::Request::from_parts(parts, bytes)
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))?;
+        Ok(http::Request::from_parts(parts, bytes))
     }
 
     fn adapt_response(resp: HttpResponse) -> Self::Response {
@@ -119,23 +119,33 @@ async fn dispatch(req: http::Request<Incoming>, ctx: HttpContext) -> http::Respo
         return status_only(http::StatusCode::NOT_FOUND);
     }
     match *req.method() {
-        Method::POST => handlers::dispatch_post::<HyperEngine>(req, &ctx).await,
-        Method::DELETE => handlers::dispatch_delete::<HyperEngine>(req, &ctx).await,
-        Method::GET => match handlers::dispatch_get_sse::<HyperEngine>(req, &ctx).await {
-            SseResponse::Stream { headers, stream } => {
-                let body = StreamBody::new(stream).boxed();
-                let mut resp = http::Response::builder()
-                    .status(http::StatusCode::OK)
-                    .header(http::header::CONTENT_TYPE, "text/event-stream")
-                    .body(body)
-                    .expect("valid response");
-                for (name, value) in headers.iter() {
-                    resp.headers_mut().insert(name, value.clone());
+        Method::POST => handlers::dispatch_post::<HyperEngine>(req, &ctx)
+            .await
+            .unwrap_or_else(|_| status_only(http::StatusCode::INTERNAL_SERVER_ERROR)),
+        Method::DELETE => handlers::dispatch_delete::<HyperEngine>(req, &ctx)
+            .await
+            .unwrap_or_else(|_| status_only(http::StatusCode::INTERNAL_SERVER_ERROR)),
+        Method::GET => {
+            let outcome = match handlers::dispatch_get_sse::<HyperEngine>(req, &ctx).await {
+                Ok(outcome) => outcome,
+                Err(_) => return status_only(http::StatusCode::INTERNAL_SERVER_ERROR),
+            };
+            match outcome {
+                SseResponse::Stream { headers, stream } => {
+                    let body = StreamBody::new(stream).boxed();
+                    let mut resp = http::Response::builder()
+                        .status(http::StatusCode::OK)
+                        .header(http::header::CONTENT_TYPE, "text/event-stream")
+                        .body(body)
+                        .expect("valid response");
+                    for (name, value) in headers.iter() {
+                        resp.headers_mut().insert(name, value.clone());
+                    }
+                    resp
                 }
-                resp
+                SseResponse::Status(resp) => HyperEngine::adapt_response(resp),
             }
-            SseResponse::Status(resp) => HyperEngine::adapt_response(resp),
-        },
+        }
         _ => status_only(http::StatusCode::METHOD_NOT_ALLOWED),
     }
 }

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -754,8 +754,8 @@ mod engine_smoke_tests {
         type Response = HttpResponse;
         type SseEvent = ();
 
-        async fn adapt_request(req: Self::Request) -> HttpRequest {
-            req
+        async fn adapt_request(req: Self::Request) -> Result<HttpRequest, Error> {
+            Ok(req)
         }
 
         fn adapt_response(resp: HttpResponse) -> Self::Response {

--- a/neva/src/transport/http/core/engine.rs
+++ b/neva/src/transport/http/core/engine.rs
@@ -54,7 +54,7 @@ use super::{
 ///     type Response = framework::Response;
 ///     type SseEvent = framework::sse::Event;
 ///
-///     async fn adapt_request(req: Self::Request) -> HttpRequest { ... }
+///     async fn adapt_request(req: Self::Request) -> Result<HttpRequest, Error> { ... }
 ///     fn adapt_response(resp: HttpResponse) -> Self::Response { ... }
 ///
 ///     fn tracked_event(seq: u64, msg: &Message) -> Self::SseEvent { ... }
@@ -95,7 +95,17 @@ pub trait HttpEngine: Send + Sync + 'static {
 
     /// Convert an engine-native request into neva's neutral
     /// [`HttpRequest`]. The body must be fully buffered before return.
-    fn adapt_request(req: Self::Request) -> impl Future<Output = HttpRequest>;
+    ///
+    /// Returns [`Err`] when the body cannot be read or the neutral request
+    /// cannot be constructed (e.g. an invalid URI / method emitted by the
+    /// underlying stack). The error is propagated through
+    /// [`super::handlers::dispatch_post`] / [`dispatch_delete`] /
+    /// [`dispatch_get_sse`] so the engine can map it onto its native
+    /// failure mode without ever needing to `unwrap` / `expect`.
+    ///
+    /// [`dispatch_delete`]: super::handlers::dispatch_delete
+    /// [`dispatch_get_sse`]: super::handlers::dispatch_get_sse
+    fn adapt_request(req: Self::Request) -> impl Future<Output = Result<HttpRequest, Error>>;
 
     /// Build an engine-native response from neva's neutral
     /// [`HttpResponse`].

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -160,11 +160,19 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
     }
 }
 
-/// Parse the body into a `Message`. Two-step decode per JSON-RPC 2.0 §5.1.
+/// Parse the body into a [`Message`].
+///
+/// Single-step decode: `serde_json::Error::classify()` distinguishes
+/// JSON-RPC 2.0 §5.1 ParseError (`Category::Syntax` / `Category::Eof` —
+/// the body is not valid JSON) from InvalidRequest (`Category::Data` —
+/// the body is valid JSON but does not match any [`Message`] variant).
 fn parse_message(body: &Bytes) -> Result<Message, ErrorCode> {
-    let value: serde_json::Value =
-        serde_json::from_slice(body).map_err(|_| ErrorCode::ParseError)?;
-    serde_json::from_value::<Message>(value).map_err(|_| ErrorCode::InvalidRequest)
+    serde_json::from_slice::<Message>(body).map_err(|e| match e.classify() {
+        serde_json::error::Category::Syntax | serde_json::error::Category::Eof => {
+            ErrorCode::ParseError
+        }
+        _ => ErrorCode::InvalidRequest,
+    })
 }
 
 fn get_or_create_mcp_session(headers: &HeaderMap) -> uuid::Uuid {

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -30,14 +30,21 @@ pub(crate) const MCP_SESSION_ID: &str = "Mcp-Session-Id";
 /// run the JSON-RPC dispatch via [`handle_post`], then convert the
 /// neutral response back via [`HttpEngine::adapt_response`].
 ///
+/// Returns [`Err`] when [`HttpEngine::adapt_request`] fails. Engines whose
+/// native response type is itself a `Result` can integrate with `?`;
+/// engines whose response type is infallible can map the error onto an
+/// HTTP 500 of their choosing.
+///
 /// Lets a route handler collapse to a single line, e.g. (axum):
 ///
 /// ```rust,ignore
 /// async fn post_handler(
-///     State(ctx): State<Arc<HttpContext>>,
+///     State(ctx): State<HttpContext>,
 ///     req: axum::Request<Body>,
-/// ) -> axum::Response {
-///     handlers::dispatch_post::<MyEngine>(req, &ctx).await
+/// ) -> Result<axum::Response, MyError> {
+///     handlers::dispatch_post::<MyEngine>(req, &ctx)
+///         .await
+///         .map_err(MyError::from)
 /// }
 /// ```
 ///
@@ -47,17 +54,23 @@ pub(crate) const MCP_SESSION_ID: &str = "Mcp-Session-Id";
 /// `adapt_request` returns (typically inside `HttpEngine::adapt_request`
 /// or in the engine's route handler just before this call). See the
 /// [`HttpEngine`] doc comment for the full contract.
-pub async fn dispatch_post<E: HttpEngine>(req: E::Request, ctx: &HttpContext) -> E::Response {
-    let neutral = E::adapt_request(req).await;
+pub async fn dispatch_post<E: HttpEngine>(
+    req: E::Request,
+    ctx: &HttpContext,
+) -> Result<E::Response, Error> {
+    let neutral = E::adapt_request(req).await?;
     let resp = handle_post(neutral, ctx).await;
-    E::adapt_response(resp)
+    Ok(E::adapt_response(resp))
 }
 
 /// One-call DELETE pipeline for engine adapters. See [`dispatch_post`].
-pub async fn dispatch_delete<E: HttpEngine>(req: E::Request, ctx: &HttpContext) -> E::Response {
-    let neutral = E::adapt_request(req).await;
+pub async fn dispatch_delete<E: HttpEngine>(
+    req: E::Request,
+    ctx: &HttpContext,
+) -> Result<E::Response, Error> {
+    let neutral = E::adapt_request(req).await?;
     let resp = handle_delete(neutral, ctx).await;
-    E::adapt_response(resp)
+    Ok(E::adapt_response(resp))
 }
 
 /// One-call GET-SSE pipeline for engine adapters: converts the
@@ -67,12 +80,15 @@ pub async fn dispatch_delete<E: HttpEngine>(req: E::Request, ctx: &HttpContext) 
 /// matches `Stream { headers, stream }` (wrapping the stream in its
 /// native SSE response type) vs `Status(resp)` (passing `resp` through
 /// [`HttpEngine::adapt_response`]).
+///
+/// Returns [`Err`] when [`HttpEngine::adapt_request`] fails — same
+/// rationale as [`dispatch_post`].
 pub async fn dispatch_get_sse<E: HttpEngine>(
     req: E::Request,
     ctx: &HttpContext,
-) -> SseResponse<impl Stream<Item = E::SseEvent> + Send + 'static> {
-    let neutral = E::adapt_request(req).await;
-    handle_get_sse::<E>(neutral, ctx).await
+) -> Result<SseResponse<impl Stream<Item = E::SseEvent> + Send + 'static>, Error> {
+    let neutral = E::adapt_request(req).await?;
+    Ok(handle_get_sse::<E>(neutral, ctx).await)
 }
 
 /// Handle a POST `/{endpoint}` request — the JSON-RPC message ingress.
@@ -498,7 +514,7 @@ mod tests {
         type Response = HttpResponse;
         type SseEvent = (Option<u64>, String);
 
-        async fn adapt_request(_req: Self::Request) -> HttpRequest {
+        async fn adapt_request(_req: Self::Request) -> Result<HttpRequest, crate::error::Error> {
             unreachable!()
         }
         fn adapt_response(_resp: HttpResponse) -> Self::Response {

--- a/neva/src/transport/http/server/volga/engine.rs
+++ b/neva/src/transport/http/server/volga/engine.rs
@@ -57,20 +57,24 @@ impl HttpEngine for VolgaEngine {
     type Response = HttpResult;
     type SseEvent = SseMessage;
 
-    async fn adapt_request(req: Self::Request) -> NeutralRequest {
+    async fn adapt_request(req: Self::Request) -> Result<NeutralRequest, Error> {
         let mut builder = http::Request::builder()
             .method(req.method().clone())
             .uri(req.uri().clone())
             .version(req.version());
-        
+
         if let Some(headers_mut) = builder.headers_mut() {
             for (k, v) in req.headers().iter() {
                 headers_mut.append(k, v.clone());
             }
         }
-        
-        let body = read_body(req.into_body()).await.unwrap_or_default();
-        builder.body(body).expect("valid request")
+
+        let body = read_body(req.into_body())
+            .await
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))?;
+        builder
+            .body(body)
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))
     }
 
     fn adapt_response(resp: NeutralResponse) -> Self::Response {

--- a/neva/src/transport/http/server/volga/engine.rs
+++ b/neva/src/transport/http/server/volga/engine.rs
@@ -62,11 +62,13 @@ impl HttpEngine for VolgaEngine {
             .method(req.method().clone())
             .uri(req.uri().clone())
             .version(req.version());
+        
         if let Some(headers_mut) = builder.headers_mut() {
             for (k, v) in req.headers().iter() {
                 headers_mut.append(k, v.clone());
             }
         }
+        
         let body = read_body(req.into_body()).await.unwrap_or_default();
         builder.body(body).expect("valid request")
     }
@@ -74,10 +76,7 @@ impl HttpEngine for VolgaEngine {
     fn adapt_response(resp: NeutralResponse) -> Self::Response {
         let (parts, body) = resp.into_parts();
         let status = parts.status.as_u16();
-
-        let mut buf = BytesMut::with_capacity(body.len());
-        buf.extend_from_slice(&body);
-        let http_body = HttpBody::full(buf.freeze());
+        let http_body = HttpBody::full(body);
 
         let mut builder = ::volga::builder!(status);
         for (name, value) in parts.headers.iter() {

--- a/neva/src/transport/http/server/volga/routes.rs
+++ b/neva/src/transport/http/server/volga/routes.rs
@@ -42,7 +42,9 @@ pub(crate) async fn post(req: HttpRequest) -> HttpResult {
     let manager: Dc<Arc<HttpContext>> = req.extract()?;
     let bts: Option<BearerTokenService> = req.extract()?;
 
-    let mut neutral = VolgaEngine::adapt_request(req).await;
+    let mut neutral = VolgaEngine::adapt_request(req)
+        .await
+        .map_err(to_volga_err)?;
 
     // Stash claims (if any) in the neutral request's extensions so the
     // engine-agnostic handler can attach them to the outgoing message.
@@ -62,7 +64,9 @@ pub(crate) async fn post(req: HttpRequest) -> HttpResult {
 /// `DELETE /<endpoint>` — explicit session termination.
 pub(crate) async fn delete(req: HttpRequest) -> HttpResult {
     let manager: Dc<Arc<HttpContext>> = req.extract()?;
-    let neutral = VolgaEngine::adapt_request(req).await;
+    let neutral = VolgaEngine::adapt_request(req)
+        .await
+        .map_err(to_volga_err)?;
     let resp = handlers::handle_delete(neutral, &manager).await;
     VolgaEngine::adapt_response(resp)
 }
@@ -70,7 +74,9 @@ pub(crate) async fn delete(req: HttpRequest) -> HttpResult {
 /// `GET /<endpoint>` — SSE subscribe.
 pub(crate) async fn get(req: HttpRequest) -> HttpResult {
     let manager: Dc<Arc<HttpContext>> = req.extract()?;
-    let outcome = handlers::dispatch_get_sse::<VolgaEngine>(req, &manager).await;
+    let outcome = handlers::dispatch_get_sse::<VolgaEngine>(req, &manager)
+        .await
+        .map_err(to_volga_err)?;
     match outcome {
         SseResponse::Stream { headers, stream } => {
             let session_id = headers
@@ -86,4 +92,10 @@ pub(crate) async fn get(req: HttpRequest) -> HttpResult {
         }
         SseResponse::Status(resp) => VolgaEngine::adapt_response(resp),
     }
+}
+
+/// Map a neva `Error` raised by engine-agnostic helpers onto a Volga
+/// server-error so the route can short-circuit with `?` into `HttpResult`.
+fn to_volga_err(err: crate::error::Error) -> VolgaError {
+    VolgaError::server_error(err.to_string())
 }


### PR DESCRIPTION
## Summary
* `HttpEngine::adapt_request` no longer forces engines to `.unwrap()`/`.expect()`
* `HttpEngine::adapt_response` drops the `BytesMut` round-trip for the default Streamable HTTP implementation.
* `parse_message` single-step decode + `Error::classify()`. Drops the `serde::Value` intermediate from the single-message hot path.
* Removed `'static` constraint for `HttpEngine::Request`, `HttpEngine::Response` and `HttpEngine::SseEvent` 

## Type
- [ ] Bug fix
- [ ] Feature
- [x] Enhancement
- [x] Performance
- [x] Documentation
- [ ] Refactor
- [ ] Security
- [x] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
