### PR TITLE
Version prefix and KID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   zero-downtime rotation. `with_request_state_secret` remains the single-key
   shorthand (kid `"0"`). (#81)
 
+### Fixed
+* The legacy `initialize` result no longer advertises the `logging` capability
+  in builds without the `tracing` feature, where the `logging/setLevel`
+  handler is not registered — capability-trusting clients (e.g. newer MCP
+  Inspector) would call it and hit `Method not found`.
+
 ### Changed
 * **Breaking (RC wire format):** the sealed MRTR `requestState` blob is now
   `v1.{kid}.b64(nonce).b64(ciphertext+tag)` (previously

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Added
+* **MRTR `requestState` key rotation.** New `App::with_request_state_keys(active_kid, keys)`
+  configures a keyring: new blobs are sealed under the active key id, inbound
+  blobs decrypt with whichever accepted key their kid names — enabling
+  zero-downtime rotation. `with_request_state_secret` remains the single-key
+  shorthand (kid `"0"`). (#81)
+
+### Changed
+* **Breaking (RC wire format):** the sealed MRTR `requestState` blob is now
+  `v1.{kid}.b64(nonce).b64(ciphertext+tag)` (previously
+  `b64(nonce).b64(ciphertext+tag)`). The `v1.{kid}` header is bound into the
+  AEAD associated data, so neither segment can be transplanted; decode rejects
+  unknown versions and key ids with `InvalidParams`. In-flight states minted
+  by an older release fail verification (TTL is 300s, so exposure is
+  transient). (#81)
+
 ## 0.4.1
 
 ### Added

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -334,6 +334,9 @@ impl App {
     /// decrypt the `requestState`. If unset, an ephemeral per-process key is
     /// used (fine for single-instance / development).
     ///
+    /// This is the single-key shorthand (kid `"0"`); for key rotation use
+    /// [`with_request_state_keys`](Self::with_request_state_keys).
+    ///
     /// # Example
     /// ```no_run
     /// # #[cfg(feature = "proto-2026-07-28-rc")] {
@@ -346,6 +349,48 @@ impl App {
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub fn with_request_state_secret(mut self, secret: impl AsRef<[u8]>) -> Self {
         self.options.set_request_state_secret(secret.as_ref());
+        self
+    }
+
+    /// Sets the keyring used to encrypt and authenticate MRTR `requestState`,
+    /// enabling zero-downtime key rotation (`proto-2026-07-28-rc`).
+    ///
+    /// New blobs are sealed with the key `active_kid` names and carry the kid
+    /// on the wire (`v1.{kid}.…`); an inbound blob is decrypted with whichever
+    /// accepted key its kid segment names. To rotate: ship the new key as
+    /// *accepted* on every instance first, then flip `active_kid` to it —
+    /// states minted under the old kid keep verifying until their TTL lapses,
+    /// after which the old key can be dropped.
+    ///
+    /// `active_kid` must name one of `keys` (encoding fails otherwise), be
+    /// non-empty and contain no `'.'` (the wire segment separator).
+    /// [`with_request_state_secret`](Self::with_request_state_secret) is the
+    /// single-key shorthand (kid `"0"`).
+    ///
+    /// # Example
+    /// ```no_run
+    /// # #[cfg(feature = "proto-2026-07-28-rc")] {
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_request_state_keys("2", [
+    ///         ("2", b"new-shared-secret".as_slice()),
+    ///         ("1", b"old-shared-secret".as_slice()),
+    ///     ]);
+    /// # }
+    /// ```
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    pub fn with_request_state_keys<K, S>(
+        mut self,
+        active_kid: impl AsRef<str>,
+        keys: impl IntoIterator<Item = (K, S)>,
+    ) -> Self
+    where
+        K: AsRef<str>,
+        S: AsRef<[u8]>,
+    {
+        self.options
+            .set_request_state_keys(active_kid.as_ref(), keys);
         self
     }
 
@@ -1174,8 +1219,10 @@ impl App {
         };
 
         // MRTR idempotency: the final-round response cache is keyed by the
-        // incoming state's sealed segment (the ciphertext+tag after the `.`,
-        // unique per minted state thanks to the random AEAD nonce) *plus* a
+        // incoming state's sealed segment (the ciphertext+tag after the last
+        // `.` — `rsplit_once` keeps grabbing it regardless of the leading
+        // `v1.kid.` header segments — unique per minted state thanks to the
+        // random AEAD nonce) *plus* a
         // digest of this round's `inputResponses`. The answers digest matters
         // because the *same* minted state can be echoed with *different*
         // answers — a client (or attacker) replaying one round-1 blob with two
@@ -1446,7 +1493,7 @@ fn seed_mrtr_ctx(
                 "requestState exceeds the configured maximum size",
             ));
         }
-        let payload = StateCodec::new(options.request_state_secret()).decode(&state)?;
+        let payload = StateCodec::new(options.request_state_keys()).decode(&state)?;
         if payload.exp < now_secs() {
             return Err(Error::new(ErrorCode::InvalidParams, "requestState expired"));
         }
@@ -1545,7 +1592,7 @@ fn build_input_required(
         req: request_binding(method, salient),
         principal,
     };
-    let state = StateCodec::new(options.request_state_secret()).encode(&payload)?;
+    let state = StateCodec::new(options.request_state_keys()).encode(&payload)?;
     if state.len() > options.max_state_bytes() {
         return Err(Error::new(
             ErrorCode::InternalError,
@@ -1664,7 +1711,8 @@ mod tests {
         }
 
         fn encode(payload: &StatePayload) -> String {
-            StateCodec::new(SECRET).encode(payload).expect("encode")
+            let ring = crate::types::mrtr::state::StateKeyring::single(SECRET);
+            StateCodec::new(&ring).encode(payload).expect("encode")
         }
 
         #[test]

--- a/neva/src/app/options.rs
+++ b/neva/src/app/options.rs
@@ -107,14 +107,16 @@ pub struct McpOptions {
     #[cfg(feature = "tasks")]
     pub(super) tasks: TaskTracker,
 
-    /// Secret used to encrypt and authenticate MRTR `requestState` (the AEAD key
-    /// is derived from it). Defaults to an ephemeral random key; multi-instance
-    /// stateless deployments must set a shared secret via
-    /// [`crate::App::with_request_state_secret`].
+    /// Keyring used to encrypt and authenticate MRTR `requestState` (the AEAD
+    /// key is derived from the secret the active kid names). Defaults to an
+    /// ephemeral random single-key ring; multi-instance stateless deployments
+    /// must set shared key material via
+    /// [`crate::App::with_request_state_secret`] or
+    /// [`crate::App::with_request_state_keys`].
     #[cfg(feature = "proto-2026-07-28-rc")]
-    request_state_secret: Arc<[u8]>,
+    request_state_keys: crate::types::mrtr::state::StateKeyring,
 
-    /// Whether [`Self::request_state_secret`] was set explicitly (vs the
+    /// Whether [`Self::request_state_keys`] was set explicitly (vs the
     /// ephemeral per-process default). Used to warn on startup about the
     /// multi-instance deployment footgun. Read only by the (tracing-gated)
     /// startup warning, so it is write-only in builds without an HTTP server
@@ -192,13 +194,13 @@ impl Default for McpOptions {
             #[cfg(feature = "tasks")]
             tasks: TaskTracker::new(),
             #[cfg(feature = "proto-2026-07-28-rc")]
-            request_state_secret: {
+            request_state_keys: {
                 // Ephemeral random key from two v4 UUIDs (16 bytes each).
                 // Non-panicking; sufficient for single-instance/dev.
                 let mut key = [0u8; 32];
                 key[..16].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
                 key[16..].copy_from_slice(uuid::Uuid::new_v4().as_bytes());
-                Arc::from(&key[..])
+                crate::types::mrtr::state::StateKeyring::single(&key)
             },
             #[cfg(feature = "proto-2026-07-28-rc")]
             request_state_secret_explicit: false,
@@ -732,17 +734,34 @@ impl McpOptions {
             .is_some_and(|tools| tools.call.is_some())
     }
 
-    /// Sets the shared secret used to encrypt/authenticate MRTR `requestState`.
+    /// Sets the shared secret used to encrypt/authenticate MRTR `requestState`
+    /// as a single-key ring under the default kid.
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub(crate) fn set_request_state_secret(&mut self, key: &[u8]) {
-        self.request_state_secret = Arc::from(key);
+        self.request_state_keys = crate::types::mrtr::state::StateKeyring::single(key);
         self.request_state_secret_explicit = true;
     }
 
-    /// Returns the MRTR `requestState` secret (AEAD key material).
+    /// Sets the MRTR `requestState` keyring: new blobs are sealed under
+    /// `active_kid`, inbound blobs decrypt with whichever accepted key their
+    /// kid segment names.
     #[cfg(feature = "proto-2026-07-28-rc")]
-    pub(crate) fn request_state_secret(&self) -> &[u8] {
-        &self.request_state_secret
+    pub(crate) fn set_request_state_keys<K, S>(
+        &mut self,
+        active_kid: &str,
+        keys: impl IntoIterator<Item = (K, S)>,
+    ) where
+        K: AsRef<str>,
+        S: AsRef<[u8]>,
+    {
+        self.request_state_keys = crate::types::mrtr::state::StateKeyring::new(active_kid, keys);
+        self.request_state_secret_explicit = true;
+    }
+
+    /// Returns the MRTR `requestState` keyring (AEAD key material).
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    pub(crate) fn request_state_keys(&self) -> &crate::types::mrtr::state::StateKeyring {
+        &self.request_state_keys
     }
 
     /// Returns whether the MRTR `requestState` secret was set explicitly
@@ -1124,6 +1143,18 @@ mod tests {
     fn request_state_secret_is_explicit_once_set() {
         let mut options = McpOptions::default();
         options.set_request_state_secret(b"shared-secret");
+        assert!(options.request_state_secret_is_explicit());
+    }
+
+    #[cfg(all(
+        feature = "proto-2026-07-28-rc",
+        feature = "http-server",
+        feature = "tracing"
+    ))]
+    #[test]
+    fn request_state_keys_are_explicit_once_set() {
+        let mut options = McpOptions::default();
+        options.set_request_state_keys("1", [("1", b"shared-secret")]);
         assert!(options.request_state_secret_is_explicit());
     }
 

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -792,8 +792,14 @@ impl InitializeResult {
                 tools: options.tools_capability(),
                 resources: options.resources_capability(),
                 prompts: options.prompts_capability(),
-                #[cfg(not(feature = "proto-2026-07-28-rc"))]
+                // The `logging/setLevel` handler is only registered under the
+                // `tracing` feature; advertise the capability only when the
+                // handler exists, otherwise clients that trust capabilities
+                // (e.g. MCP Inspector) call it and hit `MethodNotFound`.
+                #[cfg(all(not(feature = "proto-2026-07-28-rc"), feature = "tracing"))]
                 logging: Some(LoggingCapability::default()),
+                #[cfg(all(not(feature = "proto-2026-07-28-rc"), not(feature = "tracing")))]
+                logging: None,
                 completions: Some(CompletionsCapability::default()),
                 #[cfg(feature = "tasks")]
                 tasks: options.tasks_capability(),
@@ -858,6 +864,21 @@ mod tests {
         assert_eq!(caps["resources"]["subscribe"], serde_json::json!(false));
         assert_eq!(caps["resources"]["listChanged"], serde_json::json!(false));
         assert_eq!(caps["prompts"]["listChanged"], serde_json::json!(false));
+    }
+
+    /// The `logging` capability must be advertised iff the `logging/setLevel`
+    /// handler is compiled in (the `tracing` feature). Advertising it without
+    /// the handler sends capability-trusting clients into `MethodNotFound`
+    /// (caught live by MCP Inspector against `examples/server`).
+    #[cfg(all(feature = "server", not(feature = "proto-2026-07-28-rc")))]
+    #[test]
+    fn logging_capability_is_advertised_iff_handler_compiled() {
+        let init = InitializeResult::new(&McpOptions::default());
+        let caps = serde_json::to_value(&init.capabilities).unwrap();
+        #[cfg(feature = "tracing")]
+        assert!(caps.get("logging").is_some());
+        #[cfg(not(feature = "tracing"))]
+        assert!(caps.get("logging").is_none());
     }
 
     #[test]

--- a/neva/src/types/mrtr/state.rs
+++ b/neva/src/types/mrtr/state.rs
@@ -6,10 +6,12 @@
 //! responses, PII, tokens — are confidential rather than merely signed and
 //! readable by the client that echoes the blob.
 
-use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
+use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
+use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::error::{Error, ErrorCode};
@@ -17,6 +19,16 @@ use crate::types::mrtr::InputResponses;
 
 /// ChaCha20-Poly1305 nonce length (96 bits).
 const NONCE_LEN: usize = 12;
+
+/// Codec version written as the blob's first wire segment and bound into the
+/// AEAD associated data, so a blob minted under one format cannot be
+/// transplanted into a future one. Bump when the wire format or the
+/// [`StatePayload`] semantics change; [`StateCodec::decode`] rejects anything else.
+pub(crate) const STATE_VERSION: &str = "v1";
+
+/// Key id used when a single secret is configured (the
+/// [`crate::App::with_request_state_secret`] path).
+pub(crate) const DEFAULT_KID: &str = "0";
 
 /// Derives the 32-byte AEAD key from the configured secret (which may be any
 /// length). Domain-separated so the key is specific to this use and version.
@@ -56,44 +68,157 @@ pub(crate) struct StatePayload {
     pub principal: Option<String>,
 }
 
-/// Encodes/decodes [`StatePayload`] as `b64(nonce).b64(ciphertext+tag)`, sealed
-/// with ChaCha20-Poly1305. The trailing segment (the ciphertext with its AEAD
-/// tag) is unique per minted state and is what the dispatch layer uses as the
+/// The secrets accepted for `requestState` decryption plus the active one used
+/// for encryption. Enables zero-downtime key rotation: stage the new key as
+/// accepted on every instance, then flip it to active; states minted under the
+/// old kid keep verifying until their TTL lapses.
+pub(crate) struct StateKeyring {
+    /// Kid new blobs are sealed under. Must resolve in [`Self::keys`], or
+    /// [`StateCodec::encode`] fails.
+    active_kid: Box<str>,
+    /// Accepted `kid → secret` map used to select the decryption key by the
+    /// kid segment of the inbound blob.
+    keys: HashMap<Box<str>, Arc<[u8]>>,
+}
+
+impl std::fmt::Debug for StateKeyring {
+    // Manual impl so key material never reaches logs: kids only.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateKeyring")
+            .field("active_kid", &self.active_kid)
+            .field("kids", &self.keys.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl StateKeyring {
+    /// Single-key ring under [`DEFAULT_KID`] — the
+    /// [`crate::App::with_request_state_secret`] path.
+    pub(crate) fn single(secret: &[u8]) -> Self {
+        Self::new(DEFAULT_KID, [(DEFAULT_KID, secret)])
+    }
+
+    /// Builds a ring that encodes with `active_kid` and accepts every
+    /// `(kid, secret)` in `keys` for decoding.
+    pub(crate) fn new<K, S>(active_kid: &str, keys: impl IntoIterator<Item = (K, S)>) -> Self
+    where
+        K: AsRef<str>,
+        S: AsRef<[u8]>,
+    {
+        Self {
+            active_kid: Box::from(active_kid),
+            keys: keys
+                .into_iter()
+                .map(|(kid, secret)| (Box::from(kid.as_ref()), Arc::from(secret.as_ref())))
+                .collect(),
+        }
+    }
+
+    /// The `(kid, secret)` pair new blobs are sealed under.
+    fn active(&self) -> Result<(&str, &[u8]), Error> {
+        self.keys
+            .get(&*self.active_kid)
+            .map(|secret| (&*self.active_kid, &**secret))
+            .ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalError,
+                    "active requestState kid has no key in the keyring",
+                )
+            })
+    }
+
+    /// The secret accepted under `kid`, if any.
+    fn key(&self, kid: &str) -> Option<&[u8]> {
+        self.keys.get(kid).map(|secret| &**secret)
+    }
+}
+
+/// Encodes/decodes [`StatePayload`] as
+/// `{version}.{kid}.b64(nonce).b64(ciphertext+tag)`, sealed with
+/// ChaCha20-Poly1305. The `{version}.{kid}` header is bound into the AEAD
+/// associated data, so neither segment can be swapped on the wire without
+/// failing the tag. The trailing segment (the ciphertext with its AEAD tag) is
+/// unique per minted state and is what the dispatch layer uses as the
 /// per-state identity for the idempotency cache.
 pub(crate) struct StateCodec<'a> {
-    key: &'a [u8],
+    keyring: &'a StateKeyring,
 }
 
 impl<'a> StateCodec<'a> {
-    /// Creates a codec bound to an encryption secret.
-    pub(crate) fn new(key: &'a [u8]) -> Self {
-        Self { key }
+    /// Creates a codec bound to a keyring.
+    pub(crate) fn new(keyring: &'a StateKeyring) -> Self {
+        Self { keyring }
     }
 
-    fn cipher(&self) -> Result<ChaCha20Poly1305, Error> {
-        ChaCha20Poly1305::new_from_slice(&derive_key(self.key))
+    fn cipher(secret: &[u8]) -> Result<ChaCha20Poly1305, Error> {
+        ChaCha20Poly1305::new_from_slice(&derive_key(secret))
             .map_err(|_| Error::new(ErrorCode::InternalError, "bad state key"))
     }
 
-    /// Encrypts a payload into the opaque wire string.
+    /// Encrypts a payload into the opaque wire string using the keyring's
+    /// active key.
     pub(crate) fn encode(&self, payload: &StatePayload) -> Result<String, Error> {
         use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as B64};
+        let (kid, secret) = self.keyring.active()?;
+        if kid.is_empty() || kid.contains('.') {
+            // '.' is the segment separator; a kid containing it would shift the
+            // nonce/ciphertext segments and every minted blob would fail decode.
+            return Err(Error::new(
+                ErrorCode::InternalError,
+                "requestState kid must be non-empty and must not contain '.'",
+            ));
+        }
         let json = serde_json::to_vec(payload).map_err(Error::from)?;
-        let cipher = self.cipher()?;
+        let cipher = Self::cipher(secret)?;
         let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let header = format!("{STATE_VERSION}.{kid}");
         let sealed = cipher
-            .encrypt(&nonce, json.as_slice())
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: &json,
+                    aad: header.as_bytes(),
+                },
+            )
             .map_err(|_| Error::new(ErrorCode::InternalError, "requestState encryption failed"))?;
-        Ok(format!("{}.{}", B64.encode(nonce), B64.encode(sealed)))
+        Ok(format!(
+            "{header}.{}.{}",
+            B64.encode(nonce),
+            B64.encode(sealed)
+        ))
     }
 
-    /// Decrypts and verifies integrity. Does NOT check `exp`/`req`/`principal` —
-    /// callers do that against the returned [`StatePayload`].
+    /// Decrypts and verifies integrity, selecting the key by the blob's kid
+    /// segment. Does NOT check `exp`/`req`/`principal` — callers do that
+    /// against the returned [`StatePayload`].
     pub(crate) fn decode(&self, blob: &str) -> Result<StatePayload, Error> {
         use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as B64};
-        let (n_b64, c_b64) = blob
-            .split_once('.')
-            .ok_or_else(|| Error::new(ErrorCode::InvalidParams, "malformed requestState"))?;
+        // Parse a fixed segment count. A left-to-right `split_once` would take
+        // the `v1` prefix as the nonce; anything but exactly four segments is
+        // malformed (base64url has no '.', so the count is unambiguous).
+        let mut parts = blob.split('.');
+        let (Some(version), Some(kid), Some(n_b64), Some(c_b64), None) = (
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+            parts.next(),
+        ) else {
+            return Err(Error::new(
+                ErrorCode::InvalidParams,
+                "malformed requestState",
+            ));
+        };
+        if version != STATE_VERSION {
+            return Err(Error::new(
+                ErrorCode::InvalidParams,
+                "unsupported requestState version",
+            ));
+        }
+        let secret = self
+            .keyring
+            .key(kid)
+            .ok_or_else(|| Error::new(ErrorCode::InvalidParams, "unknown requestState key id"))?;
         let nonce = B64
             .decode(n_b64)
             .map_err(|_| Error::new(ErrorCode::InvalidParams, "bad requestState nonce"))?;
@@ -103,9 +228,15 @@ impl<'a> StateCodec<'a> {
         let nonce: [u8; NONCE_LEN] = nonce
             .try_into()
             .map_err(|_| Error::new(ErrorCode::InvalidParams, "bad requestState nonce"))?;
-        let json = self
-            .cipher()?
-            .decrypt(&Nonce::from(nonce), sealed.as_slice())
+        let header = format!("{STATE_VERSION}.{kid}");
+        let json = Self::cipher(secret)?
+            .decrypt(
+                &Nonce::from(nonce),
+                Payload {
+                    msg: sealed.as_slice(),
+                    aad: header.as_bytes(),
+                },
+            )
             .map_err(|_| {
                 Error::new(
                     ErrorCode::InvalidParams,
@@ -181,6 +312,30 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
+    fn ring(secret: &[u8]) -> StateKeyring {
+        StateKeyring::single(secret)
+    }
+
+    /// Seals arbitrary JSON the way `StateCodec::encode` would, so tests can
+    /// mint blobs with non-[`StatePayload`] contents or a custom kid.
+    fn seal_json(secret: &[u8], kid: &str, json: &serde_json::Value) -> String {
+        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as B64};
+        let bytes = serde_json::to_vec(json).unwrap();
+        let cipher = StateCodec::cipher(secret).unwrap();
+        let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let header = format!("{STATE_VERSION}.{kid}");
+        let sealed = cipher
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: bytes.as_slice(),
+                    aad: header.as_bytes(),
+                },
+            )
+            .unwrap();
+        format!("{header}.{}.{}", B64.encode(nonce), B64.encode(sealed))
+    }
+
     fn payload() -> StatePayload {
         StatePayload {
             answers: HashMap::new(),
@@ -195,7 +350,8 @@ mod tests {
 
     #[test]
     fn memos_and_effects_roundtrip() {
-        let codec = StateCodec::new(b"secret-key");
+        let ring = ring(b"secret-key");
+        let codec = StateCodec::new(&ring);
         let mut p = payload();
         p.memos
             .insert("quote".into(), serde_json::json!({"price": 42}));
@@ -221,15 +377,9 @@ mod tests {
             "req": request_binding("tools/call", &serde_json::json!({"name":"t"})),
             "principal": serde_json::Value::Null,
         });
-        let codec = StateCodec::new(b"secret-key");
-        let blob = {
-            use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as B64};
-            let bytes = serde_json::to_vec(&json).unwrap();
-            let cipher = codec.cipher().unwrap();
-            let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
-            let sealed = cipher.encrypt(&nonce, bytes.as_slice()).unwrap();
-            format!("{}.{}", B64.encode(nonce), B64.encode(sealed))
-        };
+        let ring = ring(b"secret-key");
+        let codec = StateCodec::new(&ring);
+        let blob = seal_json(b"secret-key", DEFAULT_KID, &json);
         let got = codec.decode(&blob).unwrap();
         assert!(got.memos.is_empty());
         assert!(got.effects.is_empty());
@@ -240,7 +390,8 @@ mod tests {
     fn memo_values_are_not_readable_from_the_wire_blob() {
         // Confidentiality: a secret cached via `ctx.memo` must not be recoverable
         // by decoding the opaque blob without the key.
-        let codec = StateCodec::new(b"secret-key");
+        let ring = ring(b"secret-key");
+        let codec = StateCodec::new(&ring);
         let mut p = payload();
         p.memos
             .insert("token".into(), serde_json::json!("super-secret-value"));
@@ -265,7 +416,8 @@ mod tests {
 
     #[test]
     fn encode_decode_roundtrips() {
-        let codec = StateCodec::new(b"secret-key");
+        let ring = ring(b"secret-key");
+        let codec = StateCodec::new(&ring);
         let p = payload();
         let blob = codec.encode(&p).unwrap();
         let got = codec.decode(&blob).unwrap();
@@ -276,8 +428,19 @@ mod tests {
     }
 
     #[test]
+    fn encode_writes_version_and_kid_segments() {
+        let ring = ring(b"secret-key");
+        let blob = StateCodec::new(&ring).encode(&payload()).unwrap();
+        let segments: Vec<&str> = blob.split('.').collect();
+        assert_eq!(segments.len(), 4, "expected v1.kid.nonce.ct, got {blob}");
+        assert_eq!(segments[0], STATE_VERSION);
+        assert_eq!(segments[1], DEFAULT_KID);
+    }
+
+    #[test]
     fn tampered_blob_is_rejected() {
-        let codec = StateCodec::new(b"secret-key");
+        let ring = ring(b"secret-key");
+        let codec = StateCodec::new(&ring);
         let mut blob = codec.encode(&payload()).unwrap();
         blob.push('x'); // corrupt the tag
         assert!(codec.decode(&blob).is_err());
@@ -285,8 +448,107 @@ mod tests {
 
     #[test]
     fn wrong_key_is_rejected() {
-        let blob = StateCodec::new(b"key-a").encode(&payload()).unwrap();
-        assert!(StateCodec::new(b"key-b").decode(&blob).is_err());
+        let ring_a = ring(b"key-a");
+        let ring_b = ring(b"key-b");
+        let blob = StateCodec::new(&ring_a).encode(&payload()).unwrap();
+        assert!(StateCodec::new(&ring_b).decode(&blob).is_err());
+    }
+
+    #[test]
+    fn unknown_version_is_rejected() {
+        let ring = ring(b"secret-key");
+        let codec = StateCodec::new(&ring);
+        let blob = codec.encode(&payload()).unwrap();
+        let transplanted = format!("v9{}", blob.strip_prefix("v1").unwrap());
+        let err = codec.decode(&transplanted).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(
+            format!("{err}").contains("unsupported requestState version"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn unknown_kid_is_rejected() {
+        let ring = ring(b"secret-key");
+        let codec = StateCodec::new(&ring);
+        // A blob sealed under a kid the ring does not accept.
+        let blob = seal_json(b"secret-key", "9", &serde_json::json!({}));
+        let err = codec.decode(&blob).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(
+            format!("{err}").contains("unknown requestState key id"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn legacy_two_segment_blob_is_rejected_as_malformed() {
+        // The pre-versioning wire format (`b64(nonce).b64(ct)`) must not be
+        // taken for a v1 blob — segment-count parsing rejects it outright.
+        let ring = ring(b"secret-key");
+        let codec = StateCodec::new(&ring);
+        let blob = codec.encode(&payload()).unwrap();
+        let legacy = blob.splitn(3, '.').nth(2).unwrap(); // strip "v1.kid."
+        let err = codec.decode(legacy).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(format!("{err}").contains("malformed requestState"), "{err}");
+    }
+
+    #[test]
+    fn kid_transplant_fails_the_aad_binding() {
+        // Two kids sharing one secret: rewriting the wire kid selects the SAME
+        // decryption key, so only the AAD binding of `{version}.{kid}` can
+        // catch the transplant.
+        let ring = StateKeyring::new("a", [("a", b"same-secret"), ("b", b"same-secret")]);
+        let codec = StateCodec::new(&ring);
+        let blob = codec.encode(&payload()).unwrap();
+        let transplanted = format!("v1.b{}", blob.strip_prefix("v1.a").unwrap());
+        let err = codec.decode(&transplanted).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(format!("{err}").contains("integrity check failed"), "{err}");
+        // Sanity: the untouched blob still decodes.
+        assert!(codec.decode(&blob).is_ok());
+    }
+
+    #[test]
+    fn rotated_keyring_still_decodes_old_kid() {
+        // Rotation: blobs minted while "1" was active keep verifying after the
+        // ring flips to "2", as long as "1" stays accepted.
+        let old = StateKeyring::new("1", [("1", b"old-secret")]);
+        let blob = StateCodec::new(&old).encode(&payload()).unwrap();
+
+        let rotated = StateKeyring::new(
+            "2",
+            [
+                ("2", b"new-secret".as_slice()),
+                ("1", b"old-secret".as_slice()),
+            ],
+        );
+        let codec = StateCodec::new(&rotated);
+        assert!(codec.decode(&blob).is_ok());
+        // New blobs are sealed under the new active kid.
+        let fresh = codec.encode(&payload()).unwrap();
+        assert!(fresh.starts_with("v1.2."), "{fresh}");
+        // Dropping the old key from the ring retires its blobs.
+        let retired = StateKeyring::new("2", [("2", b"new-secret")]);
+        assert!(StateCodec::new(&retired).decode(&blob).is_err());
+    }
+
+    #[test]
+    fn active_kid_missing_from_ring_fails_encode() {
+        let ring = StateKeyring::new("active", [("other", b"secret")]);
+        let err = StateCodec::new(&ring).encode(&payload()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InternalError);
+    }
+
+    #[test]
+    fn kid_with_separator_fails_encode() {
+        // '.' inside a kid would shift the wire segments; encode refuses to
+        // mint an undecodable blob.
+        let ring = StateKeyring::new("a.b", [("a.b", b"secret")]);
+        let err = StateCodec::new(&ring).encode(&payload()).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InternalError);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
### Added
* **MRTR `requestState` key rotation.** New `App::with_request_state_keys(active_kid, keys)`
  configures a keyring: new blobs are sealed under the active key id, inbound
  blobs decrypt with whichever accepted key their kid names — enabling
  zero-downtime rotation. `with_request_state_secret` remains the single-key
  shorthand (kid `"0"`). (#81)

### Changed
* **Breaking (RC wire format):** the sealed MRTR `requestState` blob is now
  `v1.{kid}.b64(nonce).b64(ciphertext+tag)` (previously
  `b64(nonce).b64(ciphertext+tag)`). The `v1.{kid}` header is bound into the
  AEAD associated data, so neither segment can be transplanted; decode rejects
  unknown versions and key ids with `InvalidParams`. In-flight states minted
  by an older release fail verification (TTL is 300s, so exposure is
  transient). (#81)

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [x] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers
Anything you'd like reviewers to pay extra attention to?
