### PR TITLE
OAuth Phase 1: engine-neutral resource-server primitives

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,6 +48,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_format
 
+    # audit-check publishes results via the Checks API; without `checks: write`
+    # it fails hard on push and silently passes on pull_request.
+    permissions:
+      contents: read
+      checks: write
+
     steps:
       - uses: actions/checkout@v4
       - name: Security audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   * `handlers::handle_oauth_metadata` serves the well-known document;
     `handlers::handle_unauthorized` answers 401 with the
     `WWW-Authenticate: Bearer resource_metadata="…"` challenge.
+  * The default Volga engine mounts the document on its well-known path
+    automatically (publicly reachable — auth enforcement is scoped to the
+    MCP endpoint group) and, when bearer auth is configured, advertises it
+    as `resource_metadata` on Volga's own 401 challenges.
   * Protocol types re-exported under `neva::auth::oauth`
     (`ProtectedResourceMetadata`, `BearerChallenge`, `OAuthError`, …).
 * **MRTR `requestState` key rotation.** New `App::with_request_state_keys(active_kid, keys)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.4.2
+
+### Added
+* Engine-neutral OAuth 2.1 resource-server primitives behind the new
+  `server-oauth` feature (included in `server-full`), built on
+  `volga-oauth-core` — protocol types only, no Volga framework dependency,
+  so they work with any `HttpEngine` (Volga, axum, hyper, custom):
+  * `HttpServer::with_oauth_metadata(...)` configures the RFC 9728
+    Protected Resource Metadata document (`OAuthResourceOptions`:
+    authorization servers, scopes, canonical resource override for
+    reverse proxies, full-document escape hatch). The document is
+    canonicalized (RFC 8707), pre-serialized once at server start, and
+    exposed to engines via `HttpContext::oauth_metadata_path()` /
+    `oauth_metadata_url()`.
+  * `handlers::handle_oauth_metadata` serves the well-known document;
+    `handlers::handle_unauthorized` answers 401 with the
+    `WWW-Authenticate: Bearer resource_metadata="…"` challenge.
+  * Protocol types re-exported under `neva::auth::oauth`
+    (`ProtectedResourceMetadata`, `BearerChallenge`, `OAuthError`, …).
+
 ## 0.4.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   * Protocol types re-exported under `neva::auth::oauth`
     (`ProtectedResourceMetadata`, `BearerChallenge`, `OAuthError`, …).
 
+### Fixed
+* Migrated `requestState` sealing to the `chacha20poly1305` 0.11 API
+  (nonce generation moved to the fallible `Nonce::try_generate()`; no
+  wire-format change).
+* Replaced the deprecated `sse_stream::SseStream::from_byte_stream` with
+  `from_bytes_stream` (removed upstream in sse-stream 0.3).
+
+### Security
+* Resolved RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut`)
+  by updating the transitive `anyhow` dependency to 1.0.103.
+
 ## 0.4.1
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * Engine-neutral OAuth 2.1 resource-server primitives behind the new
   `server-oauth` feature (included in `server-full`), built on
   `volga-oauth-core` — protocol types only, no Volga framework dependency,
-  so they work with any `HttpEngine` (Volga, axum, hyper, custom):
+  so they work with any `HttpEngine`:
   * `HttpServer::with_oauth_metadata(...)` configures the RFC 9728
     Protected Resource Metadata document (`OAuthResourceOptions`:
     authorization servers, scopes, canonical resource override for
@@ -24,13 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `WWW-Authenticate: Bearer resource_metadata="…"` challenge.
   * Protocol types re-exported under `neva::auth::oauth`
     (`ProtectedResourceMetadata`, `BearerChallenge`, `OAuthError`, …).
-
-### Fixed
-* Migrated `requestState` sealing to the `chacha20poly1305` 0.11 API
-  (nonce generation moved to the fallible `Nonce::try_generate()`; no
-  wire-format change).
-* Replaced the deprecated `sse_stream::SseStream::from_byte_stream` with
-  `from_bytes_stream` (removed upstream in sse-stream 0.3).
 
 ### Security
 * Resolved RUSTSEC-2026-0190 (unsoundness in `anyhow::Error::downcast_mut`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "uuid",
  "volga",
  "volga-di",
+ "volga-oauth-core",
  "windows",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "asn1-rs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,12 +193,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.1.6",
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -494,9 +494,9 @@ checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytestring"
@@ -533,37 +533,26 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cipher",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
  "aead",
- "chacha20 0.9.1",
+ "chacha20",
  "cipher",
  "poly1305",
- "zeroize",
 ]
 
 [[package]]
@@ -582,13 +571,13 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.6",
+ "block-buffer",
+ "crypto-common",
  "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -599,6 +588,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"
@@ -664,15 +659,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -697,22 +683,22 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -786,7 +772,7 @@ checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
  "const-oid",
- "crypto-common 0.2.2",
+ "crypto-common",
 ]
 
 [[package]]
@@ -1129,16 +1115,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,20 +1210,14 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1355,6 +1325,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1535,11 +1506,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1635,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.46.6"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8374249b1bdce1c1773a09fa294347e19e4bfeb86d845c2d8ebaf8a8dbf11233"
+checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1648,18 +1619,27 @@ dependencies = [
  "getrandom 0.3.4",
  "idna",
  "itoa",
+ "jsonschema-regex",
  "num-cmp",
  "num-traits",
  "percent-encoding",
  "referencing",
  "regex",
- "regex-syntax",
  "reqwest",
  "rustls",
  "serde",
  "serde_json",
  "unicode-general-category",
  "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+dependencies = [
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1764,9 +1744,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "micromap"
@@ -1820,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "bytes",
@@ -1854,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "neva_macros"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1994,12 +1974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,12 +2038,11 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "poly1305"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.2.17",
- "opaque-debug",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -2209,7 +2182,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -2293,14 +2266,14 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.46.6"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a910f9d63351f9c9d7dc3053d02b214ea3a005917140c70087d7b59cbc5bb1"
+checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
 dependencies = [
  "ahash",
  "fluent-uri",
  "getrandom 0.3.4",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "micromap",
  "parking_lot",
@@ -2674,7 +2647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -2685,7 +2658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest",
 ]
 
@@ -2791,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2816,9 +2789,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3173,12 +3146,12 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.1.6",
- "subtle",
+ "crypto-common",
+ "ctutils",
 ]
 
 [[package]]
@@ -3213,9 +3186,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3247,9 +3220,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volga"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15168bb11d8e385711f1d9540e555791a10db7e609221f62499201c8b33ee837"
+checksum = "522e0013775553cda1600cc51561c5e661c10f506957480f9fea9c159fc63dd8"
 dependencies = [
  "async-stream",
  "bytes",
@@ -3275,35 +3248,69 @@ dependencies = [
  "volga-dev-cert",
  "volga-di",
  "volga-macros",
+ "volga-oauth-client",
+ "volga-oauth-core",
 ]
 
 [[package]]
 name = "volga-dev-cert"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af25692b151306d4e11ce42d29d9fd509f4c6869c1db13068e8393202db3d53"
+checksum = "18231cadb6714f907d212911006d3d7d616a62233993215a740426a6c3c1bdc6"
 dependencies = [
  "rcgen",
 ]
 
 [[package]]
 name = "volga-di"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e857bf7d3abeeeb94ba68a90140816eb8558d9940b19cc7a9e5bee3228c03f97"
+checksum = "0744ee783c50e95e8c23f0952c5b61616a16f4662626fcc3b976a209f63a6fcf"
 dependencies = [
  "http 1.4.2",
 ]
 
 [[package]]
 name = "volga-macros"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02258d929b36fbb70156d1013e5c0d80aa61231ea8c0bdb19f08c6f874aa281f"
+checksum = "ae9a02aa327d8d340cee73e3132b3fc7283f3b436423b8327784a468ea8c2707"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "volga-oauth-client"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ca7f56d2060d50e1460ac24a4de60039e2834897f702cb8c43337dce8a3b95"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "volga-oauth-core",
+]
+
+[[package]]
+name = "volga-oauth-core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6445f8f6c6fa3c8f341b4937dfec743855892107b47077260e0c296ccddf8e09"
+dependencies = [
+ "http 1.4.2",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3482,6 +3489,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -28,7 +28,7 @@ categories = [
 ]
 
 [workspace.dependencies]
-neva_macros = { path = "neva_macros", version = "0.4.1" }
+neva_macros = { path = "neva_macros", version = "0.4.2" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -43,6 +43,7 @@ tracing = { version = "0.1.44", optional = true }
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "json"], optional = true }
 volga = { version = "0.9.5", features = ["di", "jwt-auth-full"], optional = true }
 volga-di = { version = "0.9.5", optional = true }
+volga-oauth-core = { version = "0.9.5", optional = true }
 
 # neva
 neva_macros = { workspace = true, optional = true }
@@ -66,9 +67,13 @@ tasks = []
 tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:once_cell", "volga?/tracing"]
 
 # server
-server-full = ["server-macros", "tracing", "http-server-volga", "server-tls", "di", "tasks"]
+server-full = ["server-macros", "tracing", "http-server-volga", "server-tls", "server-oauth", "di", "tasks"]
 server-macros = ["server", "macros", "neva_macros?/server"]
 server-tls = ["http-server-volga", "volga?/tls", "volga?/dev-cert"]
+# Engine-neutral OAuth 2.1 resource-server primitives: the RFC 9728
+# Protected Resource Metadata document and the WWW-Authenticate bearer
+# challenge, served through any `HttpEngine`. No Volga in deps.
+server-oauth = ["http-server", "dep:volga-oauth-core"]
 # Engine-agnostic Streamable HTTP abstractions. Enable this and implement
 # `HttpEngine` for your own stack (e.g. axum, hyper). No Volga in deps.
 http-server = ["server", "dep:tokio-stream"]

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -17,32 +17,32 @@ workspace = true
 
 [dependencies]
 base64 = "0.22.1"
-bytes = "1.12.0"
+bytes = "1.12.1"
 sha2 = { version = "0.11.0", optional = true }
 chrono = { version = "0.4.45", features = ["serde"] }
 dashmap = "6.2.1"
 futures-util = { version = "0.3.32", default-features = false, features = ["alloc"] }
 http = "1.4.2"
-memchr = "2.8.2"
+memchr = "2.8.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 schemars = { version = "1.2.1" }
 tokio = { version = "1.52.3", features = ["sync", "io-std", "io-util", "rt", "time", "macros"] }
 tokio-util = "0.7.18"
-uuid = { version = "1.23.4", features = ["v4", "serde"] }
+uuid = { version = "1.24.0", features = ["v4", "serde"] }
 
 # optional
-chacha20poly1305 = { version = "0.10.1", optional = true }
+chacha20poly1305 = { version = "0.11.0", optional = true }
 inventory = { version = "0.3.24", optional = true }
-jsonschema = { version = "0.46.6", optional = true }
+jsonschema = { version = "0.47.0", optional = true }
 once_cell = { version = "1.21.4", features = ["std"], optional = true }
 reqwest = { version = "0.13.4", features = ["stream", "json"], optional = true }
-sse-stream = { version = "0.2.3", optional = true }
+sse-stream = { version = "0.2.4", optional = true }
 tokio-stream = { version = "0.1.18", optional = true }
 tracing = { version = "0.1.44", optional = true }
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "json"], optional = true }
-volga = { version = "0.9.4", features = ["di", "jwt-auth-full"], optional = true }
-volga-di = { version = "0.9.4", optional = true }
+volga = { version = "0.9.5", features = ["di", "jwt-auth-full"], optional = true }
+volga-di = { version = "0.9.5", optional = true }
 
 # neva
 neva_macros = { workspace = true, optional = true }

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -166,6 +166,25 @@ pub mod auth {
     // alias above (which lives in the type namespace).
     #[cfg(feature = "http-server-volga")]
     pub use volga::auth::{Algorithm, Authorizer, Claims as ClaimsDerive};
+
+    #[cfg(feature = "server-oauth")]
+    pub mod oauth {
+        //! OAuth 2.1 / OIDC resource-server primitives.
+        //!
+        //! [`OAuthResourceOptions`] configures the RFC 9728 Protected
+        //! Resource Metadata document through
+        //! `HttpServer::with_oauth_metadata`; the protocol-level types
+        //! are re-exported from
+        //! [`volga-oauth-core`](https://docs.rs/volga-oauth-core) —
+        //! a crate with no HTTP I/O and no dependency on the Volga
+        //! framework, so they are available to every `HttpEngine`.
+
+        pub use crate::transport::http::core::oauth::{
+            BearerChallenge, OAuthError, OAuthErrorCode, OAuthResourceOptions,
+            ProtectedResourceMetadata, WELL_KNOWN_PROTECTED_RESOURCE, canonicalize_resource_uri,
+            protected_resource_metadata_url,
+        };
+    }
 }
 
 pub mod json {
@@ -194,6 +213,8 @@ pub mod prelude {
 
     #[cfg(feature = "http-server-volga")]
     pub use crate::auth::AuthConfig;
+    #[cfg(feature = "server-oauth")]
+    pub use crate::auth::oauth::OAuthResourceOptions;
     #[cfg(feature = "http-server")]
     pub use crate::auth::{Claims, DefaultClaims};
 

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -127,6 +127,8 @@ where
     sse_log_queue_capacity: usize,
     sse_cleanup_interval: Duration,
     sse_session_ttl: Duration,
+    #[cfg(feature = "server-oauth")]
+    oauth: Option<core::oauth::OAuthResourceOptions>,
     sender: HttpSender,
     receiver: HttpReceiver,
     _claims: std::marker::PhantomData<fn() -> C>,
@@ -202,6 +204,8 @@ impl Default for HttpServer<server::DefaultClaims, server::VolgaEngine> {
             sse_log_queue_capacity: DEFAULT_SSE_LOG_QUEUE_CAPACITY,
             sse_cleanup_interval: DEFAULT_SSE_CLEANUP_INTERVAL,
             sse_session_ttl: DEFAULT_SSE_SESSION_TTL,
+            #[cfg(feature = "server-oauth")]
+            oauth: None,
             receiver: HttpReceiver::new(),
             sender: HttpSender::new(),
             _claims: std::marker::PhantomData,
@@ -344,6 +348,8 @@ where
             sse_log_queue_capacity: DEFAULT_SSE_LOG_QUEUE_CAPACITY,
             sse_cleanup_interval: DEFAULT_SSE_CLEANUP_INTERVAL,
             sse_session_ttl: DEFAULT_SSE_SESSION_TTL,
+            #[cfg(feature = "server-oauth")]
+            oauth: None,
             receiver: HttpReceiver::new(),
             sender: HttpSender::new(),
             _claims: std::marker::PhantomData,
@@ -384,6 +390,8 @@ where
             sse_log_queue_capacity: self.sse_log_queue_capacity,
             sse_cleanup_interval: self.sse_cleanup_interval,
             sse_session_ttl: self.sse_session_ttl,
+            #[cfg(feature = "server-oauth")]
+            oauth: self.oauth,
             sender: self.sender,
             receiver: self.receiver,
             _claims: std::marker::PhantomData,
@@ -482,6 +490,34 @@ where
         self
     }
 
+    /// Configures the OAuth Protected Resource Metadata document
+    /// (RFC 9728) advertised by this server. Engine-neutral: the resolved
+    /// document reaches the engine through
+    /// [`HttpContext::oauth_metadata_path`] and the
+    /// [`handlers::handle_oauth_metadata`] /
+    /// [`handlers::handle_unauthorized`] helpers.
+    ///
+    /// The resource identifier defaults to this server's own URL; override
+    /// it with
+    /// [`OAuthResourceOptions::with_resource`](core::oauth::OAuthResourceOptions::with_resource)
+    /// when running behind a reverse proxy.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// HttpServer::new("127.0.0.1:3000")
+    ///     .with_oauth_metadata(|oauth| oauth
+    ///         .with_authorization_servers(["https://auth.example.com"])
+    ///         .with_scopes(["mcp:tools"]))
+    /// ```
+    #[cfg(feature = "server-oauth")]
+    pub fn with_oauth_metadata<F>(mut self, config: F) -> Self
+    where
+        F: FnOnce(core::oauth::OAuthResourceOptions) -> core::oauth::OAuthResourceOptions,
+    {
+        self.oauth = Some(config(core::oauth::OAuthResourceOptions::default()));
+        self
+    }
+
     fn build_context_and_engine(&mut self) -> Result<(HttpContext, Receiver<Message>), Error> {
         let Some(sender_rx) = self.sender.rx.take() else {
             return Err(Error::new(
@@ -493,6 +529,15 @@ where
         let sse_registry = std::sync::Arc::new(crate::shared::SseSessionRegistry::new(
             self.sse_buffer_capacity,
         ));
+        // Resolve the OAuth resource once at startup: canonicalize the
+        // identifier, pre-serialize the RFC 9728 document, pre-render the
+        // challenge. A misconfigured resource URI fails server start.
+        #[cfg(feature = "server-oauth")]
+        let oauth = self
+            .oauth
+            .take()
+            .map(|o| o.resolve(&self.url.to_string()))
+            .transpose()?;
         let ctx = HttpContext {
             addr: self.url.addr.as_str().into(),
             endpoint: self.url.endpoint.as_str().into(),
@@ -501,6 +546,8 @@ where
             inbound_tx: self.receiver.tx.clone(),
             sse_live_queue_capacity: self.sse_live_queue_capacity,
             sse_log_queue_capacity: self.sse_log_queue_capacity,
+            #[cfg(feature = "server-oauth")]
+            oauth,
         };
         Ok((ctx, sender_rx))
     }
@@ -530,6 +577,8 @@ impl HttpServer<server::DefaultClaims, VolgaEngine> {
             sse_log_queue_capacity: DEFAULT_SSE_LOG_QUEUE_CAPACITY,
             sse_cleanup_interval: DEFAULT_SSE_CLEANUP_INTERVAL,
             sse_session_ttl: DEFAULT_SSE_SESSION_TTL,
+            #[cfg(feature = "server-oauth")]
+            oauth: None,
             receiver: HttpReceiver::new(),
             sender: HttpSender::new(),
             _claims: std::marker::PhantomData,
@@ -826,5 +875,30 @@ mod engine_smoke_tests {
             exited.load(Ordering::SeqCst),
             "engine did not exit on cancellation"
         );
+    }
+
+    #[cfg(feature = "server-oauth")]
+    #[test]
+    fn oauth_metadata_options_reach_the_engine_context() {
+        let mut server = HttpServer::from_engine("127.0.0.1:3000", MockEngine::default())
+            .with_oauth_metadata(|oauth| {
+                oauth.with_authorization_servers(["https://auth.example.com"])
+            });
+
+        let (ctx, _rx) = server.build_context_and_engine().unwrap();
+
+        assert_eq!(
+            ctx.oauth_metadata_path(),
+            Some("/.well-known/oauth-protected-resource/mcp")
+        );
+    }
+
+    #[cfg(feature = "server-oauth")]
+    #[test]
+    fn invalid_oauth_resource_fails_server_start() {
+        let mut server = HttpServer::from_engine("127.0.0.1:3000", MockEngine::default())
+            .with_oauth_metadata(|oauth| oauth.with_resource("not a uri"));
+
+        assert!(server.build_context_and_engine().is_err());
     }
 }

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -519,6 +519,17 @@ where
     }
 
     fn build_context_and_engine(&mut self) -> Result<(HttpContext, Receiver<Message>), Error> {
+        // Resolve the OAuth resource once at startup: canonicalize the
+        // identifier, pre-serialize the RFC 9728 document, pre-render the
+        // challenge. A misconfigured resource URI fails server start.
+        // Resolved from a clone, before any `self` state is consumed, so
+        // a config failure leaves the transport untouched.
+        #[cfg(feature = "server-oauth")]
+        let oauth = self
+            .oauth
+            .clone()
+            .map(|o| o.resolve(&self.url.to_string()))
+            .transpose()?;
         let Some(sender_rx) = self.sender.rx.take() else {
             return Err(Error::new(
                 ErrorCode::InternalError,
@@ -529,15 +540,6 @@ where
         let sse_registry = std::sync::Arc::new(crate::shared::SseSessionRegistry::new(
             self.sse_buffer_capacity,
         ));
-        // Resolve the OAuth resource once at startup: canonicalize the
-        // identifier, pre-serialize the RFC 9728 document, pre-render the
-        // challenge. A misconfigured resource URI fails server start.
-        #[cfg(feature = "server-oauth")]
-        let oauth = self
-            .oauth
-            .take()
-            .map(|o| o.resolve(&self.url.to_string()))
-            .transpose()?;
         let ctx = HttpContext {
             addr: self.url.addr.as_str().into(),
             endpoint: self.url.endpoint.as_str().into(),
@@ -707,6 +709,10 @@ where
             Err(_err) => {
                 #[cfg(feature = "tracing")]
                 tracing::error!(logger = "neva", "Failed to start HTTP server: {}", _err);
+                // Hand back an already-cancelled token so `App::run`'s
+                // receive loop breaks immediately instead of waiting
+                // forever on a server that never bound.
+                token.cancel();
                 return token;
             }
         };
@@ -900,5 +906,22 @@ mod engine_smoke_tests {
             .with_oauth_metadata(|oauth| oauth.with_resource("not a uri"));
 
         assert!(server.build_context_and_engine().is_err());
+        // The config failure must not consume the HTTP writer — it fires
+        // before any transport state is taken.
+        assert!(server.sender.rx.is_some());
+    }
+
+    #[cfg(feature = "server-oauth")]
+    #[tokio::test]
+    async fn invalid_oauth_resource_cancels_startup_token() {
+        let mut server = HttpServer::from_engine("127.0.0.1:3000", MockEngine::default())
+            .with_oauth_metadata(|oauth| oauth.with_resource("not a uri"));
+
+        let token = <HttpServer<_, _> as Transport>::start(&mut server);
+
+        // A cancelled token breaks App::run's receive loop immediately;
+        // an uncancelled one would leave the app waiting forever on a
+        // server that never bound.
+        assert!(token.is_cancelled());
     }
 }

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -323,7 +323,7 @@ async fn handle_sse_connection(
             return;
         }
 
-        let mut stream = sse_stream::SseStream::from_byte_stream(resp.bytes_stream())
+        let mut stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream())
             .fuse()
             .map_ok(|event| handle_event(event, &session, &resp_tx))
             .map_err(handle_error);

--- a/neva/src/transport/http/core.rs
+++ b/neva/src/transport/http/core.rs
@@ -7,6 +7,8 @@
 
 pub mod context;
 pub mod engine;
+#[cfg(feature = "server-oauth")]
+pub mod oauth;
 pub mod types;
 
 pub(crate) mod auth;

--- a/neva/src/transport/http/core/context.rs
+++ b/neva/src/transport/http/core/context.rs
@@ -31,6 +31,8 @@ pub struct HttpContext {
     pub(crate) inbound_tx: mpsc::Sender<Result<Message, Error>>,
     pub(crate) sse_live_queue_capacity: usize,
     pub(crate) sse_log_queue_capacity: usize,
+    #[cfg(feature = "server-oauth")]
+    pub(crate) oauth: Option<super::oauth::OAuthResource>,
 }
 
 impl HttpContext {
@@ -42,5 +44,31 @@ impl HttpContext {
     /// The MCP endpoint prefix (e.g. `"/mcp"`).
     pub fn endpoint(&self) -> &str {
         &self.endpoint
+    }
+
+    /// The path of the RFC 9728 Protected Resource Metadata document
+    /// (e.g. `"/.well-known/oauth-protected-resource/mcp"`), when OAuth
+    /// is configured via
+    /// [`HttpServer::with_oauth_metadata`](crate::transport::http::HttpServer::with_oauth_metadata).
+    ///
+    /// An engine mounts a GET route here and serves it with
+    /// [`handlers::handle_oauth_metadata`](super::handlers::handle_oauth_metadata).
+    #[cfg(feature = "server-oauth")]
+    pub fn oauth_metadata_path(&self) -> Option<&str> {
+        self.oauth.as_ref().map(|o| &*o.metadata_path)
+    }
+
+    /// The absolute URL of the RFC 9728 Protected Resource Metadata
+    /// document (e.g.
+    /// `"https://api.example.com/.well-known/oauth-protected-resource/mcp"`),
+    /// when OAuth is configured.
+    ///
+    /// [`handlers::handle_unauthorized`](super::handlers::handle_unauthorized)
+    /// already advertises it on 401s; an engine that emits its own
+    /// `WWW-Authenticate` challenge (through a framework bearer-auth
+    /// pipeline) uses this as the `resource_metadata` parameter.
+    #[cfg(feature = "server-oauth")]
+    pub fn oauth_metadata_url(&self) -> Option<&str> {
+        self.oauth.as_ref().map(|o| &*o.metadata_url)
     }
 }

--- a/neva/src/transport/http/core/engine.rs
+++ b/neva/src/transport/http/core/engine.rs
@@ -42,6 +42,26 @@ use super::{
 /// `BearerTokenService`. A custom engine adapter wires up the equivalent
 /// step in its own POST route.
 ///
+/// # OAuth resource metadata contract (feature `server-oauth`)
+///
+/// When the transport is configured through
+/// `HttpServer::with_oauth_metadata`, the engine receives the resolved
+/// document via [`HttpContext`] and is responsible for two things:
+///
+/// 1. Mount a GET route on
+///    [`HttpContext::oauth_metadata_path`](super::context::HttpContext::oauth_metadata_path)
+///    and serve it with
+///    [`handlers::handle_oauth_metadata`](super::handlers::handle_oauth_metadata)
+///    — this is the RFC 9728 Protected Resource Metadata document,
+///    reachable without authentication.
+/// 2. Answer requests that fail token validation with
+///    [`handlers::handle_unauthorized`](super::handlers::handle_unauthorized),
+///    so the 401 carries the `WWW-Authenticate` challenge pointing at
+///    that document and clients can start the OAuth discovery flow.
+///
+/// Both helpers return neva's neutral [`HttpResponse`] — pass it
+/// through `adapt_response` like any other reply.
+///
 /// [`dispatch_post`]: super::handlers::dispatch_post
 ///
 /// # Example

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -313,6 +313,62 @@ fn parse_session_id(headers: &HeaderMap) -> Option<uuid::Uuid> {
         .and_then(|s| uuid::Uuid::parse_str(s).ok())
 }
 
+/// Handle a GET on the well-known path — serves the RFC 9728 Protected
+/// Resource Metadata document pre-built at server start.
+///
+/// The engine mounts this on [`HttpContext::oauth_metadata_path`]; if the
+/// route is reachable while OAuth is not configured, it answers 404.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // in the engine's well-known route:
+/// let resp = E::adapt_response(handlers::handle_oauth_metadata(&ctx));
+/// ```
+#[cfg(feature = "server-oauth")]
+pub fn handle_oauth_metadata(ctx: &HttpContext) -> HttpResponse {
+    let Some(oauth) = &ctx.oauth else {
+        return http::Response::builder()
+            .status(http::StatusCode::NOT_FOUND)
+            .body(Bytes::new())
+            .unwrap_or_default();
+    };
+    http::Response::builder()
+        .status(http::StatusCode::OK)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(oauth.body.clone())
+        .unwrap_or_default()
+}
+
+/// Build the 401 reply for a request that failed (or skipped) token
+/// validation: `WWW-Authenticate: Bearer` with the `resource_metadata`
+/// parameter pointing at the RFC 9728 document, so a client can start
+/// the OAuth discovery flow. Falls back to a bare `Bearer` challenge
+/// when OAuth is not configured.
+///
+/// The default Volga adapter emits its own challenge through Volga's
+/// bearer pipeline — this helper is for custom engines that validate
+/// tokens themselves.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// // in a custom engine, when the bearer token is missing/invalid:
+/// let resp = E::adapt_response(handlers::handle_unauthorized(&ctx));
+/// ```
+#[cfg(feature = "server-oauth")]
+pub fn handle_unauthorized(ctx: &HttpContext) -> HttpResponse {
+    let challenge = ctx
+        .oauth
+        .as_ref()
+        .map_or("Bearer", |oauth| &*oauth.challenge);
+    http::Response::builder()
+        .status(http::StatusCode::UNAUTHORIZED)
+        .header(http::header::WWW_AUTHENTICATE, challenge)
+        .body(Bytes::new())
+        .unwrap_or_default()
+}
+
 /// Internal item type used inside the GET handler — the engine's
 /// `tracked_event` / `ephemeral_event` is invoked exactly once per emitted
 /// event to produce the engine-native representation.
@@ -446,6 +502,8 @@ mod tests {
             inbound_tx,
             sse_live_queue_capacity: 64,
             sse_log_queue_capacity: 64,
+            #[cfg(feature = "server-oauth")]
+            oauth: None,
         };
         (ctx, inbound_rx)
     }
@@ -683,5 +741,83 @@ mod tests {
             }
             SseResponse::Status(_) => panic!("expected Stream, got Status"),
         }
+    }
+
+    #[cfg(feature = "server-oauth")]
+    fn make_oauth_ctx() -> HttpContext {
+        use crate::transport::http::core::oauth::OAuthResourceOptions;
+
+        let (mut ctx, _rx) = make_ctx();
+        let oauth = OAuthResourceOptions::default()
+            .with_authorization_servers(["https://auth.example.com"])
+            .resolve("http://127.0.0.1:3000/mcp")
+            .unwrap();
+        ctx.oauth = Some(oauth);
+        ctx
+    }
+
+    #[cfg(feature = "server-oauth")]
+    #[test]
+    fn oauth_metadata_serves_the_configured_document() {
+        let ctx = make_oauth_ctx();
+
+        let resp = handle_oauth_metadata(&ctx);
+
+        assert_eq!(resp.status(), http::StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get(http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+        let doc: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(doc["resource"], "http://127.0.0.1:3000/mcp");
+        assert_eq!(doc["authorization_servers"][0], "https://auth.example.com");
+    }
+
+    #[cfg(feature = "server-oauth")]
+    #[test]
+    fn oauth_metadata_without_config_returns_404() {
+        let (ctx, _rx) = make_ctx();
+        let resp = handle_oauth_metadata(&ctx);
+        assert_eq!(resp.status(), http::StatusCode::NOT_FOUND);
+    }
+
+    #[cfg(feature = "server-oauth")]
+    #[test]
+    fn unauthorized_challenge_points_at_resource_metadata() {
+        use crate::transport::http::core::oauth::BearerChallenge;
+
+        let ctx = make_oauth_ctx();
+
+        let resp = handle_unauthorized(&ctx);
+
+        assert_eq!(resp.status(), http::StatusCode::UNAUTHORIZED);
+        let header = resp
+            .headers()
+            .get(http::header::WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap();
+        let challenge = BearerChallenge::parse(header).unwrap();
+        assert_eq!(
+            challenge.resource_metadata(),
+            Some("http://127.0.0.1:3000/.well-known/oauth-protected-resource/mcp")
+        );
+    }
+
+    #[cfg(feature = "server-oauth")]
+    #[test]
+    fn unauthorized_without_config_sends_bare_bearer_challenge() {
+        let (ctx, _rx) = make_ctx();
+
+        let resp = handle_unauthorized(&ctx);
+
+        assert_eq!(resp.status(), http::StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            resp.headers()
+                .get(http::header::WWW_AUTHENTICATE)
+                .and_then(|v| v.to_str().ok()),
+            Some("Bearer")
+        );
     }
 }

--- a/neva/src/transport/http/core/oauth.rs
+++ b/neva/src/transport/http/core/oauth.rs
@@ -1,0 +1,313 @@
+//! Engine-neutral OAuth 2.1 resource-server primitives.
+//!
+//! MCP requires a Streamable HTTP server to act as an OAuth 2.1 protected
+//! resource: advertise its Protected Resource Metadata document
+//! ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)) and answer
+//! unauthorized requests with a `WWW-Authenticate` bearer challenge that
+//! points at it. This module owns the engine-neutral half of that
+//! contract — options, one-time resolution into a ready-to-serve document,
+//! and the challenge — so any [`HttpEngine`](super::engine::HttpEngine)
+//! (Volga, axum, hyper, a custom adapter) serves byte-identical metadata.
+//!
+//! Protocol-level types come from
+//! [`volga-oauth-core`](https://docs.rs/volga-oauth-core), which carries
+//! no HTTP I/O and no dependency on the Volga framework; the relevant
+//! ones are re-exported from [`crate::auth::oauth`].
+//!
+//! Token *validation* deliberately stays the engine's job (the default
+//! Volga adapter uses Volga's bearer/JWKS pipeline; a custom engine brings
+//! its own middleware) — see the authorization contract on
+//! [`HttpEngine`](super::engine::HttpEngine).
+
+use bytes::Bytes;
+use std::sync::Arc;
+
+use crate::error::{Error, ErrorCode};
+
+pub use volga_oauth_core::{
+    BearerChallenge, OAuthError, OAuthErrorCode, ProtectedResourceMetadata,
+    WELL_KNOWN_PROTECTED_RESOURCE, canonicalize_resource_uri, protected_resource_metadata_url,
+};
+
+/// Engine-neutral OAuth protected-resource options.
+///
+/// Configured with
+/// [`HttpServer::with_oauth_metadata`](crate::transport::http::HttpServer::with_oauth_metadata)
+/// and resolved once at server start into a ready-to-serve document.
+/// The `resource` identifier defaults to the server's own URL
+/// (`proto://addr/endpoint`) and only needs
+/// [`with_resource`](Self::with_resource) when the public URL differs
+/// from the bind address — e.g. behind a reverse proxy.
+///
+/// # Example
+/// ```no_run
+/// use neva::App;
+///
+/// let app = App::new()
+///     .with_options(|opt| opt
+///         .with_http(|http| http
+///             .with_oauth_metadata(|oauth| oauth
+///                 .with_authorization_servers(["https://auth.example.com"])
+///                 .with_scopes(["mcp:tools"]))
+///         )
+///     );
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct OAuthResourceOptions {
+    metadata: ProtectedResourceMetadata,
+}
+
+impl OAuthResourceOptions {
+    /// Overrides the canonical resource identifier URI ([RFC 8707](https://www.rfc-editor.org/rfc/rfc8707)).
+    ///
+    /// Defaults to the server's own URL. Set it when clients reach the
+    /// server through a different public URL than the bind address
+    /// (reverse proxy, TLS termination). The value is canonicalized —
+    /// scheme/host lowercased, default ports dropped.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_oauth_metadata(|oauth| oauth
+    ///                 .with_resource("https://api.example.com/mcp"))
+    ///         )
+    ///     );
+    /// ```
+    pub fn with_resource(mut self, uri: impl Into<String>) -> Self {
+        self.metadata.resource = uri.into();
+        self
+    }
+
+    /// Sets the issuer identifiers of the authorization servers that can
+    /// authorize access to this MCP server.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_oauth_metadata(|oauth| oauth
+    ///                 .with_authorization_servers(["https://auth.example.com"]))
+    ///         )
+    ///     );
+    /// ```
+    pub fn with_authorization_servers<I, S>(mut self, servers: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.metadata = self.metadata.with_authorization_servers(servers);
+        self
+    }
+
+    /// Sets the scope values clients should request to access this server.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_oauth_metadata(|oauth| oauth
+    ///                 .with_scopes(["mcp:tools", "mcp:resources"]))
+    ///         )
+    ///     );
+    /// ```
+    pub fn with_scopes<I, S>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.metadata = self.metadata.with_scopes(scopes);
+        self
+    }
+
+    /// Full-document escape hatch: configures any remaining
+    /// [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728) field on the
+    /// underlying [`ProtectedResourceMetadata`] builder.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_oauth_metadata(|oauth| oauth
+    ///                 .with_metadata(|md| md.with_resource_name("Weather MCP")))
+    ///         )
+    ///     );
+    /// ```
+    pub fn with_metadata<F>(mut self, config: F) -> Self
+    where
+        F: FnOnce(ProtectedResourceMetadata) -> ProtectedResourceMetadata,
+    {
+        self.metadata = config(self.metadata);
+        self
+    }
+
+    /// Resolves the options against the server's base URL into the
+    /// ready-to-serve [`OAuthResource`]: canonicalizes the resource
+    /// identifier (defaulting it to `base_url`), derives the metadata
+    /// URL/path per RFC 9728 §3.1, pre-serializes the document, and
+    /// pre-renders the `WWW-Authenticate` challenge.
+    pub(crate) fn resolve(self, base_url: &str) -> Result<OAuthResource, Error> {
+        let mut metadata = self.metadata;
+        let resource = if metadata.resource.is_empty() {
+            base_url
+        } else {
+            metadata.resource.as_str()
+        };
+        let resource = canonicalize_resource_uri(resource).map_err(config_error)?;
+        let metadata_url = protected_resource_metadata_url(&resource).map_err(config_error)?;
+        let challenge = BearerChallenge::new()
+            .with_resource_metadata(metadata_url.as_str())
+            .to_string();
+        metadata.resource = resource;
+
+        Ok(OAuthResource {
+            body: serde_json::to_vec(&metadata).map_err(Error::from)?.into(),
+            metadata_path: well_known_path(&metadata_url).into(),
+            metadata_url: metadata_url.into(),
+            challenge: challenge.into(),
+        })
+    }
+}
+
+/// Resolved, ready-to-serve protected-resource state.
+///
+/// Built once by the transport at server start and handed to the engine
+/// through [`HttpContext`](super::context::HttpContext); request-time
+/// handlers only clone cheap `Bytes` / `Arc<str>` handles.
+#[derive(Debug, Clone)]
+pub(crate) struct OAuthResource {
+    /// Pre-serialized RFC 9728 metadata document.
+    pub(crate) body: Bytes,
+    /// Absolute URL of the metadata document — the `resource_metadata`
+    /// value of the bearer challenge.
+    pub(crate) metadata_url: Arc<str>,
+    /// Path the engine mounts the metadata route on
+    /// (e.g. `/.well-known/oauth-protected-resource/mcp`).
+    pub(crate) metadata_path: Arc<str>,
+    /// Pre-rendered `WWW-Authenticate` header value.
+    pub(crate) challenge: Arc<str>,
+}
+
+/// Strips the scheme and authority off an absolute URL, leaving the path.
+///
+/// `metadata_url` always carries a path (RFC 9728 §3.1 inserts the
+/// well-known segment), so the fallback is unreachable — it only exists
+/// to keep the function total without panicking.
+fn well_known_path(url: &str) -> &str {
+    url.find("://")
+        .map(|scheme| &url[scheme + 3..])
+        .and_then(|rest| rest.find('/').map(|path| &rest[path..]))
+        .unwrap_or(WELL_KNOWN_PROTECTED_RESOURCE)
+}
+
+/// Maps a startup-time OAuth configuration failure onto neva's error type.
+fn config_error(err: OAuthError) -> Error {
+    Error::new(ErrorCode::InternalError, err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_derives_resource_from_base_url() {
+        let resource = OAuthResourceOptions::default()
+            .resolve("http://127.0.0.1:3000/mcp")
+            .unwrap();
+
+        assert_eq!(
+            &*resource.metadata_url,
+            "http://127.0.0.1:3000/.well-known/oauth-protected-resource/mcp"
+        );
+        assert_eq!(
+            &*resource.metadata_path,
+            "/.well-known/oauth-protected-resource/mcp"
+        );
+
+        let doc: ProtectedResourceMetadata = serde_json::from_slice(&resource.body).unwrap();
+        assert_eq!(doc.resource, "http://127.0.0.1:3000/mcp");
+    }
+
+    #[test]
+    fn it_canonicalizes_resource_override() {
+        let resource = OAuthResourceOptions::default()
+            .with_resource("HTTPS://API.Example.COM:443/mcp")
+            .resolve("http://127.0.0.1:3000/mcp")
+            .unwrap();
+
+        let doc: ProtectedResourceMetadata = serde_json::from_slice(&resource.body).unwrap();
+        assert_eq!(doc.resource, "https://api.example.com/mcp");
+        assert_eq!(
+            &*resource.metadata_url,
+            "https://api.example.com/.well-known/oauth-protected-resource/mcp"
+        );
+    }
+
+    #[test]
+    fn it_rejects_invalid_resource() {
+        let err = OAuthResourceOptions::default()
+            .with_resource("not a uri")
+            .resolve("http://127.0.0.1:3000/mcp")
+            .unwrap_err();
+
+        assert_eq!(err.code, ErrorCode::InternalError);
+    }
+
+    #[test]
+    fn it_serializes_authorization_servers_and_scopes() {
+        let resource = OAuthResourceOptions::default()
+            .with_authorization_servers(["https://auth.example.com"])
+            .with_scopes(["mcp:tools"])
+            .resolve("http://127.0.0.1:3000/mcp")
+            .unwrap();
+
+        let doc: ProtectedResourceMetadata = serde_json::from_slice(&resource.body).unwrap();
+        assert_eq!(doc.authorization_servers, ["https://auth.example.com"]);
+        assert_eq!(doc.scopes_supported, ["mcp:tools"]);
+    }
+
+    #[test]
+    fn it_passes_through_full_metadata_fields() {
+        let resource = OAuthResourceOptions::default()
+            .with_metadata(|md| md.with_resource_name("Weather MCP"))
+            .resolve("http://127.0.0.1:3000/mcp")
+            .unwrap();
+
+        let doc: ProtectedResourceMetadata = serde_json::from_slice(&resource.body).unwrap();
+        assert_eq!(doc.resource_name.as_deref(), Some("Weather MCP"));
+    }
+
+    #[test]
+    fn it_prerenders_a_parseable_challenge() {
+        let resource = OAuthResourceOptions::default()
+            .resolve("http://127.0.0.1:3000/mcp")
+            .unwrap();
+
+        let challenge = BearerChallenge::parse(&resource.challenge).unwrap();
+        assert_eq!(
+            challenge.resource_metadata(),
+            Some("http://127.0.0.1:3000/.well-known/oauth-protected-resource/mcp")
+        );
+    }
+
+    #[test]
+    fn it_mounts_at_well_known_root_for_root_endpoint() {
+        let resource = OAuthResourceOptions::default()
+            .resolve("http://127.0.0.1:3000/")
+            .unwrap();
+
+        assert_eq!(&*resource.metadata_path, WELL_KNOWN_PROTECTED_RESOURCE);
+    }
+}

--- a/neva/src/transport/http/server/volga/engine.rs
+++ b/neva/src/transport/http/server/volga/engine.rs
@@ -103,17 +103,31 @@ impl HttpEngine for VolgaEngine {
         let ctx = Arc::new(ctx);
         let addr = ctx.addr().to_owned();
         let endpoint = ctx.endpoint().to_owned();
+        #[cfg(feature = "server-oauth")]
+        let oauth_metadata_path = ctx.oauth_metadata_path().map(str::to_owned);
+        #[cfg(feature = "server-oauth")]
+        let oauth_metadata_url = ctx.oauth_metadata_url().map(str::to_owned);
 
         let mut server = App::new()
             .bind(addr.as_str())
             .with_no_delay()
             .without_greeter();
 
-        if let Some(auth) = self.auth {
-            let (bearer, rules) = auth.into_parts();
-            server = server.with_bearer_auth(|_| bearer);
-            server.authorize(rules);
-        }
+        let rules = match self.auth {
+            Some(auth) => {
+                let (bearer, rules) = auth.into_parts();
+                // Advertise the RFC 9728 document on Volga's own 401
+                // challenges: `WWW-Authenticate: Bearer resource_metadata="…"`.
+                #[cfg(feature = "server-oauth")]
+                let bearer = match &oauth_metadata_url {
+                    Some(url) => bearer.with_resource_metadata_url(url.as_str()),
+                    None => bearer,
+                };
+                server = server.with_bearer_auth(|_| bearer);
+                Some(rules)
+            }
+            None => None,
+        };
 
         #[cfg(feature = "server-tls")]
         if let Some(tls) = self.tls {
@@ -123,7 +137,13 @@ impl HttpEngine for VolgaEngine {
         server
             .add_singleton(ctx)
             .map_err(handle_http_error)
-            .group(endpoint.as_str(), |mcp| {
+            .group(endpoint.as_str(), move |mcp| {
+                // Token validation and role/permission rules guard only
+                // the MCP endpoint group; the well-known metadata route
+                // below stays outside it.
+                if let Some(rules) = rules {
+                    mcp.authorize(rules);
+                }
                 mcp.map_post("/", routes::post);
                 // Stateless RC transport has no SSE GET stream and no
                 // session-termination DELETE — only POST is routed.
@@ -133,6 +153,13 @@ impl HttpEngine for VolgaEngine {
                     mcp.map_delete("/", routes::delete);
                 }
             });
+
+        // RFC 9728 §3: the Protected Resource Metadata document must be
+        // reachable without credentials.
+        #[cfg(feature = "server-oauth")]
+        if let Some(path) = &oauth_metadata_path {
+            server.map_get(path, routes::oauth_metadata);
+        }
 
         if let Err(e) = server.run().await {
             token.cancel();

--- a/neva/src/transport/http/server/volga/routes.rs
+++ b/neva/src/transport/http/server/volga/routes.rs
@@ -102,6 +102,19 @@ pub(crate) async fn get(req: HttpRequest) -> HttpResult {
     }
 }
 
+/// `GET /.well-known/oauth-protected-resource[/<endpoint>]` — the RFC 9728
+/// Protected Resource Metadata document.
+///
+/// Publicly reachable by design: authorization is scoped to the MCP
+/// endpoint group, and RFC 9728 §3 requires the metadata to be fetchable
+/// without credentials — it is what a client reads to find out *how* to
+/// authenticate.
+#[cfg(feature = "server-oauth")]
+pub(crate) async fn oauth_metadata(req: HttpRequest) -> HttpResult {
+    let manager: Dc<Arc<HttpContext>> = req.extract()?;
+    VolgaEngine::adapt_response(handlers::handle_oauth_metadata(&manager))
+}
+
 /// Map a neva `Error` raised by engine-agnostic helpers onto a Volga
 /// server-error so the route can short-circuit with `?` into `HttpResult`.
 fn to_volga_err(err: crate::error::Error) -> VolgaError {

--- a/neva/src/types/mrtr/state.rs
+++ b/neva/src/types/mrtr/state.rs
@@ -6,7 +6,7 @@
 //! responses, PII, tokens — are confidential rather than merely signed and
 //! readable by the client that echoes the blob.
 
-use chacha20poly1305::aead::{Aead, AeadCore, KeyInit, OsRng};
+use chacha20poly1305::aead::{Aead, Generate, KeyInit};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
@@ -80,7 +80,12 @@ impl<'a> StateCodec<'a> {
         use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as B64};
         let json = serde_json::to_vec(payload).map_err(Error::from)?;
         let cipher = self.cipher()?;
-        let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let nonce = Nonce::try_generate().map_err(|_| {
+            Error::new(
+                ErrorCode::InternalError,
+                "requestState nonce generation failed",
+            )
+        })?;
         let sealed = cipher
             .encrypt(&nonce, json.as_slice())
             .map_err(|_| Error::new(ErrorCode::InternalError, "requestState encryption failed"))?;
@@ -226,7 +231,7 @@ mod tests {
             use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as B64};
             let bytes = serde_json::to_vec(&json).unwrap();
             let cipher = codec.cipher().unwrap();
-            let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+            let nonce = Nonce::try_generate().unwrap();
             let sealed = cipher.encrypt(&nonce, bytes.as_slice()).unwrap();
             format!("{}.{}", B64.encode(nonce), B64.encode(sealed))
         };

--- a/neva/src/types/resource/uri.rs
+++ b/neva/src/types/resource/uri.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter};
 use std::ops::{Deref, DerefMut};
 
 const PATH_SEPARATOR: char = '/';
-const SCHEME_SEPARATOR: [u8; 3] = [b':', b'/', b'/'];
+const SCHEME_SEPARATOR: [u8; 3] = *b"://";
 
 /// Represents a resource URI
 #[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]

--- a/neva_macros/Cargo.toml
+++ b/neva_macros/Cargo.toml
@@ -20,7 +20,7 @@ workspace = true
 
 [dependencies]
 quote = "1.0.46"
-syn = { version = "2.0.118", features = ["full"] }
+syn = { version = "2.0.119", features = ["full"] }
 proc-macro2 = "1.0.106"
 serde_json = "1.0.150"
 


### PR DESCRIPTION
## Summary
First PR of the OAuth integration series (#67–#72). Introduces the engine-neutral foundation that MCP authorization builds on: the RFC 9728 Protected Resource Metadata document and the `WWW-Authenticate` bearer
challenge, served identically through **any** `HttpEngine` — Volga, axum, hyper, or a custom adapter. Also makes the branch green again after the dependency bumps (details below).

Closes #67 (rescoped: instead of a thin Volga-only wiring module, the auth integration layer now lives in the engine-agnostic `transport::http::core`, so non-Volga engines get the same primitives; the Volga wiring lands next
in #68/#69).

## What's added

New **`server-oauth`** cargo feature (`http-server` + `volga-oauth-core`, included in `server-full`). It pulls **protocol types only** — [`volga-oauth-core`](https://docs.rs/volga-oauth-core) carries no HTTP I/O and no dependency on the Volga framework.

### Configuration (engine-neutral)

```rust
let app = App::new().with_options(|opt| opt
    .with_http(|http| http
        .with_oauth_metadata(|oauth| oauth
            .with_authorization_servers(["https://auth.example.com"])
            .with_scopes(["mcp:tools"]))));
```

`OAuthResourceOptions` covers the MCP-relevant RFC 9728 fields directly (authorization servers, scopes), the canonical `resource` override for reverse-proxy deployments (defaults to the server's own URL), and a
full-document escape hatch (`with_metadata`) for everything else.

Resolution happens **once at server start**: the resource identifier is canonicalized per RFC 8707, the well-known URL/path is derived per RFC 9728 §3.1, the document is pre-serialized, and the challenge header is pre-rendered — request-time handlers only clone cheap `Bytes`/`Arc<str>` handles. A misconfigured resource URI fails startup instead of surfacing on the first request.

### Engine contract

* `HttpContext::oauth_metadata_path()` — the path to mount the metadata route on (e.g. `/.well-known/oauth-protected-resource/mcp`)
* `HttpContext::oauth_metadata_url()` — the absolute document URL, for engines that emit their own challenge via a framework bearer pipeline
* `handlers::handle_oauth_metadata(&ctx)` — serves the document (404 when
  not configured)
* `handlers::handle_unauthorized(&ctx)` — `401` + `WWW-Authenticate: Bearer resource_metadata="…"` (bare `Bearer` when not configured)

The contract is documented on the `HttpEngine` trait next to the existing authorization (claims) contract. Token **validation** deliberately stays the engine's job — the default Volga adapter will wire Volga's bearer/JWKS pipeline in #69; custom engines bring their own middleware.

Protocol types are re-exported under `neva::auth::oauth` (`ProtectedResourceMetadata`, `BearerChallenge`, `OAuthError`,
`canonicalize_resource_uri`, …).

## Also included: post-bump build fixes

The recent dependency bumps left two API breaks and an advisory; fixed here to keep CI green:

* **`chacha20poly1305` 0.10 → 0.11** (`types/mrtr/state.rs`): `aead::OsRng` and `AeadCore::generate_nonce` are gone; nonce generation migrated to the fallible `Nonce::try_generate()` (maps to `Error` instead of panicking). No wire-format change.
* **`sse-stream` deprecation** (`transport/http/client.rs`): `from_byte_stream` → `from_bytes_stream` (upstream typo rename, removed in 0.3).
* **RUSTSEC-2026-0190**: transitive `anyhow` updated 1.0.102 → 1.0.103 (unsoundness in `Error::downcast_mut()`); `cargo audit` is clean again.


## Type
- [ ] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [x] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
