### PR TITLE
OAuth Phase 2: issuer validation, client flow, token lifecycle, examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.4.2
 
 ### Added
+* Client-side OAuth 2.1 authorization behind the new `client-oauth`
+  feature (included in `client-full`), built on `volga-oauth-client`:
+  * `HttpClient::with_oauth(...)` enables the automatic flow: a `401`
+    challenge drives RFC 9728/8414 discovery (OIDC fallback), dynamic
+    client registration when no `client_id` is configured (RFC 7591,
+    `application_type: "native"` for loopback redirects), and the
+    authorization-code + PKCE flow with the server's canonical URI as
+    the RFC 8707 resource indicator; the failed request is retried once
+    with the fresh token, concurrent `401`s share a single flow.
+  * The callback is validated for `state` and the RFC 9207 `iss`
+    parameter (required when the server advertises support) before the
+    code exchange — mix-up-attack responses abort the flow.
+  * The interactive step is pluggable via `AuthorizationHandler`; the
+    default `LoopbackHandler` opens the system browser and captures the
+    redirect on a loopback listener. Tokens persist through the
+    re-exported `TokenStore` abstraction (`InMemoryTokenStore` default).
+  * Everything exported under `neva::auth::oauth`.
 * Engine-neutral OAuth 2.1 resource-server primitives behind the new
   `server-oauth` feature (included in `server-full`), built on
   `volga-oauth-core` — protocol types only, no Volga framework dependency,
@@ -47,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   shorthand (kid `"0"`). (#81)
 
 ### Fixed
+* Client-only feature sets (e.g. `http-client` alone) failed to build:
+  the client's notification handler uses `tokio::task::block_in_place`,
+  but nothing enabled `tokio/rt-multi-thread` — now the `client` feature
+  does.
 * The legacy `initialize` result no longer advertises the `logging` capability
   in builds without the `tracing` feature, where the `logging/setLevel`
   handler is not registered — capability-trusting clients (e.g. newer MCP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     authorization — refresh-token rotation and dead-entry pruning
     included. Both paths are non-interactive and single-flight.
   * Everything exported under `neva::auth::oauth`.
+* OAuth examples: `examples/oauth-server` (resource server with explicit
+  RFC 9728 metadata), `examples/oauth-client` (fully automatic flow),
+  `examples/oauth-with-keycloak` (end-to-end walkthrough with a
+  ready-to-import realm), and `examples/oauth-hyper-engine` — a custom
+  `HttpEngine` on bare hyper serving the well-known document, the
+  `WWW-Authenticate` challenge and per-tool role gates through the
+  engine-neutral primitives, without Volga.
 * Engine-neutral OAuth 2.1 resource-server primitives behind the new
   `server-oauth` feature (included in `server-full`), built on
   `volga-oauth-core` — protocol types only, no Volga framework dependency,
@@ -69,6 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   shorthand (kid `"0"`). (#81)
 
 ### Fixed
+* A client whose transport died (e.g. the OAuth flow failed against an
+  unreachable issuer) sat out the full request timeout — and `Ctrl+C`
+  appeared ignored, since the shutdown handler only cancels the
+  transport token. Pending request awaits now race that token and abort
+  with `Connection closed` the moment it fires, so both transport death
+  and shutdown signals interrupt `connect()`/requests immediately.
 * Client-only feature sets (e.g. `http-client` alone) failed to build:
   the client's notification handler uses `tokio::task::block_in_place`,
   but nothing enabled `tokio/rt-multi-thread` — now the `client` feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     as `resource_metadata` on Volga's own 401 challenges.
   * Protocol types re-exported under `neva::auth::oauth`
     (`ProtectedResourceMetadata`, `BearerChallenge`, `OAuthError`, …).
+* **OAuth 2.1/OIDC issuer mode for the default Volga engine** (#69):
+  `with_auth(|auth| auth.with_oauth(|oauth| oauth.with_issuer(…)))` replaces
+  the static decoding key with issuer-discovered JWKS validation (RFC 8414
+  discovery with OIDC fallback, key rotation, refresh cooldown / max key age
+  via Volga). MCP defaults applied unless overridden: the token's `aud` must
+  contain the server's canonical resource URI (RFC 8707 — `aud` becomes
+  required) and its `iss` must match the configured issuer. The Protected
+  Resource Metadata document is derived from the issuer automatically when
+  `with_oauth_metadata` was not called (#68), so discovery, challenge and
+  validation work out of the box with a single builder call. New
+  `AuthConfig::with_resource`/`with_resources` (RFC 8707 resource
+  indicators) for overriding the audience explicitly.
 * **MRTR `requestState` key rotation.** New `App::with_request_state_keys(active_kid, keys)`
   configures a keyring: new blobs are sealed under the active key id, inbound
   blobs decrypt with whichever accepted key their kid names — enabling
@@ -39,6 +51,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   in builds without the `tracing` feature, where the `logging/setLevel`
   handler is not registered — capability-trusting clients (e.g. newer MCP
   Inspector) would call it and hit `Method not found`.
+* Per-tool/prompt/resource role and permission gates now receive the claims
+  Volga's `authorize` middleware already validated (`Authenticated<…>` from
+  the request) instead of re-decoding the `Authorization` header. With
+  Volga's default `strip_token_from_request = true` the header is removed
+  before the route runs, so the old re-decode lost the claims and protected
+  tools rejected valid tokens.
 
 ### Changed
 * **Breaking (RC wire format):** the sealed MRTR `requestState` blob is now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     default `LoopbackHandler` opens the system browser and captures the
     redirect on a loopback listener. Tokens persist through the
     re-exported `TokenStore` abstraction (`InMemoryTokenStore` default).
+  * Token lifecycle: an access token about to expire (30s leeway) is
+    refreshed proactively before the next request, and a `401` tries the
+    refresh-token grant before falling back to interactive
+    authorization — refresh-token rotation and dead-entry pruning
+    included. Both paths are non-interactive and single-flight.
   * Everything exported under `neva::auth::oauth`.
 * Engine-neutral OAuth 2.1 resource-server primitives behind the new
   `server-oauth` feature (included in `server-full`), built on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "uuid",
  "volga",
  "volga-di",
+ "volga-oauth-client",
  "volga-oauth-core",
  "windows",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "inout",
 ]
 
@@ -409,22 +409,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -455,15 +443,6 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
 
 [[package]]
 name = "block-buffer"
@@ -560,7 +539,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -596,8 +575,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "crypto-common",
  "inout",
 ]
 
@@ -625,12 +604,6 @@ dependencies = [
  "bytes",
  "memchr",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -686,15 +659,6 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -718,28 +682,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -757,33 +699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -805,17 +720,6 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "pem-rfc7468",
- "zeroize",
-]
 
 [[package]]
 name = "der-parser"
@@ -862,25 +766,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer 0.10.4",
- "const-oid 0.9.6",
- "crypto-common 0.1.6",
- "subtle",
-]
-
-[[package]]
-name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.1",
- "const-oid 0.10.2",
- "crypto-common 0.2.2",
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
 ]
 
 [[package]]
@@ -905,65 +797,6 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
-
-[[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest 0.10.7",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "email_address"
@@ -1197,22 +1030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,17 +1161,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
-dependencies = [
- "typenum",
- "version_check",
- "zeroize",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,17 +1199,6 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1475,24 +1270,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
 
 [[package]]
 name = "http"
@@ -1919,18 +1696,11 @@ checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.7",
- "rsa",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -1955,9 +1725,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -1970,12 +1737,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
@@ -2104,7 +1865,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "sse-stream",
  "tokio",
  "tokio-stream",
@@ -2185,22 +1946,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.7",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,7 +2004,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2288,30 +2032,6 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
-
-[[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2 0.10.9",
-]
 
 [[package]]
 name = "parking_lot"
@@ -2347,15 +2067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,27 +2077,6 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -2400,7 +2090,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "universal-hash",
 ]
 
@@ -2436,15 +2126,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -2535,22 +2216,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2563,16 +2233,6 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2749,16 +2409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,26 +2420,6 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2953,20 +2583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,19 +2695,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3101,8 +2706,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -3136,7 +2741,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3204,22 +2808,6 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -3610,7 +3198,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common 0.2.2",
+ "crypto-common",
  "ctutils",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -409,10 +409,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bit-set"
@@ -443,6 +455,15 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "block-buffer"
@@ -539,7 +560,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
 
@@ -575,8 +596,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -604,6 +625,12 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-oid"
@@ -659,6 +686,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
@@ -682,6 +718,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +757,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -720,6 +805,17 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid 0.9.6",
+ "pem-rfc7468",
+ "zeroize",
+]
 
 [[package]]
 name = "der-parser"
@@ -766,13 +862,25 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -797,6 +905,65 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "email_address"
@@ -918,6 +1085,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-oauth-client"
+version = "0.1.0"
+dependencies = [
+ "neva",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "example-oauth-hyper-engine"
+version = "0.1.0"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.4.2",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "jsonwebtoken",
+ "neva",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "example-oauth-server"
+version = "0.1.0"
+dependencies = [
+ "neva",
+ "tokio",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "example-oauth-with-keycloak"
+version = "0.1.0"
+dependencies = [
+ "neva",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "example-pagination"
 version = "0.1.0"
 dependencies = [
@@ -982,6 +1195,22 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1115,6 +1344,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+dependencies = [
+ "typenum",
+ "version_check",
+ "zeroize",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1393,17 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1224,6 +1475,24 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -1606,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "281c43ff06dcb331e9356d30e38853d559ce3d0a3f693e0b0e102667dec14fb1"
+checksum = "9baf521a926fd1e6f94af6922be9686b61c8a89a5fb7e14d6a1e21b79738d4cc"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1635,9 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0b351864e7ffbc5db9273daf7fa1b4d5177b0946713d667ca571b83c0b4045"
+checksum = "d668f4775619127513d9a4f190704d20a66d20ccf0efc258f8ed42548e5fd7cd"
 dependencies = [
  "regex-syntax",
 ]
@@ -1650,11 +1919,18 @@ checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
  "base64",
+ "ed25519-dalek",
  "getrandom 0.2.17",
+ "hmac",
  "js-sys",
+ "p256",
+ "p384",
  "pem",
+ "rand 0.8.7",
+ "rsa",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -1679,6 +1955,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1691,6 +1970,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
@@ -1819,7 +2104,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "sse-stream",
  "tokio",
  "tokio-stream",
@@ -1900,6 +2185,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.7",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +2259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1986,6 +2288,30 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking_lot"
@@ -2021,6 +2347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2366,27 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2044,7 +2400,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "universal-hash",
 ]
 
@@ -2080,6 +2436,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2170,11 +2535,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2187,6 +2563,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2268,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348e860aeb0b7bd035778fd11dd9cd5290d32e4aed3b8f2274a00287a9fd362b"
+checksum = "df843f41f0cb459649f64a8b6b10579cf454f7a7420dc702767c81a26f23d780"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2363,6 +2749,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,6 +2770,26 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2537,6 +2953,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2649,8 +3079,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2660,8 +3101,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2695,6 +3136,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -2762,6 +3204,22 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -2927,9 +3385,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
 dependencies = [
  "bytes",
  "libc",
@@ -3152,7 +3610,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 

--- a/examples/oauth-client/Cargo.toml
+++ b/examples/oauth-client/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example-oauth-client"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+neva = { path = "../../neva", features = ["client-full"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.20"

--- a/examples/oauth-client/src/main.rs
+++ b/examples/oauth-client/src/main.rs
@@ -1,0 +1,56 @@
+//! An MCP client with automatic OAuth 2.1 authorization: the first `401`
+//! drives discovery, dynamic client registration and the
+//! authorization-code + PKCE flow through the system browser; the token
+//! is attached (and refreshed) transparently afterwards.
+//!
+//! Start a protected server first (see `examples/oauth-server` or
+//! `examples/oauth-with-keycloak`), then:
+//!
+//! ```no_rust
+//! cargo run -p example-oauth-client
+//! ```
+use neva::prelude::*;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt().init();
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| {
+            http.bind("127.0.0.1:3000")
+                // Everything is optional: without a client id the client
+                // registers dynamically (RFC 7591); without scopes the
+                // server's advertised `scopes_supported` are requested;
+                // the default handler opens the system browser and
+                // catches the redirect on an ephemeral loopback port.
+                //
+                // Against an issuer that requires a pre-registered
+                // client and a fixed redirect port (e.g. the Keycloak
+                // example):
+                //
+                //   .with_oauth(|oauth| oauth
+                //       .with_client_id("neva-mcp-client")
+                //       .require_https(false)
+                //       .with_handler(LoopbackHandler::new().with_port(8919)))
+                .with_oauth(|oauth| oauth)
+        })
+        // The first request may wait for the user to finish in the
+        // browser — give it more than the default 10 seconds.
+        .with_timeout(Duration::from_secs(300))
+    });
+
+    client.connect().await?;
+
+    tracing::info!("--- LIST TOOLS ---");
+    let tools = client.list_tools(None).await?;
+    for tool in tools.tools.iter() {
+        tracing::info!("- {}", tool.name);
+    }
+
+    tracing::info!("--- CALL TOOL ---");
+    let result = client.call_tool("whoami", ()).await?;
+    tracing::info!("{:?}", result.content);
+
+    client.disconnect().await
+}

--- a/examples/oauth-hyper-engine/Cargo.toml
+++ b/examples/oauth-hyper-engine/Cargo.toml
@@ -13,7 +13,9 @@ http = "1.4.2"
 http-body-util = "0.1.3"
 hyper = { version = "1.8.1", features = ["server", "http1"] }
 hyper-util = { version = "0.1.19", features = ["tokio"] }
-jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
+# `aws_lc_rs` (not `rust_crypto`): the pure-Rust backend pulls the `rsa`
+# crate, which is flagged by RUSTSEC-2023-0071 (Marvin timing attack).
+jsonwebtoken = { version = "10.4.0", features = ["aws_lc_rs"] }
 serde_json = "1.0.150"
 tokio = { version = "1.47.1", features = ["full"] }
 tokio-util = "0.7.16"

--- a/examples/oauth-hyper-engine/Cargo.toml
+++ b/examples/oauth-hyper-engine/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-oauth-hyper-engine"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+# No Volga: the engine-agnostic HTTP core + the neutral OAuth primitives.
+neva = { path = "../../neva", features = ["server-macros", "http-server", "server-oauth"] }
+bytes = "1.12.1"
+futures-util = "0.3.31"
+http = "1.4.2"
+http-body-util = "0.1.3"
+hyper = { version = "1.8.1", features = ["server", "http1"] }
+hyper-util = { version = "0.1.19", features = ["tokio"] }
+jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
+serde_json = "1.0.150"
+tokio = { version = "1.47.1", features = ["full"] }
+tokio-util = "0.7.16"

--- a/examples/oauth-hyper-engine/src/main.rs
+++ b/examples/oauth-hyper-engine/src/main.rs
@@ -1,0 +1,230 @@
+//! A custom [`HttpEngine`] on bare hyper - serving a
+//! protected MCP server with the engine-neutral OAuth primitives:
+//!
+//! * the RFC 9728 Protected Resource Metadata document is mounted on
+//!   [`HttpContext::oauth_metadata_path`] and served by
+//!   [`handlers::handle_oauth_metadata`];
+//! * requests failing token validation answer with
+//!   [`handlers::handle_unauthorized`], so the `401` carries the
+//!   `WWW-Authenticate: Bearer resource_metadata="…"` challenge;
+//! * decoded claims go into the neutral request's extensions as
+//!   `Arc<dyn Claims>`, which keeps `#[tool(roles = [...])]` gates
+//!   working exactly like under the default Volga engine.
+//!
+//! Token validation here is HS256 with a shared secret to keep the
+//! example self-contained — swap `decode_claims` for your JWKS-based
+//! validation against a real issuer.
+//!
+//! Run with:
+//!
+//! ```no_rust
+//! JWT_SECRET=a-string-secret-at-least-256-bits-long \
+//!     cargo run -p example-oauth-hyper-engine
+//! ```
+use bytes::Bytes;
+use futures_util::StreamExt;
+use http_body_util::{BodyExt, Full, StreamBody, combinators::BoxBody};
+use hyper::body::{Frame, Incoming};
+use hyper::service::service_fn;
+use hyper_util::rt::TokioIo;
+use std::convert::Infallible;
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+use neva::error::{Error, ErrorCode};
+use neva::prelude::*;
+use neva::types::Message;
+
+/// A tool available to any authenticated caller
+#[tool]
+async fn whoami() -> &'static str {
+    "an authenticated caller, served by hyper"
+}
+
+/// A tool available only to admins
+#[tool(roles = ["admin"])]
+async fn admin_report(name: String) -> String {
+    format!("confidential report: {name}")
+}
+
+struct HyperEngine {
+    secret: Arc<str>,
+}
+
+impl HttpEngine for HyperEngine {
+    type Request = http::Request<Incoming>;
+    type Response = http::Response<BoxBody<Bytes, Infallible>>;
+    /// Pre-rendered SSE frames.
+    type SseEvent = Bytes;
+
+    async fn adapt_request(req: Self::Request) -> Result<HttpRequest, Error> {
+        let (parts, body) = req.into_parts();
+        let body = body
+            .collect()
+            .await
+            .map_err(|err| Error::new(ErrorCode::InternalError, err.to_string()))?
+            .to_bytes();
+        Ok(HttpRequest::from_parts(parts, body))
+    }
+
+    fn adapt_response(resp: HttpResponse) -> Self::Response {
+        resp.map(|body| Full::new(body).boxed())
+    }
+
+    fn tracked_event(seq: u64, msg: &Message) -> Self::SseEvent {
+        let json = serde_json::to_string(msg).unwrap_or_default();
+        Bytes::from(format!("id: {seq}\ndata: {json}\n\n"))
+    }
+
+    fn ephemeral_event(msg: &Message) -> Self::SseEvent {
+        let json = serde_json::to_string(msg).unwrap_or_default();
+        Bytes::from(format!("data: {json}\n\n"))
+    }
+
+    async fn run(self, ctx: HttpContext, token: CancellationToken) -> Result<(), Error> {
+        let listener = TcpListener::bind(ctx.addr()).await.map_err(Error::from)?;
+        let ctx = Arc::new(ctx);
+        let secret = self.secret;
+
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => return Ok(()),
+                conn = listener.accept() => {
+                    let (stream, _) = conn.map_err(Error::from)?;
+                    let ctx = ctx.clone();
+                    let secret = secret.clone();
+                    tokio::spawn(async move {
+                        let service = service_fn(move |req| {
+                            route(req, ctx.clone(), secret.clone())
+                        });
+                        let _ = hyper::server::conn::http1::Builder::new()
+                            .serve_connection(TokioIo::new(stream), service)
+                            .await;
+                    });
+                }
+            }
+        }
+    }
+}
+
+/// The engine's router — the hyper counterpart of the three MCP routes
+/// plus the well-known metadata document.
+async fn route(
+    req: http::Request<Incoming>,
+    ctx: Arc<HttpContext>,
+    secret: Arc<str>,
+) -> Result<http::Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    let path = req.uri().path().to_owned();
+    let method = req.method().clone();
+
+    // RFC 9728: publicly reachable, no token required.
+    if method == http::Method::GET && Some(path.as_str()) == ctx.oauth_metadata_path() {
+        return Ok(HyperEngine::adapt_response(
+            handlers::handle_oauth_metadata(&ctx),
+        ));
+    }
+
+    if path != ctx.endpoint() {
+        return Ok(status(http::StatusCode::NOT_FOUND));
+    }
+
+    let Ok(mut neutral) = HyperEngine::adapt_request(req).await else {
+        return Ok(status(http::StatusCode::INTERNAL_SERVER_ERROR));
+    };
+
+    // The engine authorization contract: validate the credential, put
+    // the claims into the neutral request's extensions — or answer with
+    // the challenge so the client can start the OAuth flow.
+    match decode_claims(neutral.headers(), &ctx, &secret) {
+        Some(claims) => {
+            let claims: Arc<dyn Claims> = Arc::new(claims);
+            neutral.extensions_mut().insert(claims);
+        }
+        None => {
+            return Ok(HyperEngine::adapt_response(handlers::handle_unauthorized(
+                &ctx,
+            )));
+        }
+    }
+
+    let resp = match method {
+        http::Method::POST => {
+            HyperEngine::adapt_response(handlers::handle_post(neutral, &ctx).await)
+        }
+        http::Method::DELETE => {
+            HyperEngine::adapt_response(handlers::handle_delete(neutral, &ctx).await)
+        }
+        http::Method::GET => match handlers::handle_get_sse::<HyperEngine>(neutral, &ctx).await {
+            SseResponse::Status(resp) => HyperEngine::adapt_response(resp),
+            SseResponse::Stream { headers, stream } => {
+                let body = StreamBody::new(stream.map(|event| Ok(Frame::data(event))));
+                let mut resp = http::Response::builder()
+                    .status(http::StatusCode::OK)
+                    .header(http::header::CONTENT_TYPE, "text/event-stream")
+                    .header(http::header::CACHE_CONTROL, "no-cache")
+                    .body(BodyExt::boxed(body))
+                    .unwrap_or_default();
+                resp.headers_mut().extend(headers);
+                resp
+            }
+        },
+        _ => status(http::StatusCode::METHOD_NOT_ALLOWED),
+    };
+    Ok(resp)
+}
+
+/// HS256 bearer validation with the audience bound to the canonical
+/// resource URI — the place to plug JWKS validation instead.
+fn decode_claims(
+    headers: &http::HeaderMap,
+    ctx: &HttpContext,
+    secret: &str,
+) -> Option<DefaultClaims> {
+    let token = headers
+        .get(http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")?;
+
+    let mut validation = jsonwebtoken::Validation::new(jsonwebtoken::Algorithm::HS256);
+    if let Some(resource) = ctx.oauth_resource() {
+        validation.set_audience(&[resource]);
+    }
+
+    jsonwebtoken::decode::<DefaultClaims>(
+        token,
+        &jsonwebtoken::DecodingKey::from_secret(secret.as_bytes()),
+        &validation,
+    )
+    .ok()
+    .map(|data| data.claims)
+}
+
+fn status(code: http::StatusCode) -> http::Response<BoxBody<Bytes, Infallible>> {
+    http::Response::builder()
+        .status(code)
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap_or_default()
+}
+
+#[tokio::main]
+async fn main() {
+    let secret = std::env::var("JWT_SECRET").expect("JWT_SECRET must be set");
+    let engine = HyperEngine {
+        secret: secret.into(),
+    };
+
+    App::new()
+        .with_options(|opt| {
+            opt.with_name("Hyper-engine OAuth Example").set_http(
+                HttpServer::from_engine("127.0.0.1:3005", engine).with_oauth_metadata(|oauth| {
+                    oauth
+                        .with_authorization_servers(["https://auth.example.com"])
+                        .with_scopes(["mcp:tools"])
+                }),
+            )
+        })
+        .run()
+        .await;
+}

--- a/examples/oauth-server/Cargo.toml
+++ b/examples/oauth-server/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example-oauth-server"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+neva = { path = "../../neva", features = ["server-full"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing-subscriber = "0.3.20"

--- a/examples/oauth-server/src/main.rs
+++ b/examples/oauth-server/src/main.rs
@@ -1,0 +1,73 @@
+//! An MCP server protected as an OAuth 2.1 resource server: bearer
+//! tokens are validated against the issuer's JWKS, the RFC 9728
+//! Protected Resource Metadata document is served on the well-known
+//! path, and 401 challenges point clients at it.
+//!
+//! Run with:
+//!
+//! ```no_rust
+//! # Any OAuth 2.1 / OIDC issuer:
+//! OAUTH_ISSUER=https://auth.example.com cargo run -p example-oauth-server
+//!
+//! # A local issuer over plain http (e.g. Keycloak from
+//! # examples/oauth-with-keycloak):
+//! OAUTH_ISSUER=http://localhost:8080/realms/neva OAUTH_ALLOW_HTTP=1 \
+//!     cargo run -p example-oauth-server
+//! ```
+//!
+//! Then connect with `cargo run -p example-oauth-client` (or MCP
+//! Inspector) - the client discovers everything from the 401 challenge.
+use neva::prelude::*;
+
+/// A tool available to any authenticated caller
+#[tool]
+async fn whoami() -> &'static str {
+    "an authenticated caller"
+}
+
+/// A tool available only to admins
+#[tool(roles = ["admin"])]
+async fn admin_report(name: String) -> String {
+    format!("confidential report: {name}")
+}
+
+#[tokio::main]
+async fn main() {
+    let issuer = std::env::var("OAUTH_ISSUER").expect("OAUTH_ISSUER must be set");
+    let allow_http = std::env::var("OAUTH_ALLOW_HTTP").is_ok();
+
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .with_options(|opt| {
+            opt.with_name("OAuth Server Example").with_http(|http| {
+                http.bind("127.0.0.1:3000")
+                    // Explicit RFC 9728 document. Optional: with
+                    // `with_auth(...with_oauth(...))` alone the document
+                    // is derived from the issuer automatically - spelled
+                    // out here to show the knobs (scopes, extra fields,
+                    // and `with_resource(...)` for reverse proxies).
+                    .with_oauth_metadata(|oauth| {
+                        oauth
+                            .with_authorization_servers([issuer.as_str()])
+                            .with_scopes(["mcp:tools"])
+                    })
+                    .with_auth(|auth| {
+                        auth.with_oauth(|oauth| {
+                            let oauth = oauth.with_issuer(issuer.as_str());
+                            // Plain-http issuers are for local development
+                            // only - discovery rejects them by default.
+                            if allow_http {
+                                oauth.with_config(|cfg| {
+                                    cfg.with_client_config(|c| c.require_https(false))
+                                })
+                            } else {
+                                oauth
+                            }
+                        })
+                    })
+            })
+        })
+        .run()
+        .await;
+}

--- a/examples/oauth-with-keycloak/Cargo.toml
+++ b/examples/oauth-with-keycloak/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "example-oauth-with-keycloak"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "keycloak-server"
+path = "src/server.rs"
+
+[[bin]]
+name = "keycloak-client"
+path = "src/client.rs"
+
+[dependencies]
+neva = { path = "../../neva", features = ["full"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.20"

--- a/examples/oauth-with-keycloak/README.md
+++ b/examples/oauth-with-keycloak/README.md
@@ -1,0 +1,82 @@
+# OAuth with Keycloak
+
+The full MCP authorization flow against a real OAuth 2.1/OIDC issuer:
+a neva server validating tokens against Keycloak's JWKS, and a neva
+client walking discovery → browser login → PKCE code exchange → tool
+calls, including a role-gated tool.
+
+## 1. Start Keycloak
+
+From the repository root:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+  -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+  -v $(pwd)/examples/oauth-with-keycloak/realm-export.json:/opt/keycloak/data/import/neva-realm.json \
+  quay.io/keycloak/keycloak:26.0 start-dev --import-realm
+```
+
+The imported `neva` realm contains:
+
+| Item | Value | Purpose |
+|---|---|---|
+| public client | `neva-mcp-client`, redirect `http://127.0.0.1:8919/callback`, PKCE S256 | the MCP client |
+| audience mapper | adds `http://127.0.0.1:3000/mcp` to `aud` | RFC 8707 binding the server verifies |
+| role mapper | realm roles → flat `roles` claim | what neva's `DefaultClaims` / `#[tool(roles = [...])]` read |
+| user | `demo` / `demo`, realm role `admin` | the person in the browser |
+
+## 2. Start the MCP server
+
+```bash
+cargo run -p example-oauth-with-keycloak --bin keycloak-server
+```
+
+One `with_oauth(|oauth| oauth.with_issuer(...))` call does everything:
+JWKS-based token validation, `aud`/`iss` checks, and the RFC 9728
+metadata document on
+`http://127.0.0.1:3000/.well-known/oauth-protected-resource/mcp`.
+
+## 3. Run the client
+
+```bash
+cargo run -p example-oauth-with-keycloak --bin keycloak-client
+```
+
+The first request hits a `401`, the client discovers Keycloak through
+the challenge, and the system browser opens the login page — sign in as
+`demo` / `demo`. After the redirect the client retries transparently and
+calls both tools; `admin_report` works because `demo` carries the
+`admin` realm role. Tokens are refreshed in the background afterwards.
+
+## MCP Inspector
+
+The server also works with the Inspector's guided OAuth flow:
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Connect with transport `Streamable HTTP` to `http://127.0.0.1:3000/mcp`.
+In the authentication settings set **Client ID** to `neva-mcp-client`
+(Keycloak restricts anonymous dynamic client registration by default,
+so the Inspector cannot register itself), then follow the prompts and
+sign in as `demo` / `demo`.
+
+The Inspector's **redirect URL field is read-only by design** — the
+callback must land on the Inspector web app itself
+(`http://localhost:6274/oauth/callback`, plus `…/callback/debug` for the
+guided flow). Both are pre-registered on `neva-mcp-client` by the realm
+import; if you run the Inspector on a non-default port, add the matching
+URIs in the Keycloak admin console (Clients → `neva-mcp-client` → Valid
+redirect URIs).
+
+## Notes
+
+* Local Keycloak runs over plain `http`, so both binaries relax
+  `require_https` for discovery/token traffic. Never do that outside
+  local development.
+* The client is pre-registered because Keycloak restricts anonymous
+  dynamic client registration by default; against an issuer with open
+  DCR the `with_client_id`/`with_port` configuration disappears and the
+  client registers itself (as `application_type: "native"`).

--- a/examples/oauth-with-keycloak/realm-export.json
+++ b/examples/oauth-with-keycloak/realm-export.json
@@ -1,0 +1,99 @@
+{
+  "realm": "neva",
+  "enabled": true,
+  "sslRequired": "none",
+  "roles": {
+    "realm": [
+      {
+        "name": "admin",
+        "description": "May call admin-gated MCP tools"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "neva-mcp-client",
+      "name": "neva MCP client",
+      "enabled": true,
+      "publicClient": true,
+      "protocol": "openid-connect",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "redirectUris": [
+        "http://127.0.0.1:8919/callback",
+        "http://localhost:6274/oauth/callback",
+        "http://localhost:6274/oauth/callback/debug"
+      ],
+      "webOrigins": ["+"],
+      "defaultClientScopes": ["basic", "profile", "mcp-audience", "roles-claim"],
+      "optionalClientScopes": [],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      }
+    }
+  ],
+  "clientScopes": [
+    {
+      "name": "mcp-audience",
+      "description": "Binds access tokens to the MCP server (RFC 8707 audience)",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "mcp-resource-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.custom.audience": "http://127.0.0.1:3000/mcp",
+            "access.token.claim": "true",
+            "id.token.claim": "false"
+          }
+        }
+      ]
+    },
+    {
+      "name": "roles-claim",
+      "description": "Delivers realm roles in the flat `roles` claim neva reads",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "realm-roles-as-roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.name": "roles",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "access.token.claim": "true",
+            "id.token.claim": "false"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "demo",
+      "enabled": true,
+      "email": "demo@example.com",
+      "emailVerified": true,
+      "firstName": "Demo",
+      "lastName": "User",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "demo",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["admin"]
+    }
+  ]
+}

--- a/examples/oauth-with-keycloak/src/client.rs
+++ b/examples/oauth-with-keycloak/src/client.rs
@@ -1,0 +1,47 @@
+//! The client half of the Keycloak walkthrough — see README.md in this
+//! directory for the full setup.
+//!
+//! Uses the client pre-registered by the realm import
+//! (`neva-mcp-client`, redirect `http://127.0.0.1:8919/callback`), so
+//! the loopback listener is pinned to that port. On the first request
+//! the browser opens Keycloak's login page — sign in as `demo` / `demo`.
+//!
+//! ```no_rust
+//! cargo run -p example-oauth-with-keycloak --bin keycloak-client
+//! ```
+use neva::auth::oauth::LoopbackHandler;
+use neva::prelude::*;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt().init();
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| {
+            http.bind("127.0.0.1:3000").with_oauth(|oauth| {
+                oauth
+                    .with_client_id("neva-mcp-client")
+                    // local Keycloak runs over plain http
+                    .require_https(false)
+                    // the realm registers exactly this redirect URI
+                    .with_handler(LoopbackHandler::new().with_port(8919))
+            })
+        })
+        // the first request waits for the browser login
+        .with_timeout(Duration::from_secs(300))
+    });
+
+    client.connect().await?;
+
+    tracing::info!("--- CALL whoami ---");
+    let result = client.call_tool("whoami", ()).await?;
+    tracing::info!("{:?}", result.content);
+
+    // `demo` carries the `admin` realm role, so the gated tool works too
+    tracing::info!("--- CALL admin_report ---");
+    let result = client.call_tool("admin_report", ("name", "q3")).await?;
+    tracing::info!("{:?}", result.content);
+
+    client.disconnect().await
+}

--- a/examples/oauth-with-keycloak/src/server.rs
+++ b/examples/oauth-with-keycloak/src/server.rs
@@ -1,0 +1,52 @@
+//! The resource-server half of the Keycloak walkthrough — see README.md
+//! in this directory for the full setup.
+//!
+//! Minimal configuration on purpose: pointing bearer auth at the issuer
+//! is enough. Tokens are validated against Keycloak's JWKS, the token's
+//! `aud` is bound to `http://127.0.0.1:3000/mcp` (granted by the realm's
+//! audience mapper), and the RFC 9728 metadata document is derived from
+//! the issuer and served on the well-known path automatically.
+//!
+//! ```no_rust
+//! cargo run -p example-oauth-with-keycloak --bin keycloak-server
+//! ```
+use neva::prelude::*;
+
+const ISSUER: &str = "http://localhost:8080/realms/neva";
+
+/// A tool available to any authenticated caller
+#[tool]
+async fn whoami() -> &'static str {
+    "an authenticated caller"
+}
+
+/// A tool available only to callers with the `admin` realm role
+/// (delivered in the `roles` claim by the realm's role mapper)
+#[tool(roles = ["admin"])]
+async fn admin_report(name: String) -> String {
+    format!("confidential report: {name}")
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt().init();
+
+    App::new()
+        .with_options(|opt| {
+            opt.with_name("Keycloak-protected MCP Server")
+                .with_http(|http| {
+                    http.bind("127.0.0.1:3000").with_auth(|auth| {
+                        auth.with_oauth(|oauth| {
+                            oauth
+                                .with_issuer(ISSUER)
+                                // local Keycloak runs over plain http
+                                .with_config(|cfg| {
+                                    cfg.with_client_config(|c| c.require_https(false))
+                                })
+                        })
+                    })
+                })
+        })
+        .run()
+        .await;
+}

--- a/examples/protected-server/src/main.rs
+++ b/examples/protected-server/src/main.rs
@@ -3,7 +3,13 @@
 //! ```no_rust
 //! npx @modelcontextprotocol/inspector
 //!
+//! # Static decoding key (HS256):
 //! JWT_SECRET=a-string-secret-at-least-256-bits-long cargo run -p example-protected-server
+//!
+//! # OAuth 2.1/OIDC issuer mode — tokens are validated against the
+//! # issuer's JWKS, and /.well-known/oauth-protected-resource/mcp is
+//! # served automatically:
+//! OAUTH_ISSUER=https://auth.example.com cargo run -p example-protected-server
 //! ```
 use neva::prelude::*;
 use tracing_subscriber::{filter, prelude::*, reload};
@@ -36,7 +42,8 @@ async fn restricted_resource(uri: Uri, name: String) -> (String, String) {
 
 #[tokio::main]
 async fn main() {
-    let secret = std::env::var("JWT_SECRET").expect("JWT_SECRET must be set");
+    let issuer = std::env::var("OAUTH_ISSUER").ok();
+    let secret = std::env::var("JWT_SECRET").ok();
 
     let (filter, handle) = reload::Layer::new(filter::LevelFilter::DEBUG);
     tracing_subscriber::registry()
@@ -49,11 +56,24 @@ async fn main() {
         .with_options(|opt| {
             opt.with_name("Protected Server Example")
                 .with_http(|http| {
-                    http.with_auth(|auth| {
-                        auth.validate_exp(false)
+                    http.with_auth(|auth| match (&issuer, &secret) {
+                        // OAuth issuer mode: keys come from the issuer's
+                        // JWKS; the token's `aud` is bound to this server's
+                        // canonical URI and its `iss` to the issuer, and the
+                        // RFC 9728 metadata document is derived and served
+                        // automatically. For a local issuer over plain http
+                        // (e.g. Keycloak on localhost), relax the discovery
+                        // client with:
+                        //   .with_config(|cfg| cfg
+                        //       .with_client_config(|c| c.require_https(false)))
+                        (Some(issuer), _) => auth.with_oauth(|oauth| oauth.with_issuer(issuer)),
+                        // Static decoding key (HS256) — the pre-OAuth setup.
+                        (None, Some(secret)) => auth
+                            .validate_exp(false)
                             .with_aud(["some aud"])
                             .with_iss(["some issuer"])
-                            .set_decoding_key(secret.as_bytes())
+                            .set_decoding_key(secret.as_bytes()),
+                        (None, None) => panic!("Set OAUTH_ISSUER or JWT_SECRET"),
                     })
                 })
                 .with_logging(handle)

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -27,14 +27,14 @@ memchr = "2.8.3"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 schemars = { version = "1.2.1" }
-tokio = { version = "1.52.3", features = ["sync", "io-std", "io-util", "rt", "time", "macros"] }
+tokio = { version = "1.53.0", features = ["sync", "io-std", "io-util", "rt", "time", "macros"] }
 tokio-util = "0.7.18"
 uuid = { version = "1.24.0", features = ["v4", "serde"] }
 
 # optional
 chacha20poly1305 = { version = "0.11.0", optional = true }
 inventory = { version = "0.3.24", optional = true }
-jsonschema = { version = "0.47.0", optional = true }
+jsonschema = { version = "0.48.0", optional = true }
 once_cell = { version = "1.21.4", features = ["std"], optional = true }
 reqwest = { version = "0.13.4", features = ["stream", "json"], optional = true }
 sse-stream = { version = "0.2.4", optional = true }
@@ -56,7 +56,7 @@ windows = { version = "0.62.0", features = ["Win32_Foundation", "Win32_System_Jo
 nix = { version = "0.31.1", features = ["signal"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.53.0", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.18" }
 
 [features]

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -72,8 +72,10 @@ server-macros = ["server", "macros", "neva_macros?/server"]
 server-tls = ["http-server-volga", "volga?/tls", "volga?/dev-cert"]
 # Engine-neutral OAuth 2.1 resource-server primitives: the RFC 9728
 # Protected Resource Metadata document and the WWW-Authenticate bearer
-# challenge, served through any `HttpEngine`. No Volga in deps.
-server-oauth = ["http-server", "dep:volga-oauth-core"]
+# challenge, served through any `HttpEngine`. No Volga in deps — but when
+# the Volga engine is enabled too, this additionally unlocks issuer-based
+# JWKS token validation (`AuthConfig::with_oauth`) via Volga.
+server-oauth = ["http-server", "dep:volga-oauth-core", "volga?/oauth-client"]
 # Engine-agnostic Streamable HTTP abstractions. Enable this and implement
 # `HttpEngine` for your own stack (e.g. axum, hyper). No Volga in deps.
 http-server = ["server", "dep:tokio-stream"]

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -44,6 +44,7 @@ tracing-subscriber = { version = "0.3.23", features = ["fmt", "json"], optional 
 volga = { version = "0.9.5", features = ["di", "jwt-auth-full"], optional = true }
 volga-di = { version = "0.9.5", optional = true }
 volga-oauth-core = { version = "0.9.5", optional = true }
+volga-oauth-client = { version = "0.9.5", optional = true }
 
 # neva
 neva_macros = { workspace = true, optional = true }
@@ -70,11 +71,6 @@ tracing = ["dep:tracing", "dep:tracing-subscriber", "dep:once_cell", "volga?/tra
 server-full = ["server-macros", "tracing", "http-server-volga", "server-tls", "server-oauth", "di", "tasks"]
 server-macros = ["server", "macros", "neva_macros?/server"]
 server-tls = ["http-server-volga", "volga?/tls", "volga?/dev-cert"]
-# Engine-neutral OAuth 2.1 resource-server primitives: the RFC 9728
-# Protected Resource Metadata document and the WWW-Authenticate bearer
-# challenge, served through any `HttpEngine`. No Volga in deps — but when
-# the Volga engine is enabled too, this additionally unlocks issuer-based
-# JWKS token validation (`AuthConfig::with_oauth`) via Volga.
 server-oauth = ["http-server", "dep:volga-oauth-core", "volga?/oauth-client"]
 # Engine-agnostic Streamable HTTP abstractions. Enable this and implement
 # `HttpEngine` for your own stack (e.g. axum, hyper). No Volga in deps.
@@ -84,11 +80,12 @@ http-server-volga = ["http-server", "dep:volga"]
 server = ["tokio/signal", "tokio/rt-multi-thread"]
 
 # client
-client-full = ["client-macros", "tracing", "http-client", "client-tls", "tasks"]
+client-full = ["client-macros", "tracing", "http-client", "client-tls", "client-oauth", "tasks"]
 client-macros = ["client", "macros", "neva_macros?/client"]
+client-oauth = ["http-client", "dep:volga-oauth-client"]
 client-tls = ["reqwest?/rustls"]
 http-client = ["client", "dep:reqwest", "dep:sse-stream", "dep:tokio-stream", "dep:once_cell"]
-client = ["dep:windows", "dep:nix", "dep:jsonschema", "tokio/process", "tokio/signal"]
+client = ["dep:windows", "dep:nix", "dep:jsonschema", "tokio/process", "tokio/signal", "tokio/rt-multi-thread"]
 
 # Opt-in MCP 2026-07-28 Release Candidate support. Mutually exclusive
 # with any future `proto-*` generation flag — see lib.rs guard.

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -231,8 +231,8 @@ impl Client {
         #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
         self.register_tracing_notification_handlers();
 
-        self.cancellation_token = Some(token);
-        self.handler = Some(RequestHandler::new(transport, &self.options));
+        self.cancellation_token = Some(token.clone());
+        self.handler = Some(RequestHandler::new(transport, &self.options, token));
 
         self.wait_for_shutdown_signal();
         self.init().await
@@ -1199,9 +1199,10 @@ impl Client {
 
             let request_timeout = handler.timeout();
             let pending = handler.pending().clone();
+            let token = handler.cancellation();
             let receivers = handler.send_batch(items).await?;
 
-            collect_batch_responses(receivers, &pending, request_timeout)
+            collect_batch_responses(receivers, &pending, request_timeout, token)
                 .await
                 .into_iter()
                 .collect()
@@ -1268,8 +1269,9 @@ impl Client {
                 .ok_or_else(|| Error::new(ErrorCode::InternalError, "Connection closed"))?;
             let request_timeout = handler.timeout();
             let pending = handler.pending().clone();
+            let token = handler.cancellation();
             let receivers = handler.send_batch(extras).await?;
-            return collect_batch_responses(receivers, &pending, request_timeout)
+            return collect_batch_responses(receivers, &pending, request_timeout, token)
                 .await
                 .into_iter()
                 .collect();
@@ -1304,8 +1306,10 @@ impl Client {
                 .ok_or_else(|| Error::new(ErrorCode::InternalError, "Connection closed"))?;
             let request_timeout = handler.timeout();
             let pending = handler.pending().clone();
+            let token = handler.cancellation();
             let receivers = handler.send_batch(envelopes).await?;
-            let responses = collect_batch_responses(receivers, &pending, request_timeout).await;
+            let responses =
+                collect_batch_responses(receivers, &pending, request_timeout, token).await;
 
             // `responses` aligns with `round_slots`: `send_batch` preserves
             // request order and extras produce no receiver. Final responses fill
@@ -1548,24 +1552,35 @@ async fn collect_batch_responses(
     )>,
     pending: &crate::shared::RequestQueue,
     request_timeout: std::time::Duration,
+    token: tokio_util::sync::CancellationToken,
 ) -> Vec<Result<Response, Error>> {
     use futures_util::future::join_all;
 
     let futures = receivers.into_iter().map(|(id, rx)| {
         let pending = pending.clone();
+        let token = token.clone();
         async move {
-            match tokio::time::timeout(request_timeout, rx).await {
-                Ok(Ok(crate::shared::PendingResponse::Response(resp))) => Ok(resp),
-                Ok(Ok(crate::shared::PendingResponse::Timeout)) => {
-                    Err(Error::new(ErrorCode::Timeout, "Batch request timed out"))
-                }
-                Ok(Err(_)) => Err(Error::new(
-                    ErrorCode::InternalError,
-                    "Response channel closed",
-                )),
-                Err(_) => {
+            tokio::select! {
+                biased;
+                // The transport died (or a shutdown signal cancelled it)
+                // — no response is coming for any receiver.
+                _ = token.cancelled() => {
                     let _ = pending.pop(&id);
-                    Err(Error::new(ErrorCode::Timeout, "Batch request timed out"))
+                    Err(Error::new(ErrorCode::InternalError, "Connection closed"))
+                }
+                result = tokio::time::timeout(request_timeout, rx) => match result {
+                    Ok(Ok(crate::shared::PendingResponse::Response(resp))) => Ok(resp),
+                    Ok(Ok(crate::shared::PendingResponse::Timeout)) => {
+                        Err(Error::new(ErrorCode::Timeout, "Batch request timed out"))
+                    }
+                    Ok(Err(_)) => Err(Error::new(
+                        ErrorCode::InternalError,
+                        "Response channel closed",
+                    )),
+                    Err(_) => {
+                        let _ = pending.pop(&id);
+                        Err(Error::new(ErrorCode::Timeout, "Batch request timed out"))
+                    }
                 }
             }
         }

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -25,6 +25,7 @@ use std::{
 #[cfg(not(feature = "proto-2026-07-28-rc"))]
 use tokio::sync::RwLock;
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
 #[cfg(all(feature = "tasks", not(feature = "proto-2026-07-28-rc")))]
 use crate::types::CreateMessageRequestParams;
@@ -56,6 +57,11 @@ pub(super) struct RequestHandler {
 
     /// Request timeout
     timeout: Duration,
+
+    /// The transport's cancellation token: pending awaits abort as soon
+    /// as the transport dies or a shutdown signal cancels it, instead of
+    /// sitting out the full request timeout.
+    token: CancellationToken,
 
     /// Pending requests
     pending: RequestQueue,
@@ -131,7 +137,11 @@ impl Roots {
 
 impl RequestHandler {
     /// Creates a new [`RequestHandler`]
-    pub(super) fn new(transport: TransportProto, options: &McpOptions) -> Self {
+    pub(super) fn new(
+        transport: TransportProto,
+        options: &McpOptions,
+        token: CancellationToken,
+    ) -> Self {
         let (tx, rx) = transport.split();
 
         let handler = Self {
@@ -141,6 +151,7 @@ impl RequestHandler {
             pending: RequestQueue::new(options.timeout),
             sender: tx,
             timeout: options.timeout,
+            token,
             #[cfg(not(feature = "proto-2026-07-28-rc"))]
             sampling_handler: options.sampling_handler.clone(),
             elicitation_handler: options.elicitation_handler.clone(),
@@ -165,6 +176,12 @@ impl RequestHandler {
         self.timeout
     }
 
+    /// Returns the transport's cancellation token
+    #[inline]
+    pub(super) fn cancellation(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
     /// Returns a reference to the pending request queue
     #[inline]
     pub(super) fn pending(&self) -> &RequestQueue {
@@ -182,18 +199,28 @@ impl RequestHandler {
         }
         self.pending.activate(&id);
 
-        match timeout(self.timeout, receiver).await {
-            Ok(Ok(PendingResponse::Response(resp))) => Ok(resp),
-            Ok(Ok(PendingResponse::Timeout)) => {
-                Err(Error::new(ErrorCode::Timeout, "Request timed out"))
-            }
-            Ok(Err(_)) => Err(Error::new(
-                ErrorCode::InternalError,
-                "Response channel closed",
-            )),
-            Err(_) => {
+        tokio::select! {
+            biased;
+            // The transport died (or a shutdown signal cancelled it) —
+            // no response is coming; fail now rather than after the
+            // full request timeout.
+            _ = self.token.cancelled() => {
                 _ = self.pending.pop(&id);
-                Err(Error::new(ErrorCode::Timeout, "Request timed out"))
+                Err(Error::new(ErrorCode::InternalError, "Connection closed"))
+            }
+            result = timeout(self.timeout, receiver) => match result {
+                Ok(Ok(PendingResponse::Response(resp))) => Ok(resp),
+                Ok(Ok(PendingResponse::Timeout)) => {
+                    Err(Error::new(ErrorCode::Timeout, "Request timed out"))
+                }
+                Ok(Err(_)) => Err(Error::new(
+                    ErrorCode::InternalError,
+                    "Response channel closed",
+                )),
+                Err(_) => {
+                    _ = self.pending.pop(&id);
+                    Err(Error::new(ErrorCode::Timeout, "Request timed out"))
+                }
             }
         }
     }
@@ -710,6 +737,41 @@ mod tests {
     use std::pin::Pin;
     #[cfg(not(feature = "proto-2026-07-28-rc"))]
     use tokio::time::Instant;
+
+    #[tokio::test]
+    #[cfg(feature = "http-client")]
+    async fn cancelled_transport_fails_pending_request_immediately() {
+        use crate::transport::http::HttpClient;
+        use tokio::time::{Duration, timeout};
+
+        let token = CancellationToken::new();
+        let mut handler = RequestHandler::new(
+            TransportProto::HttpClient(HttpClient::default()),
+            &McpOptions::default(),
+            token.clone(),
+        );
+
+        // The transport was never started — nothing will ever answer.
+        let req = Request::new(Some(RequestId::Number(1)), "ping", None::<()>);
+        let pending = handler.send_request(req);
+        tokio::pin!(pending);
+
+        // The await parks (no response, no cancellation)...
+        assert!(
+            timeout(Duration::from_millis(50), pending.as_mut())
+                .await
+                .is_err(),
+            "request should still be pending"
+        );
+
+        // ...and cancelling the transport token unblocks it immediately,
+        // long before the 10s request timeout.
+        token.cancel();
+        let result = timeout(Duration::from_millis(100), pending)
+            .await
+            .expect("cancellation must unblock the pending request");
+        assert!(result.is_err(), "the aborted request must surface an error");
+    }
 
     #[tokio::test]
     async fn batch_responses_are_distributed_individually() {

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -111,10 +111,12 @@ pub(crate) const PROTOCOL_VERSIONS: &[&str] = &[
 ))]
 compile_error!("Only one `proto-*` feature flag may be enabled per build");
 
-#[cfg(feature = "http-server")]
+#[cfg(any(feature = "http-server", feature = "client-oauth"))]
 pub mod auth {
-    //! Authentication utilities — neva's engine-neutral [`Claims`] trait
-    //! + (under the Volga adapter) the bearer-auth configuration types.
+    //! Authentication utilities: neva's engine-neutral [`Claims`] trait,
+    //! the bearer-auth configuration types (under the Volga adapter),
+    //! and the OAuth 2.1 building blocks for both sides of the
+    //! Streamable HTTP transport (under the OAuth features).
 
     /// `Claims` is neva's engine-neutral trait for typed per-tool
     /// authorization. Implement this for your custom claims type to enable
@@ -141,12 +143,14 @@ pub mod auth {
     /// let claims: Arc<dyn Claims> = Arc::new(my_decoded_claims);
     /// neutral_req.extensions_mut().insert(claims);
     /// ```
+    #[cfg(feature = "http-server")]
     pub use crate::transport::http::core::types::Claims;
 
     /// `DefaultClaims` is a pre-built [`Claims`] impl matching the JWT
     /// standard claim names. Engine-agnostic — under the Volga adapter
     /// it additionally implements `volga::auth::AuthClaims` so it can
     /// be fed straight into Volga's bearer-auth pipeline.
+    #[cfg(feature = "http-server")]
     pub use crate::transport::http::core::types::DefaultClaims;
 
     /// `AuthConfig` is the Volga-flavored builder used with
@@ -173,22 +177,34 @@ pub mod auth {
     #[cfg(feature = "http-server-volga")]
     pub use volga::auth::{Algorithm, Authorizer, Claims as ClaimsDerive};
 
-    #[cfg(feature = "server-oauth")]
+    #[cfg(any(feature = "server-oauth", feature = "client-oauth"))]
     pub mod oauth {
-        //! OAuth 2.1 / OIDC resource-server primitives.
+        //! OAuth 2.1 / OIDC building blocks.
         //!
-        //! [`OAuthResourceOptions`] configures the RFC 9728 Protected
-        //! Resource Metadata document through
-        //! `HttpServer::with_oauth_metadata`; the protocol-level types
-        //! are re-exported from
+        //! Server side (`server-oauth`): [`OAuthResourceOptions`]
+        //! configures the RFC 9728 Protected Resource Metadata document
+        //! through `HttpServer::with_oauth_metadata`; the protocol-level
+        //! types are re-exported from
         //! [`volga-oauth-core`](https://docs.rs/volga-oauth-core) —
         //! a crate with no HTTP I/O and no dependency on the Volga
         //! framework, so they are available to every `HttpEngine`.
+        //!
+        //! Client side (`client-oauth`): the pluggable
+        //! [`AuthorizationHandler`] contract with the default
+        //! [`LoopbackHandler`], plus the [`TokenStore`] persistence
+        //! abstraction — configured through `HttpClient::with_oauth`.
 
+        #[cfg(feature = "server-oauth")]
         pub use crate::transport::http::core::oauth::{
             BearerChallenge, OAuthError, OAuthErrorCode, OAuthResourceOptions,
             ProtectedResourceMetadata, WELL_KNOWN_PROTECTED_RESOURCE, canonicalize_resource_uri,
             protected_resource_metadata_url,
+        };
+
+        #[cfg(feature = "client-oauth")]
+        pub use crate::transport::http::client::oauth::{
+            AuthorizationHandler, CallbackParams, InMemoryTokenStore, LoopbackHandler,
+            OAuthClientConfig, TokenSet, TokenStore,
         };
     }
 }

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -154,6 +154,12 @@ pub mod auth {
     #[cfg(feature = "http-server-volga")]
     pub use crate::transport::http::server::volga::auth_config::AuthConfig;
 
+    /// `OAuthConfig` describes the OAuth 2.1/OIDC issuer whose keys
+    /// validate bearer tokens, used with `AuthConfig::with_oauth(...)`.
+    /// Available only under the Volga adapter with `server-oauth`.
+    #[cfg(all(feature = "http-server-volga", feature = "server-oauth"))]
+    pub use crate::transport::http::server::volga::auth_config::OAuthConfig;
+
     /// Volga's claims trait, re-exported for users who need to plug a
     /// custom claims type into Volga's `Authorizer<C>`. For neva's own
     /// per-tool checks, implement [`Claims`] instead — that one is

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -139,6 +139,8 @@ where
 pub struct HttpClient {
     url: ServiceUrl,
     access_token: Option<Box<[u8]>>,
+    #[cfg(feature = "client-oauth")]
+    oauth: Option<client::oauth::OAuthClientConfig>,
     #[cfg(feature = "client-tls")]
     tls_config: Option<McpClientTlsConfig>,
     sender: HttpSender,
@@ -158,6 +160,8 @@ pub(super) struct ClientRuntimeContext {
     tx: Sender<Result<Message, Error>>,
     rx: Receiver<Message>,
     access_token: Option<Box<[u8]>>,
+    #[cfg(feature = "client-oauth")]
+    oauth: Option<std::sync::Arc<client::oauth::OAuthSession>>,
     #[cfg(feature = "client-tls")]
     tls_config: Option<ClientTlsConfig>,
 }
@@ -220,6 +224,8 @@ impl Default for HttpClient {
         Self {
             url: ServiceUrl::default(),
             access_token: None,
+            #[cfg(feature = "client-oauth")]
+            oauth: None,
             #[cfg(feature = "client-tls")]
             tls_config: None,
             receiver: HttpReceiver::new(),
@@ -665,7 +671,45 @@ impl HttpClient {
         self
     }
 
+    /// Enables automatic OAuth 2.1 authorization: on a `401` challenge
+    /// the client discovers the server's authorization requirements,
+    /// registers itself when needed, runs the authorization-code + PKCE
+    /// flow and attaches the obtained token to every request.
+    ///
+    /// Takes precedence over a static [`with_auth`](Self::with_auth)
+    /// token.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::Client;
+    ///
+    /// let mut client = Client::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_oauth(|oauth| oauth.with_scopes(["mcp:tools"]))
+    ///         )
+    ///     );
+    /// ```
+    #[cfg(feature = "client-oauth")]
+    pub fn with_oauth<F>(mut self, config: F) -> Self
+    where
+        F: FnOnce(client::oauth::OAuthClientConfig) -> client::oauth::OAuthClientConfig,
+    {
+        self.oauth = Some(config(client::oauth::OAuthClientConfig::default()));
+        self
+    }
+
     fn runtime(&mut self) -> Result<ClientRuntimeContext, Error> {
+        // Build the OAuth session before consuming transport state —
+        // same rationale as the server-side OAuth resolve.
+        #[cfg(feature = "client-oauth")]
+        let oauth = self
+            .oauth
+            .take()
+            .map(|config| client::oauth::OAuthSession::new(config, &self.url.to_url()))
+            .transpose()?
+            .map(std::sync::Arc::new);
+
         let Some(sender_rx) = self.sender.rx.take() else {
             return Err(Error::new(
                 ErrorCode::InternalError,
@@ -681,6 +725,8 @@ impl HttpClient {
             tx: self.receiver.tx.clone(),
             rx: sender_rx,
             access_token: self.access_token.take(),
+            #[cfg(feature = "client-oauth")]
+            oauth,
             #[cfg(feature = "client-tls")]
             tls_config,
         })

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -592,11 +592,25 @@ impl HttpServer<server::DefaultClaims, VolgaEngine> {
     where
         F: FnOnce(server::AuthConfig) -> server::AuthConfig,
     {
+        let auth = config(server::AuthConfig::default());
+        // Default-flow glue: when OAuth issuer mode is on and no
+        // Protected Resource Metadata was configured explicitly, derive
+        // the document from that issuer — the well-known route and the
+        // 401 challenge then work out of the box. An explicit
+        // `with_oauth_metadata` (before or after this call) wins.
+        #[cfg(feature = "server-oauth")]
+        if self.oauth.is_none()
+            && let Some(issuer) = auth.oauth_issuer()
+        {
+            self.oauth = Some(
+                core::oauth::OAuthResourceOptions::default().with_authorization_servers([issuer]),
+            );
+        }
         let engine = self
             .engine
             .as_mut()
             .expect("HttpServer::with_auth called after start()");
-        engine.auth = Some(config(server::AuthConfig::default()));
+        engine.auth = Some(auth);
         self
     }
 
@@ -909,6 +923,42 @@ mod engine_smoke_tests {
         // The config failure must not consume the HTTP writer — it fires
         // before any transport state is taken.
         assert!(server.sender.rx.is_some());
+    }
+
+    #[cfg(all(feature = "http-server-volga", feature = "server-oauth"))]
+    #[test]
+    fn oauth_issuer_seeds_resource_metadata() {
+        let mut server = HttpServer::new("127.0.0.1:3000").with_auth(|auth| {
+            auth.with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"))
+        });
+
+        let (ctx, _rx) = server.build_context_and_engine().unwrap();
+
+        assert_eq!(
+            ctx.oauth_metadata_path(),
+            Some("/.well-known/oauth-protected-resource/mcp")
+        );
+        let resp = core::handlers::handle_oauth_metadata(&ctx);
+        let doc: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(doc["authorization_servers"][0], "https://auth.example.com");
+    }
+
+    #[cfg(all(feature = "http-server-volga", feature = "server-oauth"))]
+    #[test]
+    fn explicit_metadata_wins_over_issuer_seeding() {
+        let mut server = HttpServer::new("127.0.0.1:3000")
+            .with_auth(|auth| {
+                auth.with_oauth(|oauth| oauth.with_issuer("https://auth.example.com"))
+            })
+            .with_oauth_metadata(|oauth| {
+                oauth.with_authorization_servers(["https://other.example.com"])
+            });
+
+        let (ctx, _rx) = server.build_context_and_engine().unwrap();
+
+        let resp = core::handlers::handle_oauth_metadata(&ctx);
+        let doc: serde_json::Value = serde_json::from_slice(resp.body()).unwrap();
+        assert_eq!(doc["authorization_servers"][0], "https://other.example.com");
     }
 
     #[cfg(feature = "server-oauth")]

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -25,8 +25,44 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 pub(super) mod mcp_session;
+#[cfg(feature = "client-oauth")]
+pub(crate) mod oauth;
 #[cfg(feature = "client-tls")]
 pub(crate) mod tls_config;
+
+/// How outgoing requests are authenticated.
+///
+/// Built once per connection from the runtime context; cheap to clone
+/// into every request task.
+#[derive(Clone)]
+enum ClientAuth {
+    /// No credential attached.
+    None,
+    /// Static bearer token from `HttpClient::with_auth`.
+    Static(Arc<str>),
+    /// Managed OAuth session — the token changes as flows complete.
+    #[cfg(feature = "client-oauth")]
+    OAuth(Arc<oauth::OAuthSession>),
+}
+
+impl ClientAuth {
+    /// The bearer token to attach right now, if any.
+    fn bearer(&self) -> Option<Arc<str>> {
+        match self {
+            ClientAuth::None => None,
+            ClientAuth::Static(token) => Some(token.clone()),
+            #[cfg(feature = "client-oauth")]
+            ClientAuth::OAuth(session) => session.bearer(),
+        }
+    }
+
+    fn from_static(access_token: Option<Box<[u8]>>) -> Self {
+        match access_token {
+            Some(token) => ClientAuth::Static(String::from_utf8_lossy(&token).into()),
+            None => ClientAuth::None,
+        }
+    }
+}
 
 // SSE-only constants — the standalone GET stream does not exist under the
 // stateless RC transport.
@@ -54,7 +90,14 @@ fn name_param(req: &crate::types::Request) -> Option<&str> {
 
 pub(super) async fn connect(rt: ClientRuntimeContext, token: CancellationToken) {
     let session = Arc::new(McpSession::new(rt.url, token));
-    let access_token: Option<Arc<[u8]>> = rt.access_token.map(|t| t.into());
+
+    #[cfg(feature = "client-oauth")]
+    let auth = match rt.oauth {
+        Some(oauth) => ClientAuth::OAuth(oauth),
+        None => ClientAuth::from_static(rt.access_token),
+    };
+    #[cfg(not(feature = "client-oauth"))]
+    let auth = ClientAuth::from_static(rt.access_token);
 
     // Stateless RC transport issues only POSTs — no standalone SSE GET stream.
     #[cfg(feature = "proto-2026-07-28-rc")]
@@ -62,7 +105,7 @@ pub(super) async fn connect(rt: ClientRuntimeContext, token: CancellationToken) 
         session.clone(),
         rt.rx,
         rt.tx.clone(),
-        access_token,
+        auth,
         #[cfg(feature = "client-tls")]
         rt.tls_config.clone(),
     )
@@ -74,14 +117,14 @@ pub(super) async fn connect(rt: ClientRuntimeContext, token: CancellationToken) 
             session.clone(),
             rt.rx,
             rt.tx.clone(),
-            access_token.clone(),
+            auth.clone(),
             #[cfg(feature = "client-tls")]
             rt.tls_config.clone()
         ),
         start_sse_connection(
             session.clone(),
             rt.tx.clone(),
-            access_token.clone(),
+            auth.clone(),
             #[cfg(feature = "client-tls")]
             rt.tls_config.clone()
         )
@@ -92,7 +135,7 @@ async fn handle_connection(
     session: Arc<McpSession>,
     mut sender_rx: mpsc::Receiver<Message>,
     recv_tx: mpsc::Sender<Result<Message, Error>>,
-    access_token: Option<Arc<[u8]>>,
+    auth: ClientAuth,
     #[cfg(feature = "client-tls")] tls_config: Option<ClientTlsConfig>,
 ) {
     #[cfg(not(feature = "client-tls"))]
@@ -126,67 +169,129 @@ async fn handle_connection(
                     tracing::error!(logger = "neva", "Unexpected messaging error");
                     break;
                 };
-                let mut resp = client
-                    .post(session.url())
-                    .json(&req)
-                    .header(CONTENT_TYPE, "application/json")
-                    .header(ACCEPT, "application/json, text/event-stream");
-
-                if let Some(session_id) = session.session_id() {
-                    resp = resp.header(MCP_SESSION_ID, session_id.to_string())
-                }
-
-                // Routing headers are exercised end-to-end via the trace-context
-                // integration in Task 2.4. Unit-level hint extraction is tested in
-                // `routing_hints_tests`.
-                #[cfg(feature = "proto-2026-07-28-rc")]
-                if let Some((method, name)) = routing_hints(&req) {
-                    resp = resp.header(crate::transport::http::MCP_METHOD, method);
-                    if let Some(n) = name {
-                        resp = resp.header(crate::transport::http::MCP_NAME, n);
-                    }
-                }
-
-                // Under the RC the protocol version is fixed: `with_mcp_version`
-                // is compiled out, so the client can only ever speak the latest
-                // (RC) version. Sending the last compiled version is therefore
-                // exactly the configured version on every request.
-                #[cfg(feature = "proto-2026-07-28-rc")]
-                {
-                    resp = resp.header(
-                        crate::transport::http::MCP_PROTOCOL_VERSION,
-                        crate::PROTOCOL_VERSIONS.last().copied().unwrap_or("2026-07-28"),
-                    );
-                }
-
-                if let Some(access_token) = &access_token {
-                    resp = resp.bearer_auth(String::from_utf8_lossy(access_token))
-                }
-
                 crate::spawn_fair!(send_request(
+                    client.clone(),
                     session.clone(),
-                    resp,
                     req,
-                    recv_tx.clone()
+                    recv_tx.clone(),
+                    auth.clone()
                 ));
             }
         }
     }
 }
 
+/// Builds the JSON-RPC POST with all transport headers and the current
+/// bearer credential attached.
+fn build_post(
+    client: &reqwest::Client,
+    session: &McpSession,
+    req: &Message,
+    bearer: Option<&str>,
+) -> RequestBuilder {
+    let mut resp = client
+        .post(session.url())
+        .json(req)
+        .header(CONTENT_TYPE, "application/json")
+        .header(ACCEPT, "application/json, text/event-stream");
+
+    if let Some(session_id) = session.session_id() {
+        resp = resp.header(MCP_SESSION_ID, session_id.to_string())
+    }
+
+    // Routing headers are exercised end-to-end via the trace-context
+    // integration in Task 2.4. Unit-level hint extraction is tested in
+    // `routing_hints_tests`.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    if let Some((method, name)) = routing_hints(req) {
+        resp = resp.header(crate::transport::http::MCP_METHOD, method);
+        if let Some(n) = name {
+            resp = resp.header(crate::transport::http::MCP_NAME, n);
+        }
+    }
+
+    // Under the RC the protocol version is fixed: `with_mcp_version`
+    // is compiled out, so the client can only ever speak the latest
+    // (RC) version. Sending the last compiled version is therefore
+    // exactly the configured version on every request.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    {
+        resp = resp.header(
+            crate::transport::http::MCP_PROTOCOL_VERSION,
+            crate::PROTOCOL_VERSIONS
+                .last()
+                .copied()
+                .unwrap_or("2026-07-28"),
+        );
+    }
+
+    if let Some(bearer) = bearer {
+        resp = resp.bearer_auth(bearer)
+    }
+    resp
+}
+
 async fn send_request(
+    client: reqwest::Client,
     session: Arc<McpSession>,
-    resp: RequestBuilder,
     req: Message,
     resp_tx: mpsc::Sender<Result<Message, Error>>,
+    auth: ClientAuth,
 ) {
-    let resp = match resp.send().await {
+    let bearer = auth.bearer();
+    let resp = match build_post(&client, &session, &req, bearer.as_deref())
+        .send()
+        .await
+    {
         Ok(resp) => resp,
         Err(_err) => {
             #[cfg(feature = "tracing")]
             tracing::error!(logger = "neva", "Failed to send HTTP request: {}", _err);
             return;
         }
+    };
+
+    // A 401 under a managed OAuth session triggers the authorization
+    // flow (single-flight across concurrent requests) and one retry with
+    // the fresh token. On flow failure the original 401 falls through to
+    // the regular response path.
+    #[cfg(feature = "client-oauth")]
+    let resp = match (&auth, resp.status()) {
+        (ClientAuth::OAuth(oauth), reqwest::StatusCode::UNAUTHORIZED) => {
+            let challenge = resp
+                .headers()
+                .get(reqwest::header::WWW_AUTHENTICATE)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned);
+            match oauth
+                .authorize(challenge.as_deref(), bearer.as_deref())
+                .await
+            {
+                Ok(fresh) => {
+                    match build_post(&client, &session, &req, Some(&fresh))
+                        .send()
+                        .await
+                    {
+                        Ok(retried) => retried,
+                        Err(_err) => {
+                            #[cfg(feature = "tracing")]
+                            tracing::error!(
+                                logger = "neva",
+                                "Failed to resend HTTP request: {}",
+                                _err
+                            );
+                            return;
+                        }
+                    }
+                }
+                Err(_err) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!(logger = "neva", "OAuth authorization failed: {}", _err);
+                    resp
+                }
+            }
+        }
+        _ => resp,
     };
 
     if let Message::Notification(_) = &req {
@@ -235,7 +340,7 @@ async fn send_request(
 async fn start_sse_connection(
     session: Arc<McpSession>,
     resp_tx: mpsc::Sender<Result<Message, Error>>,
-    access_token: Option<Arc<[u8]>>,
+    auth: ClientAuth,
     #[cfg(feature = "client-tls")] tls_config: Option<ClientTlsConfig>,
 ) {
     let token = session.cancellation_token();
@@ -246,7 +351,7 @@ async fn start_sse_connection(
             tokio::spawn(handle_sse_connection(
                 session.clone(),
                 resp_tx,
-                access_token,
+                auth,
                 #[cfg(feature = "client-tls")]
                 tls_config
             ));
@@ -258,7 +363,7 @@ async fn start_sse_connection(
 async fn handle_sse_connection(
     session: Arc<McpSession>,
     resp_tx: mpsc::Sender<Result<Message, Error>>,
-    access_token: Option<Arc<[u8]>>,
+    auth: ClientAuth,
     #[cfg(feature = "client-tls")] tls_config: Option<ClientTlsConfig>,
 ) {
     #[cfg(not(feature = "client-tls"))]
@@ -282,14 +387,20 @@ async fn handle_sse_connection(
     };
 
     let token = session.cancellation_token();
+    // At most one interactive re-authorization per (re)connection attempt
+    // sequence — a second consecutive 401 means the fresh token is not
+    // accepted and the session must fail rather than loop.
+    #[cfg(feature = "client-oauth")]
+    let mut reauthorized = false;
     loop {
+        let bearer = auth.bearer();
         let mut req = client
             .get(session.url())
             .header(ACCEPT, "application/json, text/event-stream")
             .header(CACHE_CONTROL, "no-cache");
 
-        if let Some(ref access_token) = access_token {
-            req = req.bearer_auth(String::from_utf8_lossy(access_token));
+        if let Some(ref bearer) = bearer {
+            req = req.bearer_auth(bearer);
         }
 
         if let Some(session_id) = session.session_id() {
@@ -310,6 +421,33 @@ async fn handle_sse_connection(
             }
         };
 
+        // A 401 under a managed OAuth session re-runs the authorization
+        // flow once and retries the subscription with the fresh token.
+        #[cfg(feature = "client-oauth")]
+        if resp.status() == reqwest::StatusCode::UNAUTHORIZED
+            && !reauthorized
+            && let ClientAuth::OAuth(oauth) = &auth
+        {
+            let challenge = resp
+                .headers()
+                .get(reqwest::header::WWW_AUTHENTICATE)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_owned);
+            match oauth
+                .authorize(challenge.as_deref(), bearer.as_deref())
+                .await
+            {
+                Ok(_) => {
+                    reauthorized = true;
+                    continue;
+                }
+                Err(_err) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!(logger = "neva", "OAuth authorization failed: {}", _err);
+                }
+            }
+        }
+
         if !resp.status().is_success() {
             #[cfg(feature = "tracing")]
             tracing::error!(
@@ -321,6 +459,11 @@ async fn handle_sse_connection(
             // is unblocked instead of hanging forever.
             session.cancellation_token().cancel();
             return;
+        }
+
+        #[cfg(feature = "client-oauth")]
+        {
+            reauthorized = false;
         }
 
         let mut stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream())

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -46,13 +46,15 @@ enum ClientAuth {
 }
 
 impl ClientAuth {
-    /// The bearer token to attach right now, if any.
-    fn bearer(&self) -> Option<Arc<str>> {
+    /// The bearer token to attach to the next request, if any. Under a
+    /// managed OAuth session a token about to expire is refreshed first
+    /// (non-interactive, when a refresh token is available).
+    async fn fresh_bearer(&self) -> Option<Arc<str>> {
         match self {
             ClientAuth::None => None,
             ClientAuth::Static(token) => Some(token.clone()),
             #[cfg(feature = "client-oauth")]
-            ClientAuth::OAuth(session) => session.bearer(),
+            ClientAuth::OAuth(session) => session.refreshed_bearer().await,
         }
     }
 
@@ -238,7 +240,7 @@ async fn send_request(
     resp_tx: mpsc::Sender<Result<Message, Error>>,
     auth: ClientAuth,
 ) {
-    let bearer = auth.bearer();
+    let bearer = auth.fresh_bearer().await;
     let resp = match build_post(&client, &session, &req, bearer.as_deref())
         .send()
         .await
@@ -393,7 +395,7 @@ async fn handle_sse_connection(
     #[cfg(feature = "client-oauth")]
     let mut reauthorized = false;
     loop {
-        let bearer = auth.bearer();
+        let bearer = auth.fresh_bearer().await;
         let mut req = client
             .get(session.url())
             .header(ACCEPT, "application/json, text/event-stream")

--- a/neva/src/transport/http/client/oauth.rs
+++ b/neva/src/transport/http/client/oauth.rs
@@ -1,0 +1,904 @@
+//! Client-side OAuth 2.1 authorization for the Streamable HTTP transport.
+//!
+//! Implements the MCP authorization sequence on top of
+//! [`volga-oauth-client`](https://docs.rs/volga-oauth-client) (framework
+//! independent — plain hyper): a `401` challenge is parsed for its
+//! `resource_metadata` pointer (RFC 9728 §5.1), the Protected Resource
+//! Metadata and the authorization server metadata are discovered
+//! (RFC 8414, OIDC fallback), the client registers dynamically when no
+//! `client_id` is configured (RFC 7591, `application_type: "native"` for
+//! loopback redirects), and the authorization-code + PKCE flow runs with
+//! the server's canonical URI as the RFC 8707 resource indicator. The
+//! callback is checked for `state` and the RFC 9207 `iss` parameter
+//! before the code is exchanged.
+//!
+//! The interactive step is pluggable through [`AuthorizationHandler`];
+//! the default [`LoopbackHandler`] serves desktop/CLI clients by opening
+//! the system browser and capturing the redirect on a loopback listener.
+
+use futures_util::future::BoxFuture;
+use std::sync::{Arc, RwLock};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    sync::Mutex,
+};
+
+use crate::error::{Error, ErrorCode};
+
+use volga_oauth_client::{
+    AuthorizationServerMetadata, BearerChallenge, ClientConfig, ClientError, ClientMetadata,
+    DiscoveryClient, OAuthClient, RegistrationClient, canonicalize_resource_uri,
+    protected_resource_metadata_url,
+};
+pub use volga_oauth_client::{InMemoryTokenStore, TokenSet, TokenStore};
+
+/// Default time the [`LoopbackHandler`] waits for the user to complete
+/// authorization in the browser.
+const DEFAULT_AUTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Client name sent with dynamic client registration when none is
+/// configured.
+const DEFAULT_CLIENT_NAME: &str = "neva MCP client";
+
+/// The query parameters delivered to the redirect URI by the
+/// authorization server.
+///
+/// Produced by an [`AuthorizationHandler`]; parse a raw query string
+/// with [`CallbackParams::from_query`].
+#[derive(Debug, Clone)]
+pub struct CallbackParams {
+    /// The authorization code to exchange for tokens.
+    pub code: String,
+    /// The `state` echoed back by the server (CSRF check).
+    pub state: String,
+    /// The issuer identifier per RFC 9207, when the server sends one.
+    pub iss: Option<String>,
+}
+
+impl CallbackParams {
+    /// Parses authorization-response query parameters
+    /// (e.g. `"code=abc&state=xyz&iss=https%3A%2F%2Fauth"`).
+    ///
+    /// Returns an error when the response carries an OAuth `error`
+    /// (RFC 6749 §4.1.2.1) or is missing `code`/`state`.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::auth::oauth::CallbackParams;
+    ///
+    /// let params = CallbackParams::from_query("code=abc&state=xyz")?;
+    /// assert_eq!(params.code, "abc");
+    /// # Ok::<(), neva::error::Error>(())
+    /// ```
+    pub fn from_query(query: &str) -> Result<Self, Error> {
+        let mut code = None;
+        let mut state = None;
+        let mut iss = None;
+        let mut error = None;
+        let mut error_description = None;
+
+        for (key, value) in form_urlencoded_parse(query) {
+            match key.as_str() {
+                "code" => code = Some(value),
+                "state" => state = Some(value),
+                "iss" => iss = Some(value),
+                "error" => error = Some(value),
+                "error_description" => error_description = Some(value),
+                _ => {}
+            }
+        }
+
+        if let Some(error) = error {
+            let description = error_description.unwrap_or_default();
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                format!("authorization failed: {error}: {description}"),
+            ));
+        }
+
+        match (code, state) {
+            (Some(code), Some(state)) => Ok(Self { code, state, iss }),
+            _ => Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "authorization response is missing `code` or `state`",
+            )),
+        }
+    }
+}
+
+/// Minimal `application/x-www-form-urlencoded` pair iterator — enough
+/// for authorization-response queries (no `+`-space legacy handling
+/// beyond the standard).
+fn form_urlencoded_parse(query: &str) -> impl Iterator<Item = (String, String)> + '_ {
+    query.split('&').filter_map(|pair| {
+        let (key, value) = pair.split_once('=')?;
+        Some((percent_decode(key)?, percent_decode(value)?))
+    })
+}
+
+/// Percent-decodes a query component (with `+` as space).
+fn percent_decode(s: &str) -> Option<String> {
+    let mut out = Vec::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'%' => {
+                let hex = bytes.get(i + 1..i + 3)?;
+                let hex = std::str::from_utf8(hex).ok()?;
+                out.push(u8::from_str_radix(hex, 16).ok()?);
+                i += 3;
+            }
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8(out).ok()
+}
+
+/// The interactive step of the authorization-code flow: how the
+/// authorization URL is presented to the user and how the redirect
+/// callback comes back.
+///
+/// The default [`LoopbackHandler`] covers desktop/CLI clients. A web or
+/// headless embedder implements this trait to route the URL through its
+/// own UI and deliver the callback parameters however they arrive.
+///
+/// # Example
+/// ```no_run
+/// use futures_util::future::BoxFuture;
+/// use neva::auth::oauth::{AuthorizationHandler, CallbackParams};
+/// use neva::error::Error;
+///
+/// struct MyUi;
+///
+/// impl AuthorizationHandler for MyUi {
+///     fn redirect_uri(&self) -> BoxFuture<'_, Result<String, Error>> {
+///         Box::pin(async { Ok("https://my.app/oauth/callback".into()) })
+///     }
+///     fn authorize(&self, url: String) -> BoxFuture<'_, Result<CallbackParams, Error>> {
+///         Box::pin(async move {
+///             // show `url` to the user, await the callback…
+///             # let _ = url;
+///             todo!()
+///         })
+///     }
+/// }
+/// ```
+pub trait AuthorizationHandler: Send + Sync + 'static {
+    /// The redirect URI the authorization response will be delivered to.
+    ///
+    /// Called once per flow, before dynamic client registration — the
+    /// URI is registered and sent with the authorization request.
+    fn redirect_uri(&self) -> BoxFuture<'_, Result<String, Error>>;
+
+    /// Presents `authorization_url` to the user and returns the callback
+    /// parameters once the authorization server redirects back.
+    fn authorize(&self, authorization_url: String) -> BoxFuture<'_, Result<CallbackParams, Error>>;
+}
+
+/// Default [`AuthorizationHandler`] for desktop/CLI clients: binds a
+/// loopback listener, opens the system browser at the authorization URL
+/// and captures the single redirect request.
+///
+/// The redirect URI is `http://127.0.0.1:{port}/callback` — loopback
+/// redirects are the standard exception to the HTTPS rule for native
+/// clients, and dynamic registration declares such a client as
+/// `application_type: "native"` accordingly.
+///
+/// # Example
+/// ```no_run
+/// use neva::Client;
+/// use neva::auth::oauth::LoopbackHandler;
+///
+/// let mut client = Client::new()
+///     .with_options(|opt| opt
+///         .with_http(|http| http
+///             .with_oauth(|oauth| oauth
+///                 .with_handler(LoopbackHandler::new().with_port(8919)))
+///         )
+///     );
+/// ```
+pub struct LoopbackHandler {
+    port: u16,
+    open_browser: bool,
+    timeout: std::time::Duration,
+    listener: Mutex<Option<TcpListener>>,
+}
+
+impl std::fmt::Debug for LoopbackHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoopbackHandler")
+            .field("port", &self.port)
+            .field("open_browser", &self.open_browser)
+            .field("timeout", &self.timeout)
+            .finish()
+    }
+}
+
+impl Default for LoopbackHandler {
+    fn default() -> Self {
+        Self {
+            port: 0,
+            open_browser: true,
+            timeout: DEFAULT_AUTH_TIMEOUT,
+            listener: Mutex::new(None),
+        }
+    }
+}
+
+impl LoopbackHandler {
+    /// Creates a handler listening on an ephemeral loopback port.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Pins the callback listener to a fixed port — required when the
+    /// authorization server does not allow arbitrary loopback ports on
+    /// the registered redirect URI.
+    pub fn with_port(mut self, port: u16) -> Self {
+        self.port = port;
+        self
+    }
+
+    /// Disables launching the system browser; the authorization URL is
+    /// only logged. For environments that surface the URL elsewhere.
+    pub fn without_browser(mut self) -> Self {
+        self.open_browser = false;
+        self
+    }
+
+    /// Sets how long to wait for the user to complete authorization.
+    ///
+    /// Default: 5 minutes.
+    pub fn with_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+
+    async fn accept_callback(&self) -> Result<CallbackParams, Error> {
+        let listener = self.listener.lock().await.take().ok_or_else(|| {
+            Error::new(
+                ErrorCode::InternalError,
+                "loopback listener is not bound; `redirect_uri` must be called first",
+            )
+        })?;
+
+        let (mut stream, _) = listener.accept().await.map_err(Error::from)?;
+
+        // The callback is a single short GET; the request line is all we
+        // need, but read up to the header terminator to be a good citizen.
+        let mut buf = vec![0u8; 8192];
+        let mut len = 0;
+        loop {
+            let n = stream.read(&mut buf[len..]).await.map_err(Error::from)?;
+            len += n;
+            if n == 0 || len == buf.len() || buf[..len].windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        let params = parse_callback_request(&buf[..len]);
+        let (status, body) = match &params {
+            Ok(_) => (
+                "200 OK",
+                "<html><body><h3>Authorization complete.</h3>You can close this tab and return to the application.</body></html>",
+            ),
+            Err(_) => (
+                "400 Bad Request",
+                "<html><body><h3>Authorization failed.</h3>Check the application logs.</body></html>",
+            ),
+        };
+        let resp = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        // Best-effort: the response only makes the browser tab friendly.
+        let _ = stream.write_all(resp.as_bytes()).await;
+        let _ = stream.shutdown().await;
+
+        params
+    }
+}
+
+/// Extracts the query string out of the callback's request line
+/// (`GET /callback?code=…&state=… HTTP/1.1`) and parses it.
+fn parse_callback_request(raw: &[u8]) -> Result<CallbackParams, Error> {
+    let line = raw
+        .split(|&b| b == b'\r' || b == b'\n')
+        .next()
+        .unwrap_or_default();
+    let line = std::str::from_utf8(line)
+        .map_err(|_| Error::new(ErrorCode::InvalidRequest, "malformed callback request"))?;
+    let target = line
+        .split(' ')
+        .nth(1)
+        .ok_or_else(|| Error::new(ErrorCode::InvalidRequest, "malformed callback request"))?;
+    let query = target.split_once('?').map(|(_, q)| q).unwrap_or_default();
+    CallbackParams::from_query(query)
+}
+
+impl AuthorizationHandler for LoopbackHandler {
+    fn redirect_uri(&self) -> BoxFuture<'_, Result<String, Error>> {
+        Box::pin(async move {
+            let listener = TcpListener::bind(("127.0.0.1", self.port))
+                .await
+                .map_err(Error::from)?;
+            let port = listener.local_addr().map_err(Error::from)?.port();
+            *self.listener.lock().await = Some(listener);
+            Ok(format!("http://127.0.0.1:{port}/callback"))
+        })
+    }
+
+    fn authorize(&self, authorization_url: String) -> BoxFuture<'_, Result<CallbackParams, Error>> {
+        Box::pin(async move {
+            #[cfg(feature = "tracing")]
+            tracing::info!(logger = "neva", "authorize at: {authorization_url}");
+
+            if self.open_browser {
+                open_in_browser(&authorization_url);
+            }
+
+            tokio::time::timeout(self.timeout, self.accept_callback())
+                .await
+                .map_err(|_| Error::new(ErrorCode::InternalError, "authorization timed out"))?
+        })
+    }
+}
+
+/// Launches the system browser at `url`, best-effort — on failure the
+/// URL is still available from the log/handler.
+fn open_in_browser(url: &str) {
+    #[cfg(target_os = "macos")]
+    let result = std::process::Command::new("open").arg(url).spawn();
+    #[cfg(target_os = "linux")]
+    let result = std::process::Command::new("xdg-open").arg(url).spawn();
+    #[cfg(target_os = "windows")]
+    let result = std::process::Command::new("cmd")
+        .args(["/C", "start", "", url])
+        .spawn();
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    let result: std::io::Result<std::process::Child> = Err(std::io::Error::other(
+        "no known browser launcher for this platform",
+    ));
+
+    if let Err(_err) = result {
+        #[cfg(feature = "tracing")]
+        tracing::warn!(logger = "neva", "failed to open the browser: {_err}");
+    }
+}
+
+/// OAuth client configuration, set with
+/// [`HttpClient::with_oauth`](crate::transport::http::HttpClient::with_oauth).
+///
+/// Everything is optional: without a `client_id` the client registers
+/// dynamically (RFC 7591); without scopes the resource's advertised
+/// `scopes_supported` are requested; tokens live in an in-process store
+/// and the interactive step runs through [`LoopbackHandler`] unless
+/// replaced.
+///
+/// # Example
+/// ```no_run
+/// use neva::Client;
+///
+/// let mut client = Client::new()
+///     .with_options(|opt| opt
+///         .with_http(|http| http
+///             .with_oauth(|oauth| oauth.with_scopes(["mcp:tools"]))
+///         )
+///     );
+/// ```
+pub struct OAuthClientConfig {
+    client_id: Option<String>,
+    client_secret: Option<String>,
+    scopes: Option<Vec<String>>,
+    require_https: bool,
+    store: Arc<dyn TokenStore>,
+    handler: Arc<dyn AuthorizationHandler>,
+}
+
+impl std::fmt::Debug for OAuthClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuthClientConfig")
+            .field("client_id", &self.client_id)
+            .field("scopes", &self.scopes)
+            .field("require_https", &self.require_https)
+            .finish()
+    }
+}
+
+impl Default for OAuthClientConfig {
+    fn default() -> Self {
+        Self {
+            client_id: None,
+            client_secret: None,
+            scopes: None,
+            require_https: true,
+            store: Arc::new(InMemoryTokenStore::new()),
+            handler: Arc::new(LoopbackHandler::new()),
+        }
+    }
+}
+
+impl OAuthClientConfig {
+    /// Uses a pre-registered OAuth client id instead of dynamic
+    /// registration.
+    pub fn with_client_id(mut self, client_id: impl Into<String>) -> Self {
+        self.client_id = Some(client_id.into());
+        self
+    }
+
+    /// Makes this a confidential client authenticating to the token
+    /// endpoint with `client_secret`. Only meaningful together with
+    /// [`with_client_id`](Self::with_client_id).
+    pub fn with_client_secret(mut self, secret: impl Into<String>) -> Self {
+        self.client_secret = Some(secret.into());
+        self
+    }
+
+    /// Sets the scopes to request. Defaults to the resource's advertised
+    /// `scopes_supported`.
+    pub fn with_scopes<I, S>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.scopes = Some(scopes.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Controls whether plain `http://` discovery/token endpoints are
+    /// rejected. Enabled by default; disable only against a local
+    /// development issuer.
+    pub fn require_https(mut self, required: bool) -> Self {
+        self.require_https = required;
+        self
+    }
+
+    /// Replaces the in-process token store with a custom
+    /// [`TokenStore`] (encrypted file, OS keychain, …).
+    pub fn with_token_store(mut self, store: impl TokenStore + 'static) -> Self {
+        self.store = Arc::new(store);
+        self
+    }
+
+    /// Replaces the interactive step with a custom
+    /// [`AuthorizationHandler`].
+    pub fn with_handler(mut self, handler: impl AuthorizationHandler) -> Self {
+        self.handler = Arc::new(handler);
+        self
+    }
+
+    fn client_config(&self) -> ClientConfig {
+        ClientConfig::new().require_https(self.require_https)
+    }
+}
+
+/// Per-connection OAuth state: the current access token and the
+/// single-flight authorization flow.
+pub(crate) struct OAuthSession {
+    config: OAuthClientConfig,
+    /// Canonicalized server URL — the RFC 8707 resource indicator and
+    /// the token-store key.
+    resource: String,
+    /// Current bearer token, read on every outgoing request.
+    token: RwLock<Option<Arc<str>>>,
+    /// Serializes authorization flows: concurrent 401s run one flow.
+    flow: Mutex<()>,
+}
+
+impl std::fmt::Debug for OAuthSession {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuthSession")
+            .field("resource", &self.resource)
+            .finish()
+    }
+}
+
+impl OAuthSession {
+    /// Builds a session for the MCP server at `server_url`.
+    pub(crate) fn new(config: OAuthClientConfig, server_url: &str) -> Result<Self, Error> {
+        let resource = canonicalize_resource_uri(server_url)
+            .map_err(|err| Error::new(ErrorCode::InternalError, err.to_string()))?;
+        let token = config
+            .store
+            .get(&resource)
+            .filter(|tokens| !tokens.is_expired())
+            .map(|tokens| tokens.access_token.into());
+        Ok(Self {
+            config,
+            resource,
+            token: RwLock::new(token),
+            flow: Mutex::new(()),
+        })
+    }
+
+    /// The current bearer token, if any.
+    pub(crate) fn bearer(&self) -> Option<Arc<str>> {
+        self.token
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Runs the authorization flow triggered by a `401` and returns the
+    /// fresh bearer token.
+    ///
+    /// `www_authenticate` is the challenge header value, when present —
+    /// its `resource_metadata` pointer takes precedence over well-known
+    /// derivation. `used` is the token the failed request carried:
+    /// concurrent callers that lost the race simply pick up the token
+    /// the winning flow produced.
+    pub(crate) async fn authorize(
+        &self,
+        www_authenticate: Option<&str>,
+        used: Option<&str>,
+    ) -> Result<Arc<str>, Error> {
+        let _flight = self.flow.lock().await;
+
+        // Someone else completed the flow while this caller waited.
+        if let Some(current) = self.bearer()
+            && used != Some(&*current)
+        {
+            return Ok(current);
+        }
+
+        let metadata_url = www_authenticate
+            .and_then(|header| BearerChallenge::parse(header).ok())
+            .and_then(|challenge| challenge.resource_metadata().map(str::to_owned));
+        let metadata_url = match metadata_url {
+            Some(url) => url,
+            None => protected_resource_metadata_url(&self.resource)
+                .map_err(|err| Error::new(ErrorCode::InternalError, err.to_string()))?,
+        };
+
+        let discovery = DiscoveryClient::with_config(self.config.client_config());
+        let resource_metadata = discovery
+            .fetch_resource_metadata_from_url(&metadata_url, Some(&self.resource))
+            .await
+            .map_err(flow_error)?;
+        let server_metadata = discovery
+            .discover_authorization_server(&resource_metadata)
+            .await
+            .map_err(flow_error)?;
+
+        let redirect_uri = self.config.handler.redirect_uri().await?;
+        let client = self.build_client(&server_metadata, &redirect_uri).await?;
+
+        let scopes = self
+            .config
+            .scopes
+            .clone()
+            .unwrap_or_else(|| resource_metadata.scopes_supported.clone());
+        let request = client
+            .authorization_request(&server_metadata)
+            .with_scopes(scopes)
+            .with_resource(self.resource.clone())
+            .build()
+            .map_err(flow_error)?;
+
+        let params = self.config.handler.authorize(request.url.clone()).await?;
+
+        if !request.matches_state(&params.state) {
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "authorization response `state` mismatch",
+            ));
+        }
+        validate_issuer(&params, &server_metadata)?;
+
+        let tokens = exchange_code(client, server_metadata, params, request).await?;
+
+        self.config.store.put(&self.resource, &tokens);
+        let token: Arc<str> = tokens.access_token.into();
+        *self
+            .token
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(token.clone());
+        Ok(token)
+    }
+
+    /// Builds the [`OAuthClient`] — from the configured `client_id` or
+    /// through dynamic registration (RFC 7591).
+    async fn build_client(
+        &self,
+        server_metadata: &AuthorizationServerMetadata,
+        redirect_uri: &str,
+    ) -> Result<OAuthClient, Error> {
+        let client = match &self.config.client_id {
+            Some(client_id) => {
+                let mut client = OAuthClient::new(client_id.clone());
+                if let Some(secret) = &self.config.client_secret {
+                    client = client.with_secret(secret.clone());
+                }
+                client
+            }
+            None => {
+                let registration = RegistrationClient::with_config(self.config.client_config());
+                let response = registration
+                    .register(server_metadata, &registration_metadata(redirect_uri))
+                    .await
+                    .map_err(flow_error)?;
+                OAuthClient::from_registration(&response).map_err(flow_error)?
+            }
+        };
+        Ok(client
+            .with_config(self.config.client_config())
+            .with_redirect_uri(redirect_uri)
+            .with_token_store(self.config.store.clone()))
+    }
+}
+
+/// Builds the RFC 7591 registration document for a public
+/// authorization-code client.
+///
+/// A loopback redirect URI makes this a **native** client
+/// (`application_type: "native"`) — authorization servers reject `web`
+/// clients with plain-http loopback redirects, which is exactly the
+/// desktop/CLI case.
+fn registration_metadata(redirect_uri: &str) -> ClientMetadata {
+    let mut metadata = ClientMetadata::default()
+        .with_redirect_uris([redirect_uri])
+        .with_grant_types(["authorization_code", "refresh_token"])
+        .with_response_types(["code"])
+        .with_token_endpoint_auth_method("none")
+        .with_client_name(DEFAULT_CLIENT_NAME);
+    if is_loopback_redirect(redirect_uri) {
+        metadata = metadata.with_additional_field("application_type", "native");
+    }
+    metadata
+}
+
+/// Whether `uri` redirects to a loopback interface (`127.0.0.1`,
+/// `localhost` or `[::1]`), per the native-client loopback exception.
+fn is_loopback_redirect(uri: &str) -> bool {
+    let Some(rest) = uri
+        .strip_prefix("http://")
+        .or_else(|| uri.strip_prefix("https://"))
+    else {
+        return false;
+    };
+    let authority = rest.split(['/', '?']).next().unwrap_or_default();
+    // Bracketed IPv6 hosts carry colons of their own — split on the
+    // closing bracket first, then strip a `:port` for everything else.
+    let host = match authority.split_once(']') {
+        Some((bracketed, _)) => &authority[..bracketed.len() + 1],
+        None => authority
+            .rsplit_once(':')
+            .map_or(authority, |(host, _port)| host),
+    };
+    matches!(host, "127.0.0.1" | "localhost" | "[::1]")
+}
+
+/// Validates the RFC 9207 `iss` authorization-response parameter.
+///
+/// When the server metadata advertises
+/// `authorization_response_iss_parameter_supported`, the parameter is
+/// required and must match the issuer; when it is merely present, it
+/// must still match. A mismatch means the response may come from a
+/// different (potentially malicious) authorization server — mix-up
+/// attack — and aborts the flow.
+fn validate_issuer(
+    params: &CallbackParams,
+    metadata: &AuthorizationServerMetadata,
+) -> Result<(), Error> {
+    let supported = metadata
+        .additional_fields
+        .get("authorization_response_iss_parameter_supported")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    match (&params.iss, supported) {
+        (Some(iss), _) if *iss != metadata.issuer => Err(Error::new(
+            ErrorCode::InvalidRequest,
+            format!(
+                "authorization response `iss` mismatch: expected {}, got {iss}",
+                metadata.issuer
+            ),
+        )),
+        (None, true) => Err(Error::new(
+            ErrorCode::InvalidRequest,
+            "authorization server advertises RFC 9207 but the response carries no `iss`",
+        )),
+        _ => Ok(()),
+    }
+}
+
+/// Exchanges the authorization code for tokens on a dedicated
+/// current-thread runtime.
+///
+/// `OAuthClient::exchange_code` in volga-oauth-client 0.9.5 holds a
+/// `form_urlencoded::Serializer` across an `.await`, which makes its
+/// future `!Send` — it cannot run inside neva's spawned request tasks
+/// directly. The token exchange is a single short round-trip at the end
+/// of an interactive flow, so bridging it through `spawn_blocking` is
+/// invisible in practice. Drop this bridge once upstream releases a
+/// `Send` `exchange_code`.
+async fn exchange_code(
+    client: OAuthClient,
+    server_metadata: AuthorizationServerMetadata,
+    params: CallbackParams,
+    request: volga_oauth_client::AuthorizationRequest,
+) -> Result<TokenSet, Error> {
+    tokio::task::spawn_blocking(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(Error::from)?;
+        rt.block_on(client.exchange_code(&server_metadata, &params.code, &request))
+            .map_err(flow_error)
+    })
+    .await
+    .map_err(|err| Error::new(ErrorCode::InternalError, err.to_string()))?
+}
+
+/// Maps a `volga-oauth-client` failure onto neva's error type.
+fn flow_error(err: ClientError) -> Error {
+    Error::new(
+        ErrorCode::InternalError,
+        format!("OAuth flow failed: {err}"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_parses_callback_query() {
+        let params =
+            CallbackParams::from_query("code=abc&state=xyz&iss=https%3A%2F%2Fauth.example.com")
+                .unwrap();
+        assert_eq!(params.code, "abc");
+        assert_eq!(params.state, "xyz");
+        assert_eq!(params.iss.as_deref(), Some("https://auth.example.com"));
+    }
+
+    #[test]
+    fn it_rejects_error_responses() {
+        let err = CallbackParams::from_query("error=access_denied&error_description=nope&state=s")
+            .unwrap_err();
+        assert!(err.to_string().contains("access_denied"));
+    }
+
+    #[test]
+    fn it_rejects_missing_code_or_state() {
+        assert!(CallbackParams::from_query("code=abc").is_err());
+        assert!(CallbackParams::from_query("state=xyz").is_err());
+    }
+
+    #[test]
+    fn loopback_redirects_are_detected() {
+        assert!(is_loopback_redirect("http://127.0.0.1:8919/callback"));
+        assert!(is_loopback_redirect("http://localhost/callback"));
+        assert!(is_loopback_redirect("http://[::1]:9000/callback"));
+        assert!(!is_loopback_redirect("https://my.app/oauth/callback"));
+        assert!(!is_loopback_redirect("res://localhost"));
+    }
+
+    #[test]
+    fn loopback_registration_declares_a_native_client() {
+        let metadata = registration_metadata("http://127.0.0.1:8919/callback");
+        assert_eq!(
+            metadata.additional_fields.get("application_type"),
+            Some(&serde_json::Value::from("native"))
+        );
+        assert_eq!(metadata.token_endpoint_auth_method.as_deref(), Some("none"));
+    }
+
+    #[test]
+    fn web_registration_stays_a_web_client() {
+        let metadata = registration_metadata("https://my.app/oauth/callback");
+        assert!(!metadata.additional_fields.contains_key("application_type"));
+    }
+
+    fn as_metadata(supported: Option<bool>) -> AuthorizationServerMetadata {
+        let mut metadata = AuthorizationServerMetadata::new("https://auth.example.com");
+        if let Some(supported) = supported {
+            metadata = metadata
+                .with_additional_field("authorization_response_iss_parameter_supported", supported);
+        }
+        metadata
+    }
+
+    fn callback(iss: Option<&str>) -> CallbackParams {
+        CallbackParams {
+            code: "c".into(),
+            state: "s".into(),
+            iss: iss.map(str::to_owned),
+        }
+    }
+
+    #[test]
+    fn iss_mismatch_is_rejected() {
+        let err = validate_issuer(
+            &callback(Some("https://evil.example.com")),
+            &as_metadata(None),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("mismatch"));
+    }
+
+    #[test]
+    fn missing_iss_with_rfc9207_support_is_rejected() {
+        assert!(validate_issuer(&callback(None), &as_metadata(Some(true))).is_err());
+    }
+
+    #[test]
+    fn matching_iss_passes() {
+        assert!(
+            validate_issuer(
+                &callback(Some("https://auth.example.com")),
+                &as_metadata(Some(true))
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn missing_iss_without_support_passes() {
+        assert!(validate_issuer(&callback(None), &as_metadata(None)).is_ok());
+        assert!(validate_issuer(&callback(None), &as_metadata(Some(false))).is_ok());
+    }
+
+    #[tokio::test]
+    async fn loopback_handler_round_trip() {
+        let handler = LoopbackHandler::new().without_browser();
+        let redirect = handler.redirect_uri().await.unwrap();
+        assert!(redirect.starts_with("http://127.0.0.1:"));
+
+        let addr = redirect
+            .strip_prefix("http://")
+            .and_then(|rest| rest.split('/').next())
+            .unwrap()
+            .to_owned();
+
+        // Simulate the browser being redirected back by the AS.
+        let callback = tokio::spawn(async move {
+            let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+            stream
+                .write_all(b"GET /callback?code=abc&state=xyz HTTP/1.1\r\nHost: x\r\n\r\n")
+                .await
+                .unwrap();
+            let mut resp = String::new();
+            stream.read_to_string(&mut resp).await.unwrap();
+            resp
+        });
+
+        let params = handler
+            .authorize("http://unused.example".into())
+            .await
+            .unwrap();
+        assert_eq!(params.code, "abc");
+        assert_eq!(params.state, "xyz");
+
+        let browser_view = callback.await.unwrap();
+        assert!(browser_view.starts_with("HTTP/1.1 200"));
+    }
+
+    #[tokio::test]
+    async fn session_serves_stored_unexpired_token() {
+        let store = InMemoryTokenStore::new();
+        store.put(
+            "http://127.0.0.1:3000/mcp",
+            &TokenSet {
+                access_token: "stored-token".into(),
+                token_type: "Bearer".into(),
+                refresh_token: None,
+                scope: None,
+                id_token: None,
+                expires_at: None,
+            },
+        );
+        let config = OAuthClientConfig::default().with_token_store(store);
+        let session = OAuthSession::new(config, "http://127.0.0.1:3000/mcp").unwrap();
+        assert_eq!(session.bearer().as_deref(), Some("stored-token"));
+    }
+}

--- a/neva/src/transport/http/client/oauth.rs
+++ b/neva/src/transport/http/client/oauth.rs
@@ -698,7 +698,7 @@ impl OAuthSession {
             client,
             metadata: server_metadata,
         });
-        
+
         let token: Arc<str> = tokens.access_token.into();
         self.set_token(token.clone());
         Ok(token)

--- a/neva/src/transport/http/client/oauth.rs
+++ b/neva/src/transport/http/client/oauth.rs
@@ -17,6 +17,7 @@
 //! the system browser and capturing the redirect on a loopback listener.
 
 use futures_util::future::BoxFuture;
+use std::future::Future;
 use std::sync::{Arc, RwLock};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -481,6 +482,19 @@ impl OAuthClientConfig {
     }
 }
 
+/// The OAuth client and authorization-server metadata retained from the
+/// last successful flow — everything a non-interactive token refresh
+/// needs.
+struct FlowState {
+    client: OAuthClient,
+    metadata: AuthorizationServerMetadata,
+}
+
+/// How early before expiration a stored access token is proactively
+/// refreshed. Mirrors the leeway `OAuthClient::token` applies, so the
+/// cheap staleness probe and the actual refresh decision agree.
+const REFRESH_LEEWAY: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Per-connection OAuth state: the current access token and the
 /// single-flight authorization flow.
 pub(crate) struct OAuthSession {
@@ -490,8 +504,9 @@ pub(crate) struct OAuthSession {
     resource: String,
     /// Current bearer token, read on every outgoing request.
     token: RwLock<Option<Arc<str>>>,
-    /// Serializes authorization flows: concurrent 401s run one flow.
-    flow: Mutex<()>,
+    /// Serializes authorization flows (concurrent 401s run one flow) and
+    /// caches the client + metadata for non-interactive refresh.
+    flow: Mutex<Option<FlowState>>,
 }
 
 impl std::fmt::Debug for OAuthSession {
@@ -516,7 +531,7 @@ impl OAuthSession {
             config,
             resource,
             token: RwLock::new(token),
-            flow: Mutex::new(()),
+            flow: Mutex::new(None),
         })
     }
 
@@ -526,6 +541,76 @@ impl OAuthSession {
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
+    }
+
+    fn set_token(&self, token: Arc<str>) {
+        *self
+            .token
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(token);
+    }
+
+    /// The bearer token to attach to the next request, proactively
+    /// refreshed when the stored set is about to expire and a refresh
+    /// token is available — the session then renews without user
+    /// interaction. Falls back to the current token when refresh is not
+    /// possible; the `401` path handles the rest.
+    pub(crate) async fn refreshed_bearer(&self) -> Option<Arc<str>> {
+        // Cheap staleness probe before taking the flow lock.
+        let stale = self
+            .config
+            .store
+            .get(&self.resource)
+            .is_some_and(|tokens| tokens.expires_within(REFRESH_LEEWAY));
+
+        if !stale {
+            return self.bearer();
+        }
+
+        let mut flow = self.flow.lock().await;
+        self.maintain(&mut flow).await.or_else(|| self.bearer())
+    }
+
+    /// Non-interactive token maintenance through the cached client:
+    /// serves the stored set, refreshing it when stale (rotation
+    /// carry-over and dead-entry pruning included, via
+    /// `OAuthClient::token`). Returns `None` when interactive
+    /// authorization is required or no flow has completed yet.
+    async fn maintain(&self, state: &mut Option<FlowState>) -> Option<Arc<str>> {
+        let FlowState { client, metadata } = state.take()?;
+        let key = self.resource.clone();
+        let outcome = run_non_send(move || async move {
+            let result = client.token(&key, &metadata).await;
+            Ok((client, metadata, result))
+        })
+        .await;
+
+        match outcome {
+            Ok((client, metadata, result)) => {
+                *state = Some(FlowState { client, metadata });
+                match result {
+                    Ok(Some(tokens)) => {
+                        let token: Arc<str> = tokens.access_token.into();
+                        self.set_token(token.clone());
+                        Some(token)
+                    }
+                    // Nothing renewable — interactive authorization it is.
+                    Ok(None) => None,
+                    // Transient failure (issuer unreachable): keep the
+                    // current token and let the request outcome decide.
+                    Err(_err) => {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(logger = "neva", "token refresh failed: {_err}");
+                        None
+                    }
+                }
+            }
+            Err(_err) => {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(logger = "neva", "token refresh failed: {_err}");
+                None
+            }
+        }
     }
 
     /// Runs the authorization flow triggered by a `401` and returns the
@@ -541,13 +626,22 @@ impl OAuthSession {
         www_authenticate: Option<&str>,
         used: Option<&str>,
     ) -> Result<Arc<str>, Error> {
-        let _flight = self.flow.lock().await;
+        let mut flight = self.flow.lock().await;
 
         // Someone else completed the flow while this caller waited.
         if let Some(current) = self.bearer()
             && used != Some(&*current)
         {
             return Ok(current);
+        }
+
+        // Refresh before interrupting the user: a stored refresh token
+        // renews the session silently. A token identical to the rejected
+        // one is no help though (revoked server-side) — interactive then.
+        if let Some(token) = self.maintain(&mut flight).await
+            && used != Some(&*token)
+        {
+            return Ok(token);
         }
 
         let metadata_url = www_authenticate
@@ -594,14 +688,19 @@ impl OAuthSession {
         }
         validate_issuer(&params, &server_metadata)?;
 
-        let tokens = exchange_code(client, server_metadata, params, request).await?;
+        let (client, server_metadata, tokens) =
+            exchange_code(client, server_metadata, params, request).await?;
 
         self.config.store.put(&self.resource, &tokens);
+        // Keep the client + metadata so future refreshes stay
+        // non-interactive.
+        *flight = Some(FlowState {
+            client,
+            metadata: server_metadata,
+        });
+        
         let token: Arc<str> = tokens.access_token.into();
-        *self
-            .token
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(token.clone());
+        self.set_token(token.clone());
         Ok(token)
     }
 
@@ -711,29 +810,46 @@ fn validate_issuer(
     }
 }
 
-/// Exchanges the authorization code for tokens on a dedicated
-/// current-thread runtime.
-///
-/// `OAuthClient::exchange_code` in volga-oauth-client 0.9.5 holds a
-/// `form_urlencoded::Serializer` across an `.await`, which makes its
-/// future `!Send` — it cannot run inside neva's spawned request tasks
-/// directly. The token exchange is a single short round-trip at the end
-/// of an interactive flow, so bridging it through `spawn_blocking` is
-/// invisible in practice. Drop this bridge once upstream releases a
-/// `Send` `exchange_code`.
+/// Exchanges the authorization code for tokens, returning the client
+/// and metadata back for the session's refresh cache.
 async fn exchange_code(
     client: OAuthClient,
     server_metadata: AuthorizationServerMetadata,
     params: CallbackParams,
     request: volga_oauth_client::AuthorizationRequest,
-) -> Result<TokenSet, Error> {
+) -> Result<(OAuthClient, AuthorizationServerMetadata, TokenSet), Error> {
+    run_non_send(move || async move {
+        let tokens = client
+            .exchange_code(&server_metadata, &params.code, &request)
+            .await
+            .map_err(flow_error)?;
+        Ok((client, server_metadata, tokens))
+    })
+    .await
+}
+
+/// Runs a token-endpoint future to completion on a dedicated
+/// current-thread runtime.
+///
+/// `OAuthClient::exchange_code` / `refresh` in volga-oauth-client 0.9.5
+/// hold a `form_urlencoded::Serializer` across an `.await`, which makes
+/// their futures `!Send` — they cannot run inside neva's spawned request
+/// tasks directly. These are single short round-trips (end of an
+/// interactive flow, or a rare refresh), so bridging them through
+/// `spawn_blocking` is invisible in practice. Drop this bridge once
+/// upstream ships `Send` token-endpoint futures.
+async fn run_non_send<T, F, Fut>(f: F) -> Result<T, Error>
+where
+    F: FnOnce() -> Fut + Send + 'static,
+    Fut: Future<Output = Result<T, Error>>,
+    T: Send + 'static,
+{
     tokio::task::spawn_blocking(move || {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
             .map_err(Error::from)?;
-        rt.block_on(client.exchange_code(&server_metadata, &params.code, &request))
-            .map_err(flow_error)
+        rt.block_on(f())
     })
     .await
     .map_err(|err| Error::new(ErrorCode::InternalError, err.to_string()))?
@@ -881,6 +997,111 @@ mod tests {
 
         let browser_view = callback.await.unwrap();
         assert!(browser_view.starts_with("HTTP/1.1 200"));
+    }
+
+    /// Serves one canned token-endpoint response over raw HTTP and
+    /// returns the bound address.
+    async fn spawn_token_endpoint(body: &'static str) -> std::net::SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf).await;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(resp.as_bytes()).await.unwrap();
+        });
+        addr
+    }
+
+    fn stale_tokens() -> TokenSet {
+        TokenSet {
+            access_token: "stale-token".into(),
+            token_type: "Bearer".into(),
+            refresh_token: Some("refresh-1".into()),
+            scope: None,
+            id_token: None,
+            expires_at: Some(std::time::SystemTime::now()),
+        }
+    }
+
+    fn session_with(store: Arc<dyn TokenStore>, flow: Option<FlowState>) -> OAuthSession {
+        let config = OAuthClientConfig {
+            store,
+            ..OAuthClientConfig::default()
+        };
+        OAuthSession {
+            config,
+            resource: "http://127.0.0.1:3000/mcp".into(),
+            token: RwLock::new(Some("stale-token".into())),
+            flow: Mutex::new(flow),
+        }
+    }
+
+    #[tokio::test]
+    async fn stale_token_is_refreshed_without_interaction() {
+        let addr = spawn_token_endpoint(
+            r#"{"access_token":"fresh-token","token_type":"Bearer","expires_in":3600}"#,
+        )
+        .await;
+
+        let store: Arc<dyn TokenStore> = Arc::new(InMemoryTokenStore::new());
+        store.put("http://127.0.0.1:3000/mcp", &stale_tokens());
+
+        let flow = FlowState {
+            client: OAuthClient::new("cid")
+                .with_config(ClientConfig::new().require_https(false))
+                .with_token_store(store.clone()),
+            metadata: AuthorizationServerMetadata::new("http://issuer.local")
+                .with_token_endpoint(format!("http://{addr}/token")),
+        };
+        let session = session_with(store.clone(), Some(flow));
+
+        let token = session.refreshed_bearer().await;
+
+        assert_eq!(token.as_deref(), Some("fresh-token"));
+        let stored = store.get("http://127.0.0.1:3000/mcp").unwrap();
+        assert_eq!(stored.access_token, "fresh-token");
+        // No rotation in the response — the old refresh token carries over.
+        assert_eq!(stored.refresh_token.as_deref(), Some("refresh-1"));
+        // The flow state survives for the next refresh.
+        assert!(session.flow.lock().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn fresh_token_skips_refresh() {
+        let store: Arc<dyn TokenStore> = Arc::new(InMemoryTokenStore::new());
+        let mut tokens = stale_tokens();
+        tokens.expires_at =
+            Some(std::time::SystemTime::now() + std::time::Duration::from_secs(3600));
+        store.put("http://127.0.0.1:3000/mcp", &tokens);
+
+        // No flow state — a refresh attempt would return None; a fresh
+        // token must never get that far.
+        let session = session_with(store, None);
+
+        assert_eq!(
+            session.refreshed_bearer().await.as_deref(),
+            Some("stale-token")
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_token_without_flow_state_stays_usable() {
+        let store: Arc<dyn TokenStore> = Arc::new(InMemoryTokenStore::new());
+        store.put("http://127.0.0.1:3000/mcp", &stale_tokens());
+
+        let session = session_with(store, None);
+
+        // Nothing to refresh with — the current token is returned and
+        // the 401 path decides what happens next.
+        assert_eq!(
+            session.refreshed_bearer().await.as_deref(),
+            Some("stale-token")
+        );
     }
 
     #[tokio::test]

--- a/neva/src/transport/http/core/context.rs
+++ b/neva/src/transport/http/core/context.rs
@@ -71,4 +71,16 @@ impl HttpContext {
     pub fn oauth_metadata_url(&self) -> Option<&str> {
         self.oauth.as_ref().map(|o| &*o.metadata_url)
     }
+
+    /// The canonicalized resource identifier (RFC 8707) this server is
+    /// deployed as (e.g. `"https://api.example.com/mcp"`), when OAuth is
+    /// configured.
+    ///
+    /// This is the audience value access tokens must be bound to — the
+    /// default Volga adapter feeds it into bearer validation as a
+    /// required `aud`; a custom engine should enforce the same check.
+    #[cfg(feature = "server-oauth")]
+    pub fn oauth_resource(&self) -> Option<&str> {
+        self.oauth.as_ref().map(|o| &*o.resource)
+    }
 }

--- a/neva/src/transport/http/core/oauth.rs
+++ b/neva/src/transport/http/core/oauth.rs
@@ -177,6 +177,7 @@ impl OAuthResourceOptions {
             metadata_path: well_known_path(&metadata_url).into(),
             metadata_url: metadata_url.into(),
             challenge: challenge.into(),
+            resource: metadata.resource.into(),
         })
     }
 }
@@ -198,6 +199,9 @@ pub(crate) struct OAuthResource {
     pub(crate) metadata_path: Arc<str>,
     /// Pre-rendered `WWW-Authenticate` header value.
     pub(crate) challenge: Arc<str>,
+    /// Canonicalized resource identifier (RFC 8707) — the audience value
+    /// access tokens must be bound to.
+    pub(crate) resource: Arc<str>,
 }
 
 /// Strips the scheme and authority off an absolute URL, leaving the path.

--- a/neva/src/transport/http/server/volga/auth_config.rs
+++ b/neva/src/transport/http/server/volga/auth_config.rs
@@ -2,6 +2,8 @@
 
 use crate::transport::http::core::types::DefaultClaims;
 use std::fmt::Debug;
+#[cfg(feature = "server-oauth")]
+use volga::auth::OAuthConfig as VolgaOAuthConfig;
 use volga::auth::{Algorithm, AuthClaims, Authorizer, BearerAuthConfig, DecodingKey, predicate};
 
 // Bridge Volga's `AuthClaims` onto neva's canonical, engine-agnostic
@@ -29,7 +31,24 @@ impl AuthClaims for DefaultClaims {
 /// Represents authentication and authorization configuration
 pub struct AuthConfig<C: AuthClaims = DefaultClaims> {
     inner: BearerAuthConfig,
+
     authorizer: Authorizer<C>,
+
+    /// Whether the user configured an audience themselves (via
+    /// [`with_aud`](Self::with_aud) / [`with_resource`](Self::with_resource) /
+    /// [`with_resources`](Self::with_resources)) — suppresses the
+    /// OAuth-mode default of binding tokens to the canonical resource URI.
+    #[cfg(feature = "server-oauth")]
+    aud_configured: bool,
+
+    /// Whether the user configured acceptable issuers themselves —
+    /// suppresses the OAuth-mode default of requiring the configured
+    /// issuer.
+    #[cfg(feature = "server-oauth")]
+    iss_configured: bool,
+
+    #[cfg(feature = "server-oauth")]
+    oauth: Option<OAuthConfig>,
 }
 
 impl Debug for AuthConfig {
@@ -45,6 +64,12 @@ impl Default for AuthConfig {
         Self {
             inner: BearerAuthConfig::default(),
             authorizer: default_auth_rules(),
+            #[cfg(feature = "server-oauth")]
+            aud_configured: false,
+            #[cfg(feature = "server-oauth")]
+            iss_configured: false,
+            #[cfg(feature = "server-oauth")]
+            oauth: None,
         }
     }
 }
@@ -71,6 +96,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     /// # Example
     /// ```no_run
     /// use neva::{App, auth::Algorithm};
+    ///
     /// let app = App::new()
     ///     .with_options(|opt| opt
     ///         .with_http(|http| http
@@ -88,6 +114,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     /// # Example
     /// ```no_run
     /// use neva::App;
+    ///
     /// let app = App::new()
     ///     .with_options(|opt| opt
     ///         .with_http(|http| http
@@ -101,6 +128,62 @@ impl<C: AuthClaims> AuthConfig<C> {
         I: AsRef<[T]>,
     {
         self.inner = self.inner.with_aud(aud);
+        #[cfg(feature = "server-oauth")]
+        {
+            self.aud_configured = true;
+        }
+        self
+    }
+
+    /// Adds an OAuth 2.0 resource indicator (RFC 8707): the URI joins the
+    /// accepted audience set and the `aud` claim becomes required in
+    /// tokens.
+    ///
+    /// In OAuth issuer mode this is set automatically to the server's
+    /// canonical resource URI — call it only to accept a different
+    /// audience (e.g. a public URL behind a reverse proxy).
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_auth(|auth| auth.with_resource("https://api.example.com/mcp"))
+    ///         )
+    ///     );
+    /// ```
+    #[cfg(feature = "server-oauth")]
+    pub fn with_resource(mut self, uri: impl Into<String>) -> Self {
+        self.inner = self.inner.with_resource(uri);
+        self.aud_configured = true;
+        self
+    }
+
+    /// Adds multiple OAuth 2.0 resource indicators (RFC 8707). See
+    /// [`with_resource`](Self::with_resource).
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_auth(|auth| auth
+    ///                 .with_resources(["https://api.example.com/mcp"]))
+    ///         )
+    ///     );
+    /// ```
+    #[cfg(feature = "server-oauth")]
+    pub fn with_resources<I, U>(mut self, uris: I) -> Self
+    where
+        I: IntoIterator<Item = U>,
+        U: Into<String>,
+    {
+        self.inner = self.inner.with_resources(uris);
+        self.aud_configured = true;
         self
     }
 
@@ -109,6 +192,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     /// # Example
     /// ```no_run
     /// use neva::App;
+    ///
     /// let app = App::new()
     ///     .with_options(|opt| opt
     ///         .with_http(|http| http
@@ -122,6 +206,10 @@ impl<C: AuthClaims> AuthConfig<C> {
         I: AsRef<[T]>,
     {
         self.inner = self.inner.with_iss(iss);
+        #[cfg(feature = "server-oauth")]
+        {
+            self.iss_configured = true;
+        }
         self
     }
 
@@ -135,6 +223,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     /// # Example
     /// ```no_run
     /// use neva::App;
+    ///
     /// let app = App::new()
     ///     .with_options(|opt| opt
     ///         .with_http(|http| http
@@ -156,6 +245,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     /// # Example
     /// ```no_run
     /// use neva::App;
+    ///
     /// let app = App::new()
     ///     .with_options(|opt| opt
     ///         .with_http(|http| http
@@ -178,6 +268,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     /// # Example
     /// ```no_run
     /// use neva::App;
+    ///
     /// let app = App::new()
     ///     .with_options(|opt| opt
     ///         .with_http(|http| http
@@ -190,9 +281,212 @@ impl<C: AuthClaims> AuthConfig<C> {
         self
     }
 
+    /// Switches token validation to OAuth 2.1/OIDC issuer mode: instead
+    /// of a static decoding key, the issuer's JSON Web Key Set is
+    /// discovered (RFC 8414, with an OIDC fallback) and used to validate
+    /// incoming JWTs, keyed by each token's `kid` — with rotation,
+    /// refresh cooldown and key-age limits handled by Volga.
+    ///
+    /// MCP defaults applied automatically unless overridden: the token's
+    /// `aud` must contain the server's canonical resource URI (RFC 8707;
+    /// override via [`with_aud`](Self::with_aud) /
+    /// [`with_resource`](Self::with_resource)) and its `iss` must match
+    /// the configured issuer (override via [`with_iss`](Self::with_iss)).
+    /// The Protected Resource Metadata document is derived from the
+    /// issuer too, when not configured explicitly.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_auth(|auth| auth
+    ///                 .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com")))
+    ///         )
+    ///     );
+    /// ```
+    #[cfg(feature = "server-oauth")]
+    pub fn with_oauth<F>(mut self, config: F) -> Self
+    where
+        F: FnOnce(OAuthConfig) -> OAuthConfig,
+    {
+        self.oauth = Some(config(OAuthConfig::default()));
+        self
+    }
+
+    /// The issuer configured through [`with_oauth`](Self::with_oauth),
+    /// if any — used by the transport to seed the Protected Resource
+    /// Metadata document when it was not configured explicitly.
+    #[cfg(feature = "server-oauth")]
+    pub(crate) fn oauth_issuer(&self) -> Option<&str> {
+        self.oauth.as_ref().and_then(|o| o.issuer.as_deref())
+    }
+
+    /// Applies the MCP token-validation defaults for OAuth issuer mode:
+    /// audience = the canonical resource URI (RFC 8707, `aud` becomes
+    /// required) and issuer = the configured issuer. No-ops for anything
+    /// the user configured explicitly, and entirely outside OAuth mode.
+    #[cfg(feature = "server-oauth")]
+    pub(crate) fn apply_mcp_defaults(&mut self, resource: Option<&str>) {
+        let Some(oauth) = &self.oauth else {
+            return;
+        };
+        if !self.iss_configured
+            && let Some(issuer) = oauth.issuer.as_deref()
+        {
+            let issuer = issuer.to_owned();
+            self.inner = std::mem::take(&mut self.inner).with_iss([issuer]);
+        }
+        if !self.aud_configured
+            && let Some(resource) = resource
+        {
+            self.inner = std::mem::take(&mut self.inner).with_resource(resource);
+        }
+    }
+
+    /// Takes the Volga-facing OAuth issuer configuration out, validating
+    /// that an issuer was actually provided — `with_oauth` without
+    /// `with_issuer` is a configuration error that must fail startup.
+    #[cfg(feature = "server-oauth")]
+    pub(crate) fn take_oauth(&mut self) -> Result<Option<VolgaOAuthConfig>, crate::error::Error> {
+        match self.oauth.take() {
+            None => Ok(None),
+            Some(oauth) if oauth.issuer.is_some() => Ok(Some(oauth.inner)),
+            Some(_) => Err(crate::error::Error::new(
+                crate::error::ErrorCode::InternalError,
+                "OAuth issuer is not configured; call `with_oauth(|oauth| oauth.with_issuer(..))`",
+            )),
+        }
+    }
+
     /// Deconstructs into [`Authorizer`] and [`BearerAuthConfig`]
     pub(crate) fn into_parts(self) -> (BearerAuthConfig, Authorizer<C>) {
         (self.inner, self.authorizer)
+    }
+}
+
+/// Configuration of the OAuth 2.1/OIDC issuer whose keys validate bearer
+/// tokens, used with [`AuthConfig::with_oauth`].
+///
+/// A thin neva wrapper over [`volga::auth::OAuthConfig`] that records the
+/// issuer, so the transport can derive the MCP defaults from it (required
+/// `iss`, the Protected Resource Metadata document). Everything else has
+/// production-safe defaults; reach the remaining Volga knobs through
+/// [`with_config`](Self::with_config).
+#[cfg(feature = "server-oauth")]
+#[derive(Default)]
+pub struct OAuthConfig {
+    issuer: Option<String>,
+    inner: VolgaOAuthConfig,
+}
+
+#[cfg(feature = "server-oauth")]
+impl Debug for OAuthConfig {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OAuthConfig")
+            .field("issuer", &self.issuer)
+            .finish()
+    }
+}
+
+#[cfg(feature = "server-oauth")]
+impl OAuthConfig {
+    /// Sets the issuer identifier URL whose keys validate bearer tokens.
+    /// Mandatory — OAuth mode without an issuer fails server start.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_auth(|auth| auth
+    ///                 .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com")))
+    ///         )
+    ///     );
+    /// ```
+    pub fn with_issuer(mut self, issuer: impl Into<String>) -> Self {
+        let issuer = issuer.into();
+        self.inner = self.inner.with_issuer(issuer.as_str());
+        self.issuer = Some(issuer);
+        self
+    }
+
+    /// Sets the minimum interval between two JWKS refresh attempts.
+    ///
+    /// Default: 60 seconds.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    /// use std::time::Duration;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_auth(|auth| auth.with_oauth(|oauth| oauth
+    ///                 .with_issuer("https://auth.example.com")
+    ///                 .with_refresh_cooldown(Duration::from_secs(120))))
+    ///         )
+    ///     );
+    /// ```
+    pub fn with_refresh_cooldown(mut self, cooldown: std::time::Duration) -> Self {
+        self.inner = self.inner.with_refresh_cooldown(cooldown);
+        self
+    }
+
+    /// Sets the age after which the cached key set is re-fetched even for
+    /// known key ids, so revoked keys do not stay trusted indefinitely.
+    ///
+    /// Default: 15 minutes.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    /// use std::time::Duration;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_auth(|auth| auth.with_oauth(|oauth| oauth
+    ///                 .with_issuer("https://auth.example.com")
+    ///                 .with_max_key_age(Duration::from_secs(300))))
+    ///         )
+    ///     );
+    /// ```
+    pub fn with_max_key_age(mut self, max_age: std::time::Duration) -> Self {
+        self.inner = self.inner.with_max_key_age(max_age);
+        self
+    }
+
+    /// Escape hatch to the underlying [`volga::auth::OAuthConfig`] for
+    /// knobs without a neva-level counterpart (e.g. the discovery HTTP
+    /// client policy).
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// let app = App::new()
+    ///     .with_options(|opt| opt
+    ///         .with_http(|http| http
+    ///             .with_auth(|auth| auth.with_oauth(|oauth| oauth
+    ///                 .with_issuer("http://127.0.0.1:5000")
+    ///                 // local dev issuer over plain http
+    ///                 .with_config(|cfg| cfg.with_client_config(|c| c.require_https(false)))))
+    ///         )
+    ///     );
+    /// ```
+    pub fn with_config<F>(mut self, config: F) -> Self
+    where
+        F: FnOnce(VolgaOAuthConfig) -> VolgaOAuthConfig,
+    {
+        self.inner = config(self.inner);
+        self
     }
 }
 
@@ -200,4 +494,65 @@ impl<C: AuthClaims> AuthConfig<C> {
 #[inline]
 pub(super) fn default_auth_rules() -> Authorizer<DefaultClaims> {
     predicate(|_| true)
+}
+
+#[cfg(all(test, feature = "server-oauth"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_records_the_issuer() {
+        let auth = AuthConfig::default().with_oauth(|o| o.with_issuer("https://auth.example.com"));
+        assert_eq!(auth.oauth_issuer(), Some("https://auth.example.com"));
+    }
+
+    #[test]
+    fn take_oauth_without_oauth_mode_is_none() {
+        let mut auth = AuthConfig::default();
+        assert!(auth.take_oauth().unwrap().is_none());
+    }
+
+    #[test]
+    fn take_oauth_without_issuer_fails() {
+        let mut auth = AuthConfig::default().with_oauth(|o| o);
+        assert!(auth.take_oauth().is_err());
+    }
+
+    #[test]
+    fn take_oauth_with_issuer_yields_volga_config() {
+        let mut auth =
+            AuthConfig::default().with_oauth(|o| o.with_issuer("https://auth.example.com"));
+        assert!(auth.take_oauth().unwrap().is_some());
+    }
+
+    // `BearerAuthConfig` keeps its audience set private; its `Debug` impl
+    // exposes the RFC 8707 `resources` list, which `with_resource` feeds —
+    // assert through that.
+    fn resources_of(auth: &AuthConfig) -> String {
+        format!("{:?}", auth.inner)
+    }
+
+    #[test]
+    fn mcp_defaults_bind_audience_to_the_resource() {
+        let mut auth =
+            AuthConfig::default().with_oauth(|o| o.with_issuer("https://auth.example.com"));
+        auth.apply_mcp_defaults(Some("http://127.0.0.1:3000/mcp"));
+        assert!(resources_of(&auth).contains("http://127.0.0.1:3000/mcp"));
+    }
+
+    #[test]
+    fn explicit_audience_suppresses_the_default() {
+        let mut auth = AuthConfig::default()
+            .with_aud(["my-audience"])
+            .with_oauth(|o| o.with_issuer("https://auth.example.com"));
+        auth.apply_mcp_defaults(Some("http://127.0.0.1:3000/mcp"));
+        assert!(!resources_of(&auth).contains("http://127.0.0.1:3000/mcp"));
+    }
+
+    #[test]
+    fn mcp_defaults_outside_oauth_mode_are_noop() {
+        let mut auth = AuthConfig::default();
+        auth.apply_mcp_defaults(Some("http://127.0.0.1:3000/mcp"));
+        assert!(!resources_of(&auth).contains("http://127.0.0.1:3000/mcp"));
+    }
 }

--- a/neva/src/transport/http/server/volga/engine.rs
+++ b/neva/src/transport/http/server/volga/engine.rs
@@ -115,6 +115,18 @@ impl HttpEngine for VolgaEngine {
 
         let rules = match self.auth {
             Some(auth) => {
+                #[cfg(feature = "server-oauth")]
+                let mut auth = auth;
+                // In OAuth issuer mode, default the token checks to the
+                // MCP contract: `aud` must contain the canonical resource
+                // URI (RFC 8707) and `iss` must match the issuer.
+                #[cfg(feature = "server-oauth")]
+                auth.apply_mcp_defaults(ctx.oauth_resource());
+                // `with_oauth` without an issuer is a config error —
+                // surface it as a failed start, not a Volga panic.
+                #[cfg(feature = "server-oauth")]
+                let volga_oauth = auth.take_oauth()?;
+
                 let (bearer, rules) = auth.into_parts();
                 // Advertise the RFC 9728 document on Volga's own 401
                 // challenges: `WWW-Authenticate: Bearer resource_metadata="…"`.
@@ -124,6 +136,14 @@ impl HttpEngine for VolgaEngine {
                     None => bearer,
                 };
                 server = server.with_bearer_auth(|_| bearer);
+
+                // Issuer-based JWKS validation: keys are discovered from
+                // the issuer's metadata and rotated by Volga.
+                #[cfg(feature = "server-oauth")]
+                if let Some(oauth) = volga_oauth {
+                    server = server.with_oauth(|_| oauth);
+                    server.use_oauth();
+                }
                 Some(rules)
             }
             None => None,

--- a/neva/src/transport/http/server/volga/routes.rs
+++ b/neva/src/transport/http/server/volga/routes.rs
@@ -11,13 +11,8 @@ use crate::transport::http::core::{
     context::HttpContext, engine::HttpEngine, handlers, types::SseResponse,
 };
 use ::volga::{
-    HttpRequest, HttpResult,
-    auth::{Bearer, BearerTokenService},
-    di::Dc,
-    error::Error as VolgaError,
-    headers::AUTHORIZATION,
-    http::sse::Message as SseMessage,
-    sse,
+    HttpRequest, HttpResult, auth::Authenticated, di::Dc, error::Error as VolgaError,
+    http::sse::Message as SseMessage, sse,
 };
 use std::sync::Arc;
 
@@ -25,22 +20,17 @@ use super::engine::VolgaEngine;
 use crate::auth::Claims;
 use crate::transport::http::core::types::DefaultClaims;
 
-/// Extract the `Authorization` header and decode it into [`DefaultClaims`]
-/// using the configured [`BearerTokenService`], if any.
-fn decode_claims(
-    bts: Option<BearerTokenService>,
-    headers: &http::HeaderMap,
-) -> Option<DefaultClaims> {
-    let bts = bts?;
-    let header = headers.get(AUTHORIZATION)?;
-    let bearer = Bearer::try_from(header).ok()?;
-    bts.decode::<DefaultClaims>(bearer).ok()
-}
-
 /// `POST /<endpoint>` — JSON-RPC ingress.
 pub(crate) async fn post(req: HttpRequest) -> HttpResult {
     let manager: Dc<Arc<HttpContext>> = req.extract()?;
-    let bts: Option<BearerTokenService> = req.extract()?;
+
+    // Claims decoded and validated by Volga's `authorize` middleware —
+    // the single decode path for both static-key and OAuth/JWKS modes.
+    // Reading them from the request (rather than re-decoding the
+    // `Authorization` header) also survives Volga's default
+    // `strip_token_from_request`, which removes the header before the
+    // route runs.
+    let claims: Option<Authenticated<DefaultClaims>> = req.extract().ok();
 
     let mut neutral = VolgaEngine::adapt_request(req)
         .await
@@ -52,8 +42,8 @@ pub(crate) async fn post(req: HttpRequest) -> HttpResult {
     // documented on `HttpEngine` — every engine inserts its own
     // `Claims`-implementing type wrapped in `Arc<dyn Claims>` so neva's
     // per-tool/prompt/resource gates run identically across engines.
-    if let Some(claims) = decode_claims(bts, neutral.headers()) {
-        let claims: Arc<dyn Claims> = Arc::new(claims);
+    if let Some(claims) = claims {
+        let claims: Arc<dyn Claims> = Arc::new(claims.into_inner());
         neutral.extensions_mut().insert(claims);
     }
 


### PR DESCRIPTION
## Summary

Completes the OAuth series on top of the engine-neutral primitives from #89: the default Volga server validates tokens against an OAuth 2.1/OIDC issuer with one builder call, the HTTP client drives the full MCP authorization sequence automatically off a `401` challenge, tokens refresh silently, and four examples cover everything from a zero-config
resource server to a custom `HttpEngine` on bare hyper.

Closes #68, closes #69, closes #70, closes #71, closes #72, closes #83.

## Server side (default Volga engine) — #68 / #69

```rust
App::new().with_options(|opt| opt.with_http(|http| http
    .with_auth(|auth| auth
        .with_oauth(|oauth| oauth.with_issuer("https://auth.example.com")))));
```

That single call now gives a spec-compliant resource server:

* **Issuer/JWKS validation** via Volga's `use_oauth` pipeline — keys are discovered from the issuer metadata (RFC 8414, OIDC fallback), cached, and rotated by `kid`; while the issuer is unreachable, protected routes answer `503` (an IdP outage never takes the MCP server down).
* **MCP token defaults**, each suppressed by an explicit override: the token's `aud` must contain the server's canonical resource URI (RFC 8707, `with_resource` — the claim becomes *required*), and its `iss` must match the configured issuer.
* **Protected Resource Metadata auto-seeding**: with no explicit `with_oauth_metadata`, the RFC 9728 document is derived from the issuer and served on the well-known path out of the box.
* New `AuthConfig` passthroughs: `with_resource` / `with_resources`, and `neva::auth::OAuthConfig` (issuer, refresh cooldown, max key age, and a `with_config` escape hatch to the full Volga builder).

**Fixed along the way:** per-tool `with_roles`/`with_permissions` gates were broken under Volga's default `strip_token_from_request = true` — the route re-decoded the `Authorization` header *after* the middleware
had stripped it. Claims now come from Volga's `Authenticated<C>` request extension (the single decode path for both static-key and JWKS modes), and the manual header decoding is gone (the last item of #69).

## Client side — #70 / #71 / #83

`HttpClient::with_oauth(|oauth| oauth)` enables the automatic flow. On a `401`, the client walks the MCP authorization sequence on top of `volga-oauth-client`:

challenge (`resource_metadata`, RFC 9728 §5.1, with well-known fallback) → resource metadata → authorization-server discovery (RFC 8414 + OIDC fallback) → dynamic client registration when no `client_id` is configured (RFC 7591, **`application_type: "native"` for loopback redirects** — the desktop/CLI half of #83) → authorization-code + PKCE
with the server's canonical URI as the RFC 8707 resource indicator → callback validation → code exchange → retry of the failed request.

* **RFC 9207** (the other half of #83): the callback's `iss` parameter is validated against the discovered issuer — required when the server advertises support, checked whenever present; `state` is always verified. Negative tests for both.
* **Interactive step is pluggable** (`AuthorizationHandler`); the default `LoopbackHandler` opens the system browser and captures the redirect on a loopback listener (ephemeral or pinned port).
* **Token lifecycle (#71)**: an access token within 30s of expiry is refreshed proactively before the next request; a `401` tries the refresh-token grant before interrupting the user; refresh-token rotation carry-over and dead-entry pruning (`invalid_grant`) come from `OAuthClient::token`. All flows are single-flight — concurrent `401`s share one authorization.
* **Persistence** through the re-exported `TokenStore` abstraction (`InMemoryTokenStore` by default); client-side types exported under `neva::auth::oauth`.

## Examples — #72

| Example | Shows |
|---|---|
| `oauth-server` | resource server with the explicit RFC 9728 knobs + issuer validation |
| `oauth-client` | fully automatic flow, zero configuration |
| `oauth-with-keycloak` | end-to-end walkthrough: ready-to-import realm (audience mapper, roles-claim mapper, demo user), server + client binaries, Inspector notes |
| `oauth-hyper-engine` | a custom `HttpEngine` on bare hyper — no Volga — serving the well-known document, the `WWW-Authenticate` challenge and per-tool role gates through the engine-neutral primitives |

The Keycloak pair has been exercised live end-to-end (browser login, role-gated tool, background refresh). The hyper engine was verified over raw HTTP: metadata without credentials, challenge on `401`, audience binding, and role gates accepting/rejecting by claims.

## Other fixes

* **Hung client + swallowed `Ctrl+C`.** Pending request awaits ignored the transport's cancellation token: when the transport died (e.g. the OAuth flow failed against an unreachable issuer) the client sat out the full request timeout, and since `connect()` installs a `ctrl_c` handler that only cancels that token, `Ctrl+C` appeared dead too. Request awaits (single and batch) now race the token and abort with `Connection closed` immediately. Regression test included.
* **Client-only builds.** `http-client` alone didn't compile — the notification handler needs `tokio/rt-multi-thread`, now enabled by the `client` feature.

## Upstream notes (volga 0.9.5)

* `OAuthClient::exchange_code` / `refresh` hold a `form_urlencoded::Serializer` across an `.await`, making their futures `!Send`; neva bridges them through a dedicated current-thread runtime for now — drop the bridge once upstream ships `Send` token-endpoint futures.
* RFC 9207 `iss` validation and a first-class `application_type` field on `ClientMetadata` are natural upstream additions; neva implements both on its side today.

## Type
- [x] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [x] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
