### PR TITLE
MCP client dual mode

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,10 @@ jobs:
         run: cargo clippy --all-targets --features client-full -- -D warnings
       - name: Run server+client with proto-2026-07-28-rc
         run: cargo clippy --all-targets --features "server-full client-full proto-2026-07-28-rc" -- -D warnings
+      - name: Run slim client with proto-2026-07-28-rc
+        run: cargo clippy --all-targets --features "client proto-2026-07-28-rc" -- -D warnings
+      - name: Run slim server with proto-2026-07-28-rc
+        run: cargo clippy --all-targets --features "server proto-2026-07-28-rc" -- -D warnings
 
   audit:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## 0.4.2
 
 ### Added
+* **Dual-mode client (`initialize` fallback).** Under
+  `proto-2026-07-28-rc` the client now carries both handshakes: it tries
+  `server/discover` and, when the server clearly doesn't speak the RC
+  protocol (`MethodNotFound`, `InvalidRequest`, or a non-JSON-RPC /
+  unknown-code reply), falls back to the legacy `initialize`/`initialized`
+  handshake — negotiating the newest pre-RC version (override with
+  `with_mcp_version`) — and speaks legacy for that peer at runtime:
+  `Mcp-Session-Id` header, the standalone SSE GET stream, legacy
+  server-push sampling/roots/logging, no MRTR and no RC routing headers.
+  Network-level failures do not trigger the fallback. The switch is
+  per-connection, monotonic, and decided before any other traffic; the
+  server side remains compile-time pure. The legacy client machinery now
+  compiles (dormant) under the RC flag for this — the legacy build is
+  unchanged. (#84)
 * Client-side OAuth 2.1 authorization behind the new `client-oauth`
   feature (included in `client-full`), built on `volga-oauth-client`:
   * `HttpClient::with_oauth(...)` enables the automatic flow: a `401`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ edition = "2024"
 rust-version = "1.90.0"
 authors = ["Roman Emreis <roman.emreis@outlook.com>"]
 repository = "https://github.com/RomanEmreis/neva"
+homepage = "https://romanemreis.github.io/neva-docs/"
 documentation = "https://docs.rs/neva"
 keywords = ["modelcontextprotocol", "mcp", "sdk", "ai", "llm"]
 categories = [

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blazingly fast and easily configurable [Model Context Protocol (MCP)](https://mo
 With simple configuration and ergonomic APIs, it provides everything you need to quickly build MCP clients and servers, 
 fully aligned with the latest MCP specification.
 
-[![latest](https://img.shields.io/badge/latest-0.4.1-d8eb34)](https://crates.io/crates/neva)
+[![latest](https://img.shields.io/badge/latest-0.4.2-d8eb34)](https://crates.io/crates/neva)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-624bd1.svg)](https://github.com/RomanEmreis/neva/blob/main/LICENSE)
 [![CI](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml)
@@ -28,7 +28,7 @@ fully aligned with the latest MCP specification.
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.4.1", features = ["client-full"] }
+neva = { version = "0.4.2", features = ["client-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Error> {
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.4.1", features = ["server-full"] }
+neva = { version = "0.4.2", features = ["server-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 #### Code

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage.workspace = true
 documentation.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -26,8 +26,9 @@ use crate::{
 };
 // `RequestId` is only referenced by the server→client request paths (non-RC
 // elicitation/sampling) and the task API; under the stateless RC build without
-// tasks it is unused.
-#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "tasks", test))]
+// tasks it is unused — including in tests, whose `RequestId` uses live in
+// modules carrying those very same gates.
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "tasks"))]
 use crate::types::RequestId;
 use std::{
     collections::HashMap,

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -3,9 +3,7 @@
 use crate::error::{Error, ErrorCode};
 use crate::shared;
 use crate::transport::Transport;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use crate::types::Root;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use crate::types::sampling::{CreateMessageRequestParams, CreateMessageResult, SamplingHandler};
 use crate::types::{
     CallToolRequestParams, CallToolResponse, GetPromptRequestParams, GetPromptResult,
@@ -19,7 +17,6 @@ use crate::types::{
     notification::Notification,
     resource::{SubscribeRequestParams, UnsubscribeRequestParams},
 };
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use crate::types::{ClientCapabilities, InitializeRequestParams, InitializeResult};
 use handler::RequestHandler;
 use options::McpOptions;
@@ -120,7 +117,6 @@ impl Client {
     /// # client.disconnect().await
     /// # }
     /// ```
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[deprecated(
         note = "Roots are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
     )]
@@ -148,7 +144,6 @@ impl Client {
     /// # client.disconnect().await
     /// # }
     /// ```
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[deprecated(
         note = "Roots are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
     )]
@@ -164,7 +159,6 @@ impl Client {
     }
 
     /// Sends the "notifications/roots/list_changed" notification to the server
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[deprecated(
         note = "Roots are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
     )]
@@ -176,7 +170,6 @@ impl Client {
     }
 
     /// Registers a handler that will be running when a "sampling/createMessage" request is received
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[deprecated(
         note = "Sampling are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
     )]
@@ -228,7 +221,7 @@ impl Client {
         let mut transport = self.options.transport();
         let token = transport.start();
 
-        #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+        #[cfg(feature = "tracing")]
         self.register_tracing_notification_handlers();
 
         self.cancellation_token = Some(token.clone());
@@ -266,6 +259,17 @@ impl Client {
         Ok(())
     }
 
+    /// The protocol version this client expects from the connected peer:
+    /// the configured one, or the negotiated legacy version after a
+    /// dual-mode fallback.
+    fn expected_protocol_ver(&self) -> &'static str {
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        if self.is_legacy_peer() {
+            return self.options.legacy_protocol_ver();
+        }
+        self.options.protocol_ver()
+    }
+
     /// Validates a server-reported protocol version against what this client
     /// negotiated, cancelling the transport on mismatch.
     fn validate_server_version(&mut self, server_ver: &str) -> Result<(), Error> {
@@ -276,13 +280,13 @@ impl Client {
                 format!("Unsupported server protocol version: {server_ver}"),
             ));
         }
-        if server_ver != self.options.protocol_ver() {
+        if server_ver != self.expected_protocol_ver() {
             self.cancel_transport();
             return Err(Error::new(
                 ErrorCode::InvalidRequest,
                 format!(
                     "Server protocol version mismatch: expected {}, got {server_ver}",
-                    self.options.protocol_ver()
+                    self.expected_protocol_ver()
                 ),
             ));
         }
@@ -292,8 +296,22 @@ impl Client {
     /// Sends `initialize` request to an MCP server (pre-RC handshake).
     #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub async fn init(&mut self) -> Result<(), Error> {
+        self.legacy_init().await
+    }
+
+    /// The `initialize`/`initialized` handshake: the only handshake for
+    /// the legacy build, the dual-mode fallback for the RC build.
+    async fn legacy_init(&mut self) -> Result<(), Error> {
+        #[cfg(not(feature = "proto-2026-07-28-rc"))]
+        let protocol_ver = self.options.protocol_ver().to_string();
+        // The fallback negotiates the newest pre-RC version — offering
+        // the RC version to a server that just rejected `server/discover`
+        // would only get refused again.
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        let protocol_ver = self.options.legacy_protocol_ver().to_string();
+
         let params = InitializeRequestParams {
-            protocol_ver: self.options.protocol_ver().to_string(),
+            protocol_ver,
             client_info: Some(self.options.implementation.clone()),
             capabilities: Some(ClientCapabilities {
                 roots: self.options.roots_capability(),
@@ -301,6 +319,8 @@ impl Client {
                 elicitation: self.options.elicitation_capability(),
                 #[cfg(feature = "tasks")]
                 tasks: self.options.tasks_capability(),
+                #[cfg(feature = "proto-2026-07-28-rc")]
+                extensions: None,
                 experimental: None,
             }),
         };
@@ -348,11 +368,32 @@ impl Client {
         Ok(())
     }
 
-    /// Back-compat alias for [`discover`](Self::discover) so existing
-    /// `connect()` flows keep working under the RC flag.
+    /// The dual-mode handshake (issue #84): tries `server/discover`
+    /// first and, when the server clearly doesn't speak the RC protocol,
+    /// falls back to the legacy `initialize` handshake and marks the
+    /// peer as legacy — subsequent traffic uses legacy semantics
+    /// (session header, SSE stream, no MRTR, no RC routing headers).
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub async fn init(&mut self) -> Result<(), Error> {
-        self.discover().await
+        match self.discover().await {
+            Err(err) if is_fallback_trigger(&err) => {
+                #[cfg(feature = "tracing")]
+                tracing::info!(
+                    logger = "neva",
+                    "`server/discover` rejected ({err}); falling back to `initialize`"
+                );
+                self.options.peer_mode.set_legacy();
+                self.legacy_init().await
+            }
+            other => other,
+        }
+    }
+
+    /// Whether the peer negotiated the legacy protocol through the
+    /// dual-mode fallback.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    fn is_legacy_peer(&self) -> bool {
+        self.options.peer_mode.is_legacy()
     }
 
     /// Sends a ping to the MCP server
@@ -966,16 +1007,28 @@ impl Client {
     async fn send_request(&mut self, req: Request) -> Result<Response, Error> {
         #[cfg(feature = "proto-2026-07-28-rc")]
         {
+            // A legacy peer (dual-mode fallback) never speaks MRTR — its
+            // requests take the plain path, elicitation rides the legacy
+            // server-push channel instead.
+            if self.is_legacy_peer() {
+                return self.plain_send_request(req).await;
+            }
             self.run_with_mrtr(req).await
         }
         #[cfg(not(feature = "proto-2026-07-28-rc"))]
         {
-            self.handler
-                .as_mut()
-                .ok_or_else(|| Error::new(ErrorCode::InternalError, "Connection closed"))?
-                .send_request(req)
-                .await
+            self.plain_send_request(req).await
         }
+    }
+
+    /// Sends a request without the MRTR loop.
+    #[inline]
+    async fn plain_send_request(&mut self, req: Request) -> Result<Response, Error> {
+        self.handler
+            .as_mut()
+            .ok_or_else(|| Error::new(ErrorCode::InternalError, "Connection closed"))?
+            .send_request(req)
+            .await
     }
 
     /// Sends a request and transparently drives the MRTR loop: while the
@@ -1185,28 +1238,28 @@ impl Client {
         // Under the RC a batched request may elicit just like a single send, so
         // the batch is driven through the same MRTR retry loop (see
         // `run_batch_with_mrtr`) rather than returning the protocol-intermediate
-        // `input_required` result as final.
+        // `input_required` result as final. A legacy peer (dual-mode
+        // fallback) never speaks MRTR and takes the plain path.
         #[cfg(feature = "proto-2026-07-28-rc")]
         {
-            self.run_batch_with_mrtr(items).await
+            if !self.is_legacy_peer() {
+                return self.run_batch_with_mrtr(items).await;
+            }
         }
-        #[cfg(not(feature = "proto-2026-07-28-rc"))]
-        {
-            let handler = self
-                .handler
-                .as_mut()
-                .ok_or_else(|| Error::new(ErrorCode::InternalError, "Connection closed"))?;
+        let handler = self
+            .handler
+            .as_mut()
+            .ok_or_else(|| Error::new(ErrorCode::InternalError, "Connection closed"))?;
 
-            let request_timeout = handler.timeout();
-            let pending = handler.pending().clone();
-            let token = handler.cancellation();
-            let receivers = handler.send_batch(items).await?;
+        let request_timeout = handler.timeout();
+        let pending = handler.pending().clone();
+        let token = handler.cancellation();
+        let receivers = handler.send_batch(items).await?;
 
-            collect_batch_responses(receivers, &pending, request_timeout, token)
-                .await
-                .into_iter()
-                .collect()
-        }
+        collect_batch_responses(receivers, &pending, request_timeout, token)
+            .await
+            .into_iter()
+            .collect()
     }
 
     /// Drives the MRTR retry loop across an entire batch.
@@ -1405,7 +1458,7 @@ impl Client {
             .await
     }
 
-    #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+    #[cfg(feature = "tracing")]
     fn register_tracing_notification_handlers(&mut self) {
         use crate::types::notification::commands::*;
 
@@ -1414,7 +1467,7 @@ impl Client {
         self.subscribe(PROGRESS, Self::default_notification_handler);
     }
 
-    #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+    #[cfg(feature = "tracing")]
     async fn default_notification_handler(notification: Notification) {
         notification.write();
     }
@@ -1589,6 +1642,27 @@ async fn collect_batch_responses(
     join_all(futures).await
 }
 
+/// Whether a `server/discover` failure means "this server doesn't speak
+/// the RC protocol" — the dual-mode fallback triggers only then.
+///
+/// * `MethodNotFound` — a legacy server rejecting the unknown method
+///   (neva's own legacy build answers exactly this);
+/// * `InvalidRequest` — strict servers rejecting the RC request shape;
+/// * `ParseError` — a non-JSON-RPC reply (an HTTP 4xx page) or an error
+///   code outside neva's `ErrorCode` set (e.g. the TS SDK's `-32000`
+///   "server not initialized"), both of which surface as parse failures.
+///
+/// Network-level failures (`Timeout`, `InternalError`/"Connection
+/// closed") are *not* triggers: the server never answered, so falling
+/// back would only mask the outage.
+#[cfg(feature = "proto-2026-07-28-rc")]
+fn is_fallback_trigger(err: &Error) -> bool {
+    matches!(
+        err.code,
+        ErrorCode::MethodNotFound | ErrorCode::InvalidRequest | ErrorCode::ParseError
+    )
+}
+
 #[inline]
 fn make_handler<F, R, P, O>(handler: F) -> Handler<P, O>
 where
@@ -1709,5 +1783,281 @@ mod tests {
         let meta = &req.params.as_ref().expect("params present")["_meta"];
         assert!(meta.get("traceparent").is_none());
         assert!(meta.get("tracestate").is_none());
+    }
+}
+
+#[cfg(all(test, feature = "proto-2026-07-28-rc"))]
+mod fallback_trigger_tests {
+    use super::*;
+
+    fn err(code: ErrorCode) -> Error {
+        Error::new(code, "test")
+    }
+
+    #[test]
+    fn protocol_level_rejections_trigger_the_fallback() {
+        assert!(is_fallback_trigger(&err(ErrorCode::MethodNotFound)));
+        assert!(is_fallback_trigger(&err(ErrorCode::InvalidRequest)));
+        // Non-JSON-RPC replies (HTTP 4xx pages) and unknown error codes
+        // (e.g. the TS SDK's -32000) surface as parse failures.
+        assert!(is_fallback_trigger(&err(ErrorCode::ParseError)));
+    }
+
+    #[test]
+    fn transport_failures_do_not_trigger_the_fallback() {
+        assert!(!is_fallback_trigger(&err(ErrorCode::Timeout)));
+        assert!(!is_fallback_trigger(&err(ErrorCode::InternalError)));
+        assert!(!is_fallback_trigger(&err(ErrorCode::InvalidParams)));
+    }
+}
+
+/// The dual-mode "Done when" (issue #84): an RC client completes calls
+/// against a 2025-11-25 server via the `initialize` fallback. The legacy
+/// server is a raw-HTTP mock because a legacy neva server cannot exist
+/// in an RC-flagged build.
+#[cfg(all(test, feature = "http-client", feature = "proto-2026-07-28-rc"))]
+mod dual_mode_tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    const LEGACY_SESSION_ID: &str = "6f2f0dc8-6a5e-4f6e-9c1a-2b7f9d3f1c11";
+
+    /// Reads one HTTP/1.1 request; returns `(head, body)`.
+    async fn read_request(stream: &mut TcpStream) -> Option<(String, String)> {
+        let mut buf = Vec::new();
+        let mut tmp = [0u8; 2048];
+        let header_end = loop {
+            let n = stream.read(&mut tmp).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+            if buf.len() > 65536 {
+                return None;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+        let content_length = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse::<usize>().ok())
+            })
+            .flatten()
+            .unwrap_or(0);
+        while buf.len() < header_end + content_length {
+            let n = stream.read(&mut tmp).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+        }
+        let body =
+            String::from_utf8_lossy(&buf[header_end..header_end + content_length]).to_string();
+        Some((head, body))
+    }
+
+    async fn write_response(stream: &mut TcpStream, status: &str, extra_headers: &str, body: &str) {
+        let resp = format!(
+            "HTTP/1.1 {status}\r\n{extra_headers}Content-Length: {}\r\nConnection: keep-alive\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = stream.write_all(resp.as_bytes()).await;
+    }
+
+    fn rpc_result(id: &serde_json::Value, result: serde_json::Value) -> String {
+        serde_json::json!({ "jsonrpc": "2.0", "id": id, "result": result }).to_string()
+    }
+
+    /// A minimal 2025-11-25 server: rejects `server/discover` with
+    /// `MethodNotFound`, answers `initialize` with a session id, serves
+    /// an SSE GET stream and an empty `tools/list`.
+    async fn serve_legacy(listener: TcpListener, log: Arc<Mutex<Vec<String>>>) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let log = log.clone();
+            tokio::spawn(async move {
+                loop {
+                    let Some((head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+                    log.lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .push(format!("{head}{body}"));
+
+                    if head.starts_with("GET") {
+                        let _ = stream
+                            .write_all(
+                                b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\n\r\n: hi\n\n",
+                            )
+                            .await;
+                        // Hold the stream open like a real legacy server.
+                        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                        return;
+                    }
+
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    match msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default()
+                    {
+                        crate::commands::DISCOVER => {
+                            let body = serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": id,
+                                "error": { "code": -32601, "message": "Method not found" }
+                            })
+                            .to_string();
+                            write_response(
+                                &mut stream,
+                                "200 OK",
+                                "Content-Type: application/json\r\n",
+                                &body,
+                            )
+                            .await;
+                        }
+                        crate::commands::INIT => {
+                            let body = rpc_result(
+                                &id,
+                                serde_json::json!({
+                                    "protocolVersion": "2025-11-25",
+                                    "capabilities": { "tools": {} },
+                                    "serverInfo": { "name": "legacy-mock", "version": "1.0.0" }
+                                }),
+                            );
+                            let headers = format!(
+                                "Content-Type: application/json\r\nMcp-Session-Id: {LEGACY_SESSION_ID}\r\n"
+                            );
+                            write_response(&mut stream, "200 OK", &headers, &body).await;
+                        }
+                        crate::types::tool::commands::LIST => {
+                            let body = rpc_result(&id, serde_json::json!({ "tools": [] }));
+                            write_response(
+                                &mut stream,
+                                "200 OK",
+                                "Content-Type: application/json\r\n",
+                                &body,
+                            )
+                            .await;
+                        }
+                        // notifications (initialized / cancelled)
+                        _ => write_response(&mut stream, "202 Accepted", "", "").await,
+                    }
+                }
+            });
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rc_client_falls_back_to_initialize_against_legacy_server() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let log = Arc::new(Mutex::new(Vec::<String>::new()));
+        tokio::spawn(serve_legacy(listener, log.clone()));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+
+        client
+            .connect()
+            .await
+            .expect("fallback connect must succeed");
+        assert!(client.is_legacy_peer(), "peer must be marked legacy");
+        assert_eq!(
+            client.server_info.as_ref().map(|i| i.name.as_str()),
+            Some("legacy-mock")
+        );
+
+        let tools = client
+            .list_tools(None)
+            .await
+            .expect("tools/list must work after the fallback");
+        assert!(tools.tools.is_empty());
+
+        let log = log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let discover = log
+            .iter()
+            .find(|r| r.contains("server/discover"))
+            .expect("discover must be attempted first");
+        assert!(
+            discover
+                .to_ascii_lowercase()
+                .contains("mcp-protocol-version"),
+            "the RC attempt carries the protocol-version header"
+        );
+
+        let init = log
+            .iter()
+            .find(|r| r.contains("\"method\":\"initialize\""))
+            .expect("initialize must be sent after the rejection");
+        assert!(
+            init.contains("2025-11-25"),
+            "the fallback negotiates the newest pre-RC version"
+        );
+
+        let list = log
+            .iter()
+            .find(|r| r.contains(crate::types::tool::commands::LIST))
+            .expect("tools/list recorded");
+        let list_lower = list.to_ascii_lowercase();
+        assert!(
+            !list_lower.contains("mcp-protocol-version"),
+            "legacy peers must not receive the RC protocol-version header"
+        );
+        assert!(
+            !list_lower.contains("mcp-method:"),
+            "legacy peers must not receive RC routing headers"
+        );
+        assert!(
+            list_lower.contains(&format!("mcp-session-id: {LEGACY_SESSION_ID}")),
+            "the captured session id must ride every request"
+        );
+    }
+}
+
+/// The other half of the "Done when": against an RC server the client
+/// keeps using `server/discover` (no fallback).
+#[cfg(all(
+    test,
+    feature = "http-client",
+    feature = "http-server-volga",
+    feature = "proto-2026-07-28-rc"
+))]
+mod rc_roundtrip_tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rc_client_discovers_rc_server() {
+        let mut app = crate::App::new()
+            .with_options(|opt| opt.with_http(|http| http.bind("127.0.0.1:39817")));
+        app.map_tool("echo", |name: String| async move { name });
+        tokio::spawn(app.run());
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind("127.0.0.1:39817"))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+
+        client.connect().await.expect("discover must succeed");
+        assert!(!client.is_legacy_peer(), "RC peers never fall back");
+
+        let tools = client.list_tools(None).await.expect("tools/list");
+        assert_eq!(tools.tools.len(), 1);
+        assert_eq!(tools.tools[0].name, "echo");
     }
 }

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1936,11 +1936,15 @@ mod dual_mode_tests {
     /// "server not initialized" family); a future server answers
     /// *successfully* but with a `protocolVersion` this build does not
     /// support — which must NOT trigger the fallback.
+    /// A protected endpoint answering `401` with a non-JSON body must not
+    /// trigger the fallback either — that is an authentication failure,
+    /// not evidence of a legacy peer.
     #[derive(Clone, Copy)]
     enum DiscoverReply {
         MethodNotFound,
         Html400,
         UnsupportedVersion,
+        Unauthorized401,
     }
 
     async fn serve_legacy(
@@ -2002,6 +2006,15 @@ mod dual_mode_tests {
                                     "400 Bad Request",
                                     "Content-Type: text/html\r\n",
                                     "<html><body>Bad Request</body></html>",
+                                )
+                                .await;
+                            }
+                            DiscoverReply::Unauthorized401 => {
+                                write_response(
+                                    &mut stream,
+                                    "401 Unauthorized",
+                                    "Content-Type: text/html\r\nWWW-Authenticate: Bearer\r\n",
+                                    "<html><body>Unauthorized</body></html>",
                                 )
                                 .await;
                             }
@@ -2199,6 +2212,48 @@ mod dual_mode_tests {
         assert!(
             !log.iter().any(|r| r.contains("\"method\":\"initialize\"")),
             "no initialize fallback may be attempted after successful discovery"
+        );
+    }
+
+    /// A protected RC endpoint replying `401` with a non-JSON body must
+    /// surface the authentication failure, not be mistaken for a legacy
+    /// peer — otherwise the client silently drops the RC headers and
+    /// retries `initialize`, masking the real cause.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unauthorized_discover_does_not_fall_back() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let log = Arc::new(Mutex::new(Vec::<String>::new()));
+        tokio::spawn(serve_legacy(
+            listener,
+            log.clone(),
+            DiscoverReply::Unauthorized401,
+        ));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+
+        let err = client
+            .connect()
+            .await
+            .expect_err("an unauthenticated connect must fail");
+        assert!(
+            err.to_string().contains("401"),
+            "the HTTP status must be carried through, got: {err}"
+        );
+        assert!(
+            !client.is_legacy_peer(),
+            "an auth failure must never mark the peer legacy"
+        );
+
+        let log = log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            !log.iter().any(|r| r.contains("\"method\":\"initialize\"")),
+            "no initialize fallback may be attempted after an auth failure"
         );
     }
 

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -2140,7 +2140,19 @@ mod rc_roundtrip_tests {
             .with_options(|opt| opt.with_http(|http| http.bind("127.0.0.1:39817")));
         app.map_tool("echo", |name: String| async move { name });
         tokio::spawn(app.run());
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        // Wait until the server socket actually accepts connections —
+        // a fixed sleep is not enough on loaded CI machines.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            match tokio::net::TcpStream::connect("127.0.0.1:39817").await {
+                Ok(_) => break,
+                Err(_) if tokio::time::Instant::now() < deadline => {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await
+                }
+                Err(err) => panic!("RC server never became reachable: {err}"),
+            }
+        }
 
         let mut client = Client::new().with_options(|opt| {
             opt.with_http(|http| http.bind("127.0.0.1:39817"))

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1945,6 +1945,7 @@ mod dual_mode_tests {
         Html400,
         UnsupportedVersion,
         Unauthorized401,
+        Unavailable503,
     }
 
     async fn serve_legacy(
@@ -2006,6 +2007,15 @@ mod dual_mode_tests {
                                     "400 Bad Request",
                                     "Content-Type: text/html\r\n",
                                     "<html><body>Bad Request</body></html>",
+                                )
+                                .await;
+                            }
+                            DiscoverReply::Unavailable503 => {
+                                write_response(
+                                    &mut stream,
+                                    "503 Service Unavailable",
+                                    "Content-Type: text/html\r\n",
+                                    "<html><body>upstream down</body></html>",
                                 )
                                 .await;
                             }
@@ -2254,6 +2264,48 @@ mod dual_mode_tests {
         assert!(
             !log.iter().any(|r| r.contains("\"method\":\"initialize\"")),
             "no initialize fallback may be attempted after an auth failure"
+        );
+    }
+
+    /// An upstream outage (reverse proxy `503`, rate limit, gateway
+    /// timeout) says nothing about the peer's protocol generation: the
+    /// failure must surface instead of being read as "legacy" and retried
+    /// as `initialize` into the very same outage.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn upstream_failure_during_discover_does_not_fall_back() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let log = Arc::new(Mutex::new(Vec::<String>::new()));
+        tokio::spawn(serve_legacy(
+            listener,
+            log.clone(),
+            DiscoverReply::Unavailable503,
+        ));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+
+        let err = client
+            .connect()
+            .await
+            .expect_err("an upstream outage must fail the connect");
+        assert!(
+            err.to_string().contains("503"),
+            "the upstream status must surface, got: {err}"
+        );
+        assert!(
+            !client.is_legacy_peer(),
+            "an upstream outage must never mark the peer legacy"
+        );
+
+        let log = log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            !log.iter().any(|r| r.contains("\"method\":\"initialize\"")),
+            "no initialize fallback may be attempted on an upstream failure"
         );
     }
 

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -259,15 +259,25 @@ impl Client {
         Ok(())
     }
 
-    /// The protocol version this client expects from the connected peer:
-    /// the configured one, or the negotiated legacy version after a
-    /// dual-mode fallback.
+    /// The protocol version this client expects from the connected peer.
+    ///
+    /// Under the RC flag the RC expectation is pinned to
+    /// [`crate::RC_PROTOCOL_VERSION`]: a `with_mcp_version` override only
+    /// selects which legacy version the dual-mode fallback negotiates —
+    /// it must never make `server/discover` reject a valid RC server.
     fn expected_protocol_ver(&self) -> &'static str {
         #[cfg(feature = "proto-2026-07-28-rc")]
-        if self.is_legacy_peer() {
-            return self.options.legacy_protocol_ver();
+        {
+            if self.is_legacy_peer() {
+                self.options.legacy_protocol_ver()
+            } else {
+                crate::RC_PROTOCOL_VERSION
+            }
         }
-        self.options.protocol_ver()
+        #[cfg(not(feature = "proto-2026-07-28-rc"))]
+        {
+            self.options.protocol_ver()
+        }
     }
 
     /// Validates a server-reported protocol version against what this client
@@ -1878,7 +1888,21 @@ mod dual_mode_tests {
     /// A minimal 2025-11-25 server: rejects `server/discover` with
     /// `MethodNotFound`, answers `initialize` with a session id, serves
     /// an SSE GET stream and an empty `tools/list`.
-    async fn serve_legacy(listener: TcpListener, log: Arc<Mutex<Vec<String>>>) {
+    /// How the mock rejects `server/discover` — legacy servers in the
+    /// wild answer either with a JSON-RPC `MethodNotFound` (neva's own
+    /// legacy build) or with a plain non-JSON-RPC 4xx page (framework
+    /// routers, the TS SDK's "server not initialized" family).
+    #[derive(Clone, Copy)]
+    enum DiscoverRejection {
+        MethodNotFound,
+        Html400,
+    }
+
+    async fn serve_legacy(
+        listener: TcpListener,
+        log: Arc<Mutex<Vec<String>>>,
+        rejection: DiscoverRejection,
+    ) {
         loop {
             let Ok((mut stream, _)) = listener.accept().await else {
                 return;
@@ -1911,21 +1935,32 @@ mod dual_mode_tests {
                         .and_then(|m| m.as_str())
                         .unwrap_or_default()
                     {
-                        crate::commands::DISCOVER => {
-                            let body = serde_json::json!({
-                                "jsonrpc": "2.0",
-                                "id": id,
-                                "error": { "code": -32601, "message": "Method not found" }
-                            })
-                            .to_string();
-                            write_response(
-                                &mut stream,
-                                "200 OK",
-                                "Content-Type: application/json\r\n",
-                                &body,
-                            )
-                            .await;
-                        }
+                        crate::commands::DISCOVER => match rejection {
+                            DiscoverRejection::MethodNotFound => {
+                                let body = serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "id": id,
+                                    "error": { "code": -32601, "message": "Method not found" }
+                                })
+                                .to_string();
+                                write_response(
+                                    &mut stream,
+                                    "200 OK",
+                                    "Content-Type: application/json\r\n",
+                                    &body,
+                                )
+                                .await;
+                            }
+                            DiscoverRejection::Html400 => {
+                                write_response(
+                                    &mut stream,
+                                    "400 Bad Request",
+                                    "Content-Type: text/html\r\n",
+                                    "<html><body>Bad Request</body></html>",
+                                )
+                                .await;
+                            }
+                        },
                         crate::commands::INIT => {
                             let body = rpc_result(
                                 &id,
@@ -1963,7 +1998,11 @@ mod dual_mode_tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let log = Arc::new(Mutex::new(Vec::<String>::new()));
-        tokio::spawn(serve_legacy(listener, log.clone()));
+        tokio::spawn(serve_legacy(
+            listener,
+            log.clone(),
+            DiscoverRejection::MethodNotFound,
+        ));
 
         let mut client = Client::new().with_options(|opt| {
             opt.with_http(|http| http.bind(addr.to_string()))
@@ -2026,6 +2065,51 @@ mod dual_mode_tests {
             list_lower.contains(&format!("mcp-session-id: {LEGACY_SESSION_ID}")),
             "the captured session id must ride every request"
         );
+    }
+
+    /// A legacy server that rejects `server/discover` with a plain
+    /// non-JSON-RPC 4xx page (no JSON-RPC error at all) must also
+    /// trigger the fallback: the transport completes the request with an
+    /// id-bound `ParseError` response instead of a bare channel error.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rc_client_falls_back_when_discover_gets_a_non_json_4xx() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let log = Arc::new(Mutex::new(Vec::<String>::new()));
+        tokio::spawn(serve_legacy(
+            listener,
+            log.clone(),
+            DiscoverRejection::Html400,
+        ));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+
+        client
+            .connect()
+            .await
+            .expect("fallback connect must succeed");
+        assert!(client.is_legacy_peer(), "peer must be marked legacy");
+
+        let tools = client
+            .list_tools(None)
+            .await
+            .expect("tools/list must work after the fallback");
+        assert!(tools.tools.is_empty());
+    }
+
+    /// A `with_mcp_version` legacy override must not leak into the RC
+    /// expectation: `server/discover` still expects the RC version, the
+    /// override only selects the fallback's negotiated legacy version.
+    #[test]
+    fn legacy_version_override_keeps_the_rc_expectation() {
+        let client = Client::new().with_options(|opt| opt.with_mcp_version("2025-06-18"));
+        assert_eq!(client.expected_protocol_ver(), crate::RC_PROTOCOL_VERSION);
+
+        client.options.peer_mode.set_legacy();
+        assert_eq!(client.expected_protocol_ver(), "2025-06-18");
     }
 }
 

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -949,12 +949,22 @@ impl Client {
     }
 
     /// Resolves the server's tasks capability from the negotiated server
-    /// capabilities (extension form, MCP 2026-07-28 RC).
+    /// capabilities (MCP 2026-07-28 RC build).
+    ///
+    /// An RC peer advertises tasks through
+    /// `capabilities.extensions["io.modelcontextprotocol/tasks"]`; a
+    /// legacy peer reached via the dual-mode fallback advertises the
+    /// top-level `tasks` field of its `initialize` result — both must
+    /// resolve, or task-augmented calls report no support after a
+    /// fallback.
     #[cfg(all(feature = "tasks", feature = "proto-2026-07-28-rc"))]
     fn server_tasks_capability(&self) -> Option<crate::types::ServerTasksCapability> {
-        self.server_capabilities
+        let caps = self.server_capabilities.as_ref()?;
+        if let Some(tasks) = &caps.tasks {
+            return Some(tasks.clone());
+        }
+        caps.extensions
             .as_ref()
-            .and_then(|c| c.extensions.as_ref())
             .and_then(|ext| ext.get(crate::types::task::TASKS_EXTENSION_ID))
             .and_then(|v| serde_json::from_value(v.clone()).ok())
     }
@@ -2143,5 +2153,48 @@ mod rc_roundtrip_tests {
         let tools = client.list_tools(None).await.expect("tools/list");
         assert_eq!(tools.tools.len(), 1);
         assert_eq!(tools.tools[0].name, "echo");
+    }
+}
+
+/// After a dual-mode fallback, a legacy peer's top-level `tasks`
+/// capability must survive and resolve — an RC peer's extension form
+/// must keep working too.
+#[cfg(all(test, feature = "tasks", feature = "proto-2026-07-28-rc"))]
+mod fallback_tasks_capability_tests {
+    use super::*;
+    use crate::types::ServerCapabilities;
+    use serde_json::json;
+
+    fn client_with_capabilities(caps: serde_json::Value) -> Client {
+        let mut client = Client::new();
+        client.server_capabilities =
+            Some(serde_json::from_value::<ServerCapabilities>(caps).expect("valid capabilities"));
+        client
+    }
+
+    #[test]
+    fn legacy_top_level_tasks_capability_resolves() {
+        let client = client_with_capabilities(json!({
+            "tools": {},
+            "tasks": { "requests": { "tools": { "call": {} } } }
+        }));
+        assert!(client.is_server_supports_tasks());
+    }
+
+    #[test]
+    fn rc_extension_tasks_capability_still_resolves() {
+        let client = client_with_capabilities(json!({
+            "tools": {},
+            "extensions": {
+                "io.modelcontextprotocol/tasks": { "requests": { "tools": { "call": {} } } }
+            }
+        }));
+        assert!(client.is_server_supports_tasks());
+    }
+
+    #[test]
+    fn no_tasks_capability_resolves_to_none() {
+        let client = client_with_capabilities(json!({ "tools": {} }));
+        assert!(!client.is_server_supports_tasks());
     }
 }

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -360,21 +360,28 @@ impl Client {
     /// notification is sent — the transport is stateless.
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub async fn discover(&mut self) -> Result<(), Error> {
-        let req = Request::new(
+        let resp = self.send_request(Self::discover_request()).await?;
+        let result = resp.into_result::<crate::types::DiscoverResult>()?;
+        self.apply_discover(result)
+    }
+
+    /// Builds the `server/discover` request.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    fn discover_request() -> Request {
+        Request::new(
             Some(RequestId::Uuid(uuid::Uuid::new_v4())),
             crate::commands::DISCOVER,
             Some(crate::types::DiscoverRequestParams::default()),
-        );
+        )
+    }
 
-        let resp = self.send_request(req).await?;
-
-        let result = resp.into_result::<crate::types::DiscoverResult>()?;
-
+    /// Applies a successful `server/discover` result: validates the
+    /// reported protocol version and stores the capabilities.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    fn apply_discover(&mut self, result: crate::types::DiscoverResult) -> Result<(), Error> {
         self.validate_server_version(result.protocol_ver.as_str())?;
-
         self.server_capabilities = Some(result.capabilities);
         self.server_info = Some(result.server_info);
-
         Ok(())
     }
 
@@ -383,20 +390,45 @@ impl Client {
     /// falls back to the legacy `initialize` handshake and marks the
     /// peer as legacy — subsequent traffic uses legacy semantics
     /// (session header, SSE stream, no MRTR, no RC routing headers).
+    ///
+    /// Only **wire-phase** failures classify for the fallback: transport
+    /// errors and the server's JSON-RPC *error* reply. Once the server
+    /// answers `server/discover` successfully, the peer has committed to
+    /// the RC protocol — later local failures (a malformed result, an
+    /// unsupported/mismatched `protocolVersion`) surface as real errors
+    /// instead of a misleading fallback attempt on a transport that
+    /// version validation may already have cancelled.
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub async fn init(&mut self) -> Result<(), Error> {
-        match self.discover().await {
-            Err(err) if is_fallback_trigger(&err) => {
-                #[cfg(feature = "tracing")]
-                tracing::info!(
-                    logger = "neva",
-                    "`server/discover` rejected ({err}); falling back to `initialize`"
-                );
-                self.options.peer_mode.set_legacy();
-                self.legacy_init().await
+        let resp = match self.send_request(Self::discover_request()).await {
+            Ok(resp) => resp,
+            Err(err) if is_fallback_trigger(&err) => return self.fallback_init(&err).await,
+            Err(err) => return Err(err),
+        };
+
+        let is_error_reply = matches!(resp, Response::Err(_));
+        let result = match resp.into_result::<crate::types::DiscoverResult>() {
+            Ok(result) => result,
+            Err(err) if is_error_reply && is_fallback_trigger(&err) => {
+                return self.fallback_init(&err).await;
             }
-            other => other,
-        }
+            Err(err) => return Err(err),
+        };
+
+        self.apply_discover(result)
+    }
+
+    /// Runs the legacy half of the dual-mode handshake after a
+    /// classified `server/discover` rejection.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    async fn fallback_init(&mut self, _err: &Error) -> Result<(), Error> {
+        #[cfg(feature = "tracing")]
+        tracing::info!(
+            logger = "neva",
+            "`server/discover` rejected ({_err}); falling back to `initialize`"
+        );
+        self.options.peer_mode.set_legacy();
+        self.legacy_init().await
     }
 
     /// Whether the peer negotiated the legacy protocol through the
@@ -1898,20 +1930,23 @@ mod dual_mode_tests {
     /// A minimal 2025-11-25 server: rejects `server/discover` with
     /// `MethodNotFound`, answers `initialize` with a session id, serves
     /// an SSE GET stream and an empty `tools/list`.
-    /// How the mock rejects `server/discover` — legacy servers in the
-    /// wild answer either with a JSON-RPC `MethodNotFound` (neva's own
-    /// legacy build) or with a plain non-JSON-RPC 4xx page (framework
-    /// routers, the TS SDK's "server not initialized" family).
+    /// How the mock answers `server/discover`: legacy servers reject it
+    /// with a JSON-RPC `MethodNotFound` (neva's own legacy build) or a
+    /// plain non-JSON-RPC 4xx page (framework routers, the TS SDK's
+    /// "server not initialized" family); a future server answers
+    /// *successfully* but with a `protocolVersion` this build does not
+    /// support — which must NOT trigger the fallback.
     #[derive(Clone, Copy)]
-    enum DiscoverRejection {
+    enum DiscoverReply {
         MethodNotFound,
         Html400,
+        UnsupportedVersion,
     }
 
     async fn serve_legacy(
         listener: TcpListener,
         log: Arc<Mutex<Vec<String>>>,
-        rejection: DiscoverRejection,
+        reply: DiscoverReply,
     ) {
         loop {
             let Ok((mut stream, _)) = listener.accept().await else {
@@ -1945,8 +1980,8 @@ mod dual_mode_tests {
                         .and_then(|m| m.as_str())
                         .unwrap_or_default()
                     {
-                        crate::commands::DISCOVER => match rejection {
-                            DiscoverRejection::MethodNotFound => {
+                        crate::commands::DISCOVER => match reply {
+                            DiscoverReply::MethodNotFound => {
                                 let body = serde_json::json!({
                                     "jsonrpc": "2.0",
                                     "id": id,
@@ -1961,12 +1996,29 @@ mod dual_mode_tests {
                                 )
                                 .await;
                             }
-                            DiscoverRejection::Html400 => {
+                            DiscoverReply::Html400 => {
                                 write_response(
                                     &mut stream,
                                     "400 Bad Request",
                                     "Content-Type: text/html\r\n",
                                     "<html><body>Bad Request</body></html>",
+                                )
+                                .await;
+                            }
+                            DiscoverReply::UnsupportedVersion => {
+                                let body = rpc_result(
+                                    &id,
+                                    serde_json::json!({
+                                        "protocolVersion": "2099-01-01",
+                                        "capabilities": { "tools": {} },
+                                        "serverInfo": { "name": "future-mock", "version": "1.0.0" }
+                                    }),
+                                );
+                                write_response(
+                                    &mut stream,
+                                    "200 OK",
+                                    "Content-Type: application/json\r\n",
+                                    &body,
                                 )
                                 .await;
                             }
@@ -2011,7 +2063,7 @@ mod dual_mode_tests {
         tokio::spawn(serve_legacy(
             listener,
             log.clone(),
-            DiscoverRejection::MethodNotFound,
+            DiscoverReply::MethodNotFound,
         ));
 
         let mut client = Client::new().with_options(|opt| {
@@ -2086,11 +2138,7 @@ mod dual_mode_tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let log = Arc::new(Mutex::new(Vec::<String>::new()));
-        tokio::spawn(serve_legacy(
-            listener,
-            log.clone(),
-            DiscoverRejection::Html400,
-        ));
+        tokio::spawn(serve_legacy(listener, log.clone(), DiscoverReply::Html400));
 
         let mut client = Client::new().with_options(|opt| {
             opt.with_http(|http| http.bind(addr.to_string()))
@@ -2108,6 +2156,50 @@ mod dual_mode_tests {
             .await
             .expect("tools/list must work after the fallback");
         assert!(tools.tools.is_empty());
+    }
+
+    /// A server that answers `server/discover` *successfully* but with a
+    /// protocol version this build does not support has committed to the
+    /// RC path — the client must surface the real version error, not
+    /// mark the peer legacy and chase `initialize` on a cancelled
+    /// transport.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn successful_discover_with_unsupported_version_does_not_fall_back() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let log = Arc::new(Mutex::new(Vec::<String>::new()));
+        tokio::spawn(serve_legacy(
+            listener,
+            log.clone(),
+            DiscoverReply::UnsupportedVersion,
+        ));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+
+        let err = client
+            .connect()
+            .await
+            .expect_err("an unsupported RC version must fail the connect");
+        assert!(
+            err.to_string()
+                .contains("Unsupported server protocol version"),
+            "the real version error must surface, got: {err}"
+        );
+        assert!(
+            !client.is_legacy_peer(),
+            "a successful discovery must never mark the peer legacy"
+        );
+
+        let log = log
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert!(
+            !log.iter().any(|r| r.contains("\"method\":\"initialize\"")),
+            "no initialize fallback may be attempted after successful discovery"
+        );
     }
 
     /// A `with_mcp_version` legacy override must not leak into the RC

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -1,9 +1,7 @@
 //! Request handling utilities
 
 use crate::client::notification_handler::NotificationsHandler;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use crate::types::sampling::SamplingHandler;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use crate::types::{Root, root::ListRootsResult};
 use crate::{
     client::options::McpOptions,
@@ -22,12 +20,11 @@ use std::{
     sync::atomic::{AtomicI64, Ordering},
     time::Duration,
 };
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use tokio::sync::RwLock;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
-#[cfg(all(feature = "tasks", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "tasks")]
 use crate::types::CreateMessageRequestParams;
 #[cfg(feature = "tasks")]
 use crate::{
@@ -42,7 +39,6 @@ use crate::{
 #[cfg(feature = "tasks")]
 const DEFAULT_PAGE_SIZE: usize = 10;
 
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 struct Roots {
     /// Cached list of [`Root`]
     inner: Arc<RwLock<Vec<Root>>>,
@@ -70,11 +66,9 @@ pub(super) struct RequestHandler {
     sender: TransportProtoSender,
 
     /// Cached list of [`Root`]
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     roots: Roots,
 
     /// Represents a handler function that runs when received a "sampling/createMessage" request
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     sampling_handler: Option<SamplingHandler>,
 
     /// Represents a handler function that runs when received an "elicitation/create" request
@@ -88,7 +82,6 @@ pub(super) struct RequestHandler {
     tasks: Arc<TaskTracker>,
 }
 
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 impl Roots {
     fn new(options: &McpOptions, notifications_sender: &TransportProtoSender) -> Self {
         let mut roots = Self {
@@ -145,14 +138,12 @@ impl RequestHandler {
         let (tx, rx) = transport.split();
 
         let handler = Self {
-            #[cfg(not(feature = "proto-2026-07-28-rc"))]
             roots: Roots::new(options, &tx),
             counter: AtomicI64::new(1),
             pending: RequestQueue::new(options.timeout),
             sender: tx,
             timeout: options.timeout,
             token,
-            #[cfg(not(feature = "proto-2026-07-28-rc"))]
             sampling_handler: options.sampling_handler.clone(),
             elicitation_handler: options.elicitation_handler.clone(),
             notification_handler: options.notification_handler.clone(),
@@ -293,7 +284,6 @@ impl RequestHandler {
     }
 
     /// Updates [`Root`] cache
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(super) fn notify_roots_changed(&mut self, roots: Vec<Root>) {
         self.roots.update(roots);
     }
@@ -302,9 +292,7 @@ impl RequestHandler {
     fn start(self, mut rx: TransportProtoReceiver) -> Self {
         let pending = self.pending.clone();
         let mut sender = self.sender.clone();
-        #[cfg(not(feature = "proto-2026-07-28-rc"))]
         let roots = self.roots.inner.clone();
-        #[cfg(not(feature = "proto-2026-07-28-rc"))]
         let sampling_handler = self.sampling_handler.clone();
         let elicitation_handler = self.elicitation_handler.clone();
         let notification_handler = self.notification_handler.clone();
@@ -319,9 +307,7 @@ impl RequestHandler {
                     Message::Request(req) => {
                         let resp = dispatch_request(
                             req,
-                            #[cfg(not(feature = "proto-2026-07-28-rc"))]
                             &roots,
-                            #[cfg(not(feature = "proto-2026-07-28-rc"))]
                             &sampling_handler,
                             &elicitation_handler,
                             #[cfg(feature = "tasks")]
@@ -356,9 +342,7 @@ impl RequestHandler {
                         // individual messages.
                         let responses = dispatch_batch_deferred(
                             deferred,
-                            #[cfg(not(feature = "proto-2026-07-28-rc"))]
                             &roots,
-                            #[cfg(not(feature = "proto-2026-07-28-rc"))]
                             &sampling_handler,
                             &elicitation_handler,
                             &notification_handler,
@@ -386,8 +370,8 @@ impl RequestHandler {
 #[inline]
 async fn dispatch_batch_deferred(
     deferred: Vec<MessageEnvelope>,
-    #[cfg(not(feature = "proto-2026-07-28-rc"))] roots: &Arc<RwLock<Vec<Root>>>,
-    #[cfg(not(feature = "proto-2026-07-28-rc"))] sampling_handler: &Option<SamplingHandler>,
+    roots: &Arc<RwLock<Vec<Root>>>,
+    sampling_handler: &Option<SamplingHandler>,
     elicitation_handler: &Option<ElicitationHandler>,
     notification_handler: &Option<Arc<NotificationsHandler>>,
     #[cfg(feature = "tasks")] tasks: &Arc<TaskTracker>,
@@ -400,9 +384,7 @@ async fn dispatch_batch_deferred(
             MessageEnvelope::Request(req) => Some(MessageEnvelope::Response(
                 dispatch_request(
                     req,
-                    #[cfg(not(feature = "proto-2026-07-28-rc"))]
                     roots,
-                    #[cfg(not(feature = "proto-2026-07-28-rc"))]
                     sampling_handler,
                     elicitation_handler,
                     #[cfg(feature = "tasks")]
@@ -435,14 +417,13 @@ async fn send_response_impl(sender: &mut TransportProtoSender, resp: Response) {
 #[inline]
 async fn dispatch_request(
     req: Request,
-    #[cfg(not(feature = "proto-2026-07-28-rc"))] roots: &Arc<RwLock<Vec<Root>>>,
-    #[cfg(not(feature = "proto-2026-07-28-rc"))] sampling_handler: &Option<SamplingHandler>,
+    roots: &Arc<RwLock<Vec<Root>>>,
+    sampling_handler: &Option<SamplingHandler>,
     elicitation_handler: &Option<ElicitationHandler>,
     #[cfg(feature = "tasks")] tasks: &Arc<TaskTracker>,
 ) -> Response {
     let req_id = req.id();
     match req.method.as_str() {
-        #[cfg(not(feature = "proto-2026-07-28-rc"))]
         crate::types::sampling::commands::CREATE => {
             handle_sampling(
                 req,
@@ -461,7 +442,6 @@ async fn dispatch_request(
             )
             .await
         }
-        #[cfg(not(feature = "proto-2026-07-28-rc"))]
         crate::types::root::commands::LIST => handle_roots(req, roots).await,
         #[cfg(feature = "tasks")]
         crate::types::task::commands::RESULT => get_task_result(req, tasks).await,
@@ -485,12 +465,11 @@ async fn dispatch_notification(
     if let Some(h) = handler {
         h.notify(notification).await
     } else {
-        #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+        #[cfg(feature = "tracing")]
         notification.write();
     }
 }
 
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 #[inline]
 async fn handle_roots(req: Request, roots: &Arc<RwLock<Vec<Root>>>) -> Response {
     let roots = {
@@ -501,7 +480,7 @@ async fn handle_roots(req: Request, roots: &Arc<RwLock<Vec<Root>>>) -> Response 
 }
 
 #[inline]
-#[cfg(all(not(feature = "tasks"), not(feature = "proto-2026-07-28-rc")))]
+#[cfg(not(feature = "tasks"))]
 async fn handle_sampling(req: Request, handler: &Option<SamplingHandler>) -> Response {
     let id = req.id();
     if let Some(handler) = &handler {
@@ -525,7 +504,7 @@ async fn handle_sampling(req: Request, handler: &Option<SamplingHandler>) -> Res
 }
 
 #[inline]
-#[cfg(all(feature = "tasks", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "tasks")]
 async fn handle_sampling(
     req: Request,
     handler: &Option<SamplingHandler>,
@@ -733,20 +712,17 @@ fn validate_batch_ids(items: &[MessageEnvelope]) -> Result<(), Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     use std::pin::Pin;
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     use tokio::time::Instant;
 
     #[tokio::test]
     #[cfg(feature = "http-client")]
     async fn cancelled_transport_fails_pending_request_immediately() {
-        use crate::transport::http::HttpClient;
         use tokio::time::{Duration, timeout};
 
         let token = CancellationToken::new();
         let mut handler = RequestHandler::new(
-            TransportProto::HttpClient(HttpClient::default()),
+            TransportProto::HttpClient(Box::default()),
             &McpOptions::default(),
             token.clone(),
         );
@@ -817,7 +793,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     async fn batch_requests_are_dispatched_concurrently() {
         use crate::types::sampling::{CreateMessageRequestParams, CreateMessageResult};
         use tokio::time::Duration;

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -80,6 +80,12 @@ pub(super) struct RequestHandler {
     /// Task tracker for client sampling tasks.
     #[cfg(feature = "tasks")]
     tasks: Arc<TaskTracker>,
+
+    /// Which protocol generation the peer speaks (issue #84) — shared with
+    /// [`Client`](crate::client::Client), so the dual-mode fallback's flip
+    /// is observed by the receive loop.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    peer_mode: crate::shared::PeerMode,
 }
 
 impl Roots {
@@ -149,6 +155,8 @@ impl RequestHandler {
             notification_handler: options.notification_handler.clone(),
             #[cfg(feature = "tasks")]
             tasks: Arc::new(TaskTracker::new()),
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            peer_mode: options.peer_mode.clone(),
         };
 
         handler.start(rx)
@@ -299,6 +307,8 @@ impl RequestHandler {
 
         #[cfg(feature = "tasks")]
         let tasks = self.tasks.clone();
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        let peer_mode = self.peer_mode.clone();
 
         tokio::task::spawn(async move {
             while let Ok(msg) = rx.recv().await {
@@ -312,6 +322,8 @@ impl RequestHandler {
                             &elicitation_handler,
                             #[cfg(feature = "tasks")]
                             &tasks,
+                            #[cfg(feature = "proto-2026-07-28-rc")]
+                            &peer_mode,
                         )
                         .await;
                         send_response_impl(&mut sender, resp).await;
@@ -348,6 +360,8 @@ impl RequestHandler {
                             &notification_handler,
                             #[cfg(feature = "tasks")]
                             &tasks,
+                            #[cfg(feature = "proto-2026-07-28-rc")]
+                            &peer_mode,
                         )
                         .await;
                         // MessageBatch::new returns Err for an empty vec (all
@@ -375,6 +389,7 @@ async fn dispatch_batch_deferred(
     elicitation_handler: &Option<ElicitationHandler>,
     notification_handler: &Option<Arc<NotificationsHandler>>,
     #[cfg(feature = "tasks")] tasks: &Arc<TaskTracker>,
+    #[cfg(feature = "proto-2026-07-28-rc")] peer_mode: &crate::shared::PeerMode,
 ) -> Vec<MessageEnvelope> {
     use futures_util::future::join_all;
 
@@ -389,6 +404,8 @@ async fn dispatch_batch_deferred(
                     elicitation_handler,
                     #[cfg(feature = "tasks")]
                     tasks,
+                    #[cfg(feature = "proto-2026-07-28-rc")]
+                    peer_mode,
                 )
                 .await,
             )),
@@ -414,6 +431,13 @@ async fn send_response_impl(sender: &mut TransportProtoSender, resp: Response) {
 /// returns the [`Response`] to send back. Unknown methods produce a
 /// [`ErrorCode::MethodNotFound`] error response so the peer is never left
 /// waiting for a reply that will never arrive.
+///
+/// Under `proto-2026-07-28-rc` the legacy server-initiated methods
+/// (`sampling/createMessage`, `roots/list`) are dispatched **only** once the
+/// dual-mode fallback (issue #84) has marked the peer legacy: an RC client
+/// advertises neither capability, so an RC peer asking for them is out of
+/// contract and is answered `MethodNotFound` like any unknown method,
+/// instead of silently running the configured handler.
 #[inline]
 async fn dispatch_request(
     req: Request,
@@ -421,10 +445,18 @@ async fn dispatch_request(
     sampling_handler: &Option<SamplingHandler>,
     elicitation_handler: &Option<ElicitationHandler>,
     #[cfg(feature = "tasks")] tasks: &Arc<TaskTracker>,
+    #[cfg(feature = "proto-2026-07-28-rc")] peer_mode: &crate::shared::PeerMode,
 ) -> Response {
+    // The legacy build is legacy by construction; the RC build reads the
+    // switch per dispatch so a post-fallback flip is observed immediately.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    let legacy_peer = peer_mode.is_legacy();
+    #[cfg(not(feature = "proto-2026-07-28-rc"))]
+    let legacy_peer = true;
+
     let req_id = req.id();
     match req.method.as_str() {
-        crate::types::sampling::commands::CREATE => {
+        crate::types::sampling::commands::CREATE if legacy_peer => {
             handle_sampling(
                 req,
                 sampling_handler,
@@ -442,7 +474,7 @@ async fn dispatch_request(
             )
             .await
         }
-        crate::types::root::commands::LIST => handle_roots(req, roots).await,
+        crate::types::root::commands::LIST if legacy_peer => handle_roots(req, roots).await,
         #[cfg(feature = "tasks")]
         crate::types::task::commands::RESULT => get_task_result(req, tasks).await,
         #[cfg(feature = "tasks")]
@@ -824,6 +856,15 @@ mod tests {
             )),
         ];
 
+        // `sampling/createMessage` is a legacy server-initiated method, so
+        // the dispatcher only runs the handler for a legacy peer.
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        let peer_mode = {
+            let mode = crate::shared::PeerMode::default();
+            mode.set_legacy();
+            mode
+        };
+
         let started = Instant::now();
         let responses = dispatch_batch_deferred(
             deferred,
@@ -833,6 +874,8 @@ mod tests {
             &notification_handler,
             #[cfg(feature = "tasks")]
             &Arc::new(crate::shared::TaskTracker::default()),
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            &peer_mode,
         )
         .await;
 
@@ -841,6 +884,72 @@ mod tests {
             started.elapsed() < Duration::from_millis(180),
             "batch requests should run concurrently"
         );
+    }
+
+    /// Legacy server-initiated methods are out of contract for an RC peer:
+    /// the client advertises neither `sampling` nor `roots`, so the
+    /// configured handlers must stay unreachable until the dual-mode
+    /// fallback marks the peer legacy.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[tokio::test]
+    async fn legacy_server_push_is_gated_on_the_peer_mode() {
+        use crate::types::sampling::{CreateMessageRequestParams, CreateMessageResult};
+
+        let roots = Arc::new(RwLock::new(Vec::<Root>::new()));
+        let sampling_handler: Option<SamplingHandler> = Some(Arc::new(
+            |_params: CreateMessageRequestParams| -> Pin<
+                Box<dyn Future<Output = CreateMessageResult> + Send + 'static>,
+            > { Box::pin(async move { CreateMessageResult::assistant() }) },
+        ));
+        let elicitation_handler = None;
+        let peer_mode = crate::shared::PeerMode::default();
+
+        // `sampling/createMessage` needs well-formed params to reach its
+        // handler at all, so the gate is what the assertions isolate.
+        let request = |method: &str| match method {
+            crate::types::sampling::commands::CREATE => Request::new(
+                Some(RequestId::Number(1)),
+                method,
+                Some(CreateMessageRequestParams::default()),
+            ),
+            _ => Request::new(Some(RequestId::Number(1)), method, None::<()>),
+        };
+
+        let dispatch = async |method: &str, peer_mode: &crate::shared::PeerMode| {
+            dispatch_request(
+                request(method),
+                &roots,
+                &sampling_handler,
+                &elicitation_handler,
+                #[cfg(feature = "tasks")]
+                &Arc::new(crate::shared::TaskTracker::default()),
+                peer_mode,
+            )
+            .await
+        };
+
+        for method in [
+            crate::types::sampling::commands::CREATE,
+            crate::types::root::commands::LIST,
+        ] {
+            let resp = dispatch(method, &peer_mode).await;
+            let Response::Err(err) = resp else {
+                panic!("an RC peer must not reach the legacy `{method}` handler");
+            };
+            assert_eq!(err.error.code, ErrorCode::MethodNotFound);
+        }
+
+        // After the fallback the very same requests are in contract again.
+        peer_mode.set_legacy();
+        for method in [
+            crate::types::sampling::commands::CREATE,
+            crate::types::root::commands::LIST,
+        ] {
+            assert!(
+                matches!(dispatch(method, &peer_mode).await, Response::Ok(_)),
+                "a legacy peer must reach the `{method}` handler"
+            );
+        }
     }
 
     #[test]

--- a/neva/src/client/options.rs
+++ b/neva/src/client/options.rs
@@ -3,15 +3,11 @@
 use crate::PROTOCOL_VERSIONS;
 use crate::client::notification_handler::NotificationsHandler;
 use crate::transport::{StdIoClient, TransportProto, stdio::options::StdIoOptions};
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use crate::types::SamplingCapability;
 use crate::types::elicitation::ElicitationHandler;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use crate::types::sampling::SamplingHandler;
 use crate::types::{ElicitationCapability, Implementation};
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use crate::types::{Root, RootsCapability, Uri};
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
@@ -56,11 +52,9 @@ pub struct McpOptions {
     pub(super) timeout: Duration,
 
     /// Roots capability options
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(super) roots_capability: Option<RootsCapability>,
 
     /// Sampling capability options
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(super) sampling_capability: Option<SamplingCapability>,
 
     /// Elicitation capability options
@@ -71,7 +65,6 @@ pub struct McpOptions {
     pub(super) tasks_capability: Option<ClientTasksCapability>,
 
     /// Represents a handler function that runs when received a "sampling/createMessage" request
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(super) sampling_handler: Option<SamplingHandler>,
 
     /// Represents a handler function that runs when received a "elicitation/create" request
@@ -87,7 +80,6 @@ pub struct McpOptions {
     proto: Option<TransportProto>,
 
     /// Represents a list of roots that the client supports
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     roots: HashMap<Uri, Root>,
 
     /// Optional W3C Trace Context provider. Invoked before each outbound
@@ -99,6 +91,12 @@ pub struct McpOptions {
     /// (guards against a server that never converges).
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub(crate) max_mrtr_rounds: usize,
+
+    /// The dual-mode runtime switch: which protocol generation the
+    /// connected peer speaks. Shared with the transport so per-request
+    /// behavior (headers) follows the handshake outcome.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    pub(crate) peer_mode: crate::shared::PeerMode,
 }
 
 impl Debug for McpOptions {
@@ -109,14 +107,12 @@ impl Debug for McpOptions {
             .field("timeout", &self.timeout)
             .field("elicitation_capability", &self.elicitation_capability);
 
-        #[cfg(not(feature = "proto-2026-07-28-rc"))]
         let dbg = dbg
             .field("roots_capability", &self.roots_capability)
             .field("sampling_capability", &self.sampling_capability);
 
         let dbg = dbg.field("protocol_ver", &self.protocol_ver);
 
-        #[cfg(not(feature = "proto-2026-07-28-rc"))]
         let dbg = dbg.field("roots", &self.roots);
 
         #[cfg(feature = "tasks")]
@@ -132,18 +128,14 @@ impl Default for McpOptions {
         Self {
             timeout: Duration::from_secs(DEFAULT_REQUEST_TIMEOUT),
             implementation: Default::default(),
-            #[cfg(not(feature = "proto-2026-07-28-rc"))]
             roots: Default::default(),
-            #[cfg(not(feature = "proto-2026-07-28-rc"))]
             roots_capability: None,
-            #[cfg(not(feature = "proto-2026-07-28-rc"))]
             sampling_capability: None,
             elicitation_capability: None,
             #[cfg(feature = "tasks")]
             tasks_capability: None,
             proto: None,
             protocol_ver: None,
-            #[cfg(not(feature = "proto-2026-07-28-rc"))]
             sampling_handler: None,
             elicitation_handler: None,
             notification_handler: None,
@@ -151,6 +143,8 @@ impl Default for McpOptions {
             trace_context_provider: None,
             #[cfg(feature = "proto-2026-07-28-rc")]
             max_mrtr_rounds: DEFAULT_MAX_MRTR_ROUNDS,
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            peer_mode: Default::default(),
         }
     }
 }
@@ -170,7 +164,9 @@ impl McpOptions {
     /// Sets Streamable HTTP as a transport protocol
     #[cfg(feature = "http-client")]
     pub fn with_http<F: FnOnce(HttpClient) -> HttpClient>(mut self, config: F) -> Self {
-        self.proto = Some(TransportProto::HttpClient(config(HttpClient::default())));
+        self.proto = Some(TransportProto::HttpClient(Box::new(config(
+            HttpClient::default(),
+        ))));
         self
     }
 
@@ -201,20 +197,16 @@ impl McpOptions {
     ///
     /// Default: last available protocol version
     ///
-    /// Not available under `proto-2026-07-28-rc`: that flag compiles the client
-    /// as a pure 2026-07-28 RC peer (sampling/roots removed, stateless transport,
-    /// MRTR), so negotiating an older version would advertise a protocol the
-    /// build cannot actually speak. The RC version is fixed and sent on every
-    /// request. When the RC graduates and the flags invert, version selection
-    /// returns under the legacy flag.
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
+    /// Under `proto-2026-07-28-rc` the RC version itself is fixed — the
+    /// value set here only selects which **legacy** version the
+    /// dual-mode fallback negotiates when a server rejects
+    /// `server/discover` (default: the newest pre-RC version).
     pub fn with_mcp_version(mut self, ver: &'static str) -> Self {
         self.protocol_ver = Some(ver);
         self
     }
 
     /// Configures Roots capability
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[deprecated(
         note = "Roots are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
     )]
@@ -227,7 +219,6 @@ impl McpOptions {
     }
 
     /// Configures Sampling capability
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[deprecated(
         note = "Sampling is removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
     )]
@@ -313,18 +304,41 @@ impl McpOptions {
 
     /// Returns current transport protocol
     pub(crate) fn transport(&mut self) -> TransportProto {
-        let transport = self.proto.take();
-        transport.unwrap_or_default()
+        let transport = self.proto.take().unwrap_or_default();
+        // Hand the dual-mode switch to the HTTP transport so request
+        // headers follow the negotiated protocol generation.
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        let transport = match transport {
+            TransportProto::HttpClient(http) => {
+                TransportProto::HttpClient(Box::new(http.with_peer_mode(self.peer_mode.clone())))
+            }
+            other => other,
+        };
+        transport
+    }
+
+    /// The newest pre-RC protocol version — what the dual-mode fallback
+    /// negotiates with a legacy peer. Honors a legacy
+    /// [`with_mcp_version`](Self::with_mcp_version) override.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    pub(crate) fn legacy_protocol_ver(&self) -> &'static str {
+        match self.protocol_ver {
+            Some(ver) if ver != crate::RC_PROTOCOL_VERSION => ver,
+            _ => PROTOCOL_VERSIONS
+                .iter()
+                .rev()
+                .find(|ver| **ver != crate::RC_PROTOCOL_VERSION)
+                .copied()
+                .unwrap_or("2025-11-25"),
+        }
     }
 
     /// Adds a root
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub fn add_root(&mut self, root: Root) -> &mut Root {
         self.roots.entry(root.uri.clone()).or_insert(root)
     }
 
     /// Adds multiple roots
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub fn add_roots<T, I>(&mut self, roots: I) -> &mut Self
     where
         T: Into<Root>,
@@ -339,13 +353,11 @@ impl McpOptions {
     }
 
     /// Returns a list of defined Roots
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub fn roots(&self) -> Vec<Root> {
         self.roots.values().cloned().collect()
     }
 
     /// Registers a handler for sampling requests
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(crate) fn add_sampling_handler(&mut self, handler: SamplingHandler) {
         self.sampling_handler = Some(handler);
     }
@@ -358,7 +370,6 @@ impl McpOptions {
     /// Returns [`RootsCapability`] if configured.
     /// If not configured but at least one [`Root`] exists, returns [`Default`].
     /// Otherwise, returns `None`.
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(crate) fn roots_capability(&self) -> Option<RootsCapability> {
         self.roots_capability
             .clone()
@@ -368,7 +379,6 @@ impl McpOptions {
     /// Returns [`SamplingCapability`] if configured.
     /// If not configured but a sampling handler exists, it returns [`Default`].
     /// Otherwise, returns `None`.
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(crate) fn sampling_capability(&self) -> Option<SamplingCapability> {
         self.sampling_capability
             .clone()
@@ -378,7 +388,6 @@ impl McpOptions {
     /// Returns [`ElicitationCapability`] if configured.
     /// If not configured but an elicitation handler exists, it returns [`Default`].
     /// Otherwise, returns `None`.
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(crate) fn elicitation_capability(&self) -> Option<ElicitationCapability> {
         self.elicitation_capability
             .clone()
@@ -388,7 +397,7 @@ impl McpOptions {
     /// Returns [`ClientTasksCapability`] if configured.
     ///
     /// Otherwise, returns `None`.
-    #[cfg(all(feature = "tasks", not(feature = "proto-2026-07-28-rc")))]
+    #[cfg(feature = "tasks")]
     pub(crate) fn tasks_capability(&self) -> Option<ClientTasksCapability> {
         self.tasks_capability.clone()
     }

--- a/neva/src/client/options.rs
+++ b/neva/src/client/options.rs
@@ -294,6 +294,11 @@ impl McpOptions {
     }
 
     /// Returns a Model Context Protocol version that client supports
+    ///
+    /// Under `proto-2026-07-28-rc` the RC version is pinned and the
+    /// legacy override is read via
+    /// [`legacy_protocol_ver`](Self::legacy_protocol_ver) instead.
+    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[inline]
     pub(crate) fn protocol_ver(&self) -> &'static str {
         match self.protocol_ver {

--- a/neva/src/client/options.rs
+++ b/neva/src/client/options.rs
@@ -311,8 +311,11 @@ impl McpOptions {
     pub(crate) fn transport(&mut self) -> TransportProto {
         let transport = self.proto.take().unwrap_or_default();
         // Hand the dual-mode switch to the HTTP transport so request
-        // headers follow the negotiated protocol generation.
-        #[cfg(feature = "proto-2026-07-28-rc")]
+        // headers follow the negotiated protocol generation. Only the
+        // HTTP transport carries them, so this is gated on `http-client`
+        // as well — stdio-only RC clients (no `TransportProto::HttpClient`
+        // variant at all) pass the transport through untouched.
+        #[cfg(all(feature = "proto-2026-07-28-rc", feature = "http-client"))]
         let transport = match transport {
             TransportProto::HttpClient(http) => {
                 TransportProto::HttpClient(Box::new(http.with_peer_mode(self.peer_mode.clone())))

--- a/neva/src/client/options.rs
+++ b/neva/src/client/options.rs
@@ -390,7 +390,7 @@ impl McpOptions {
     pub(crate) fn sampling_capability(&self) -> Option<SamplingCapability> {
         self.sampling_capability
             .clone()
-            .or_else(|| self.sampling_handler.is_none().then(Default::default))
+            .or_else(|| self.sampling_handler.is_some().then(Default::default))
     }
 
     /// Returns [`ElicitationCapability`] if configured.
@@ -399,7 +399,7 @@ impl McpOptions {
     pub(crate) fn elicitation_capability(&self) -> Option<ElicitationCapability> {
         self.elicitation_capability
             .clone()
-            .or_else(|| self.elicitation_handler.is_none().then(Default::default))
+            .or_else(|| self.elicitation_handler.is_some().then(Default::default))
     }
 
     /// Returns [`ClientTasksCapability`] if configured.
@@ -413,8 +413,41 @@ impl McpOptions {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[allow(unused_imports)]
     use super::*;
+
+    /// Implicit sampling/elicitation capabilities follow the *installed
+    /// handler*: advertising one a client cannot serve makes a legacy
+    /// server send requests answered with `MethodNotFound`, while hiding
+    /// one that is installed makes it skip the feature entirely.
+    #[test]
+    fn implicit_capabilities_follow_the_installed_handlers() {
+        let mut opts = McpOptions::default();
+        assert!(
+            opts.sampling_capability().is_none(),
+            "no sampling handler — nothing to advertise"
+        );
+        assert!(
+            opts.elicitation_capability().is_none(),
+            "no elicitation handler — nothing to advertise"
+        );
+
+        opts.add_sampling_handler(Arc::new(|_params| {
+            Box::pin(async move { crate::types::sampling::CreateMessageResult::assistant() })
+        }));
+        opts.add_elicitation_handler(Arc::new(|_params| {
+            Box::pin(async move { crate::types::elicitation::ElicitResult::decline() })
+        }));
+
+        assert!(
+            opts.sampling_capability().is_some(),
+            "an installed sampling handler must be advertised"
+        );
+        assert!(
+            opts.elicitation_capability().is_some(),
+            "an installed elicitation handler must be advertised"
+        );
+    }
 
     #[test]
     #[cfg(feature = "proto-2026-07-28-rc")]

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -96,8 +96,12 @@ pub(crate) const PROTOCOL_VERSIONS: &[&str] = &[
     "2025-06-18",
     "2025-11-25",
     #[cfg(feature = "proto-2026-07-28-rc")]
-    "2026-07-28",
+    RC_PROTOCOL_VERSION,
 ];
+
+/// The MCP 2026-07-28 RC protocol version string.
+#[cfg(feature = "proto-2026-07-28-rc")]
+pub(crate) const RC_PROTOCOL_VERSION: &str = "2026-07-28";
 
 // Mutual-exclusion guard for `proto-*` generation flags.
 //

--- a/neva/src/shared.rs
+++ b/neva/src/shared.rs
@@ -104,6 +104,32 @@ async fn wait_for_shutdown_signal_impl() -> std::io::Result<()> {
     }
 }
 
+/// Which protocol generation the connected peer speaks — the runtime
+/// switch behind the dual-mode client (issue #84).
+///
+/// An RC-flagged client starts in RC mode (`server/discover`, stateless,
+/// MRTR) and flips to legacy exactly once, in `Client::connect`'s
+/// fallback, before any other traffic — so nothing races the switch.
+/// The legacy build has no switch: it is legacy by construction.
+///
+/// Cheap to clone; all clones observe the same flip.
+#[cfg(all(feature = "client", feature = "proto-2026-07-28-rc"))]
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PeerMode(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+#[cfg(all(feature = "client", feature = "proto-2026-07-28-rc"))]
+impl PeerMode {
+    /// Marks the peer as a legacy (pre-RC) server.
+    pub(crate) fn set_legacy(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::Release);
+    }
+
+    /// Whether the peer speaks the legacy (pre-RC) protocol.
+    pub(crate) fn is_legacy(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
 /// MRTR-eligible client requests (the only ones that may receive an
 /// `InputRequiredResult`).
 #[cfg(feature = "proto-2026-07-28-rc")]

--- a/neva/src/shared.rs
+++ b/neva/src/shared.rs
@@ -50,7 +50,12 @@ mod task_tracker;
 pub(crate) fn wait_for_shutdown_signal(token: CancellationToken) {
     tokio::spawn(async move {
         match wait_for_shutdown_signal_impl().await {
-            Ok(_) => (),
+            // A shutdown signal actually arrived — cancel the transport.
+            Ok(_) => token.cancel(),
+            // Failing to *register* the handler (e.g. a sandboxed
+            // environment restricting signal APIs) must not tear the
+            // transport down — the watcher simply exits and process
+            // lifecycle stays with whatever launched it.
             #[cfg(feature = "tracing")]
             Err(err) => tracing::error!(
                 logger = "neva",
@@ -60,7 +65,6 @@ pub(crate) fn wait_for_shutdown_signal(token: CancellationToken) {
             #[cfg(not(feature = "tracing"))]
             Err(_) => (),
         }
-        token.cancel();
     });
 }
 

--- a/neva/src/transport.rs
+++ b/neva/src/transport.rs
@@ -56,7 +56,7 @@ pub(crate) enum TransportProto {
     #[cfg(feature = "http-server")]
     HttpServer(Box<dyn http::core::engine::HttpTransport>),
     #[cfg(feature = "http-client")]
-    HttpClient(HttpClient),
+    HttpClient(Box<HttpClient>),
     //Ws(Websocket),
     // add more options here...
 }

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -139,6 +139,8 @@ where
 pub struct HttpClient {
     url: ServiceUrl,
     access_token: Option<Box<[u8]>>,
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    peer_mode: crate::shared::PeerMode,
     #[cfg(feature = "client-oauth")]
     oauth: Option<client::oauth::OAuthClientConfig>,
     #[cfg(feature = "client-tls")]
@@ -160,6 +162,8 @@ pub(super) struct ClientRuntimeContext {
     tx: Sender<Result<Message, Error>>,
     rx: Receiver<Message>,
     access_token: Option<Box<[u8]>>,
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    pub(super) peer_mode: crate::shared::PeerMode,
     #[cfg(feature = "client-oauth")]
     oauth: Option<std::sync::Arc<client::oauth::OAuthSession>>,
     #[cfg(feature = "client-tls")]
@@ -224,6 +228,8 @@ impl Default for HttpClient {
         Self {
             url: ServiceUrl::default(),
             access_token: None,
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            peer_mode: Default::default(),
             #[cfg(feature = "client-oauth")]
             oauth: None,
             #[cfg(feature = "client-tls")]
@@ -663,6 +669,15 @@ impl HttpClient {
         self
     }
 
+    /// Hands the dual-mode protocol switch to this transport (set by
+    /// `McpOptions::transport`) so per-request headers follow the
+    /// negotiated protocol generation.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    pub(crate) fn with_peer_mode(mut self, peer_mode: crate::shared::PeerMode) -> Self {
+        self.peer_mode = peer_mode;
+        self
+    }
+
     /// Set the bearer token for requests
     ///
     ///Default: `None`
@@ -725,6 +740,8 @@ impl HttpClient {
             tx: self.receiver.tx.clone(),
             rx: sender_rx,
             access_token: self.access_token.take(),
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            peer_mode: self.peer_mode.clone(),
             #[cfg(feature = "client-oauth")]
             oauth,
             #[cfg(feature = "client-tls")]

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -315,6 +315,7 @@ async fn send_request(
         }
     }
 
+    let status = resp.status();
     match resp.json::<Message>().await {
         Ok(msg) => {
             if let Err(_err) = resp_tx.send(Ok(msg)).await {
@@ -324,26 +325,53 @@ async fn send_request(
         }
         // A reply that is not JSON-RPC — an HTML error page, or an error
         // code outside neva's `ErrorCode` set (e.g. the TS SDK's -32000).
-        // Complete every originating request with an id-bound `ParseError`
+        // Complete every originating request with an id-bound error
         // response: a bare `Err` pushed into the channel would terminate
         // the receive loop without ever resolving the pending request.
         // This is also what lets `server/discover` classify such replies
         // and fall back to `initialize`.
         Err(err) => {
             #[cfg(feature = "tracing")]
-            tracing::error!(logger = "neva", "Failed to parse HTTP response: {}", err);
-            let reason = err.to_string();
+            tracing::error!(
+                logger = "neva",
+                "Failed to parse HTTP response ({}): {}",
+                status,
+                err
+            );
+            let (code, reason) = parse_failure(status, &err);
             for id in request_ids(&req) {
-                let resp = crate::types::Response::error(
-                    id,
-                    Error::new(ErrorCode::ParseError, reason.clone()),
-                );
+                let resp = crate::types::Response::error(id, Error::new(code, reason.clone()));
                 if resp_tx.send(Ok(Message::Response(resp))).await.is_err() {
                     break;
                 }
             }
         }
     }
+}
+
+/// Classifies a non-JSON-RPC HTTP reply into the code and message the
+/// originating requests are completed with, carrying the HTTP status so
+/// the caller can tell *why* the body wasn't JSON-RPC.
+///
+/// The code matters beyond diagnostics: `ParseError` is one of the
+/// dual-mode fallback triggers, so a protected endpoint
+/// answering `401`/`403`/`407` with an HTML page must **not** produce it —
+/// otherwise a failed authentication against a perfectly valid RC server
+/// would be read as "this peer is legacy", silently dropping the RC
+/// headers and retrying `initialize`. Authentication failures are
+/// transport-level (`InternalError`, like "Connection closed") and
+/// surface to the caller as-is.
+#[inline]
+fn parse_failure(status: reqwest::StatusCode, err: &reqwest::Error) -> (ErrorCode, String) {
+    use reqwest::StatusCode;
+
+    let code = match status {
+        StatusCode::UNAUTHORIZED
+        | StatusCode::FORBIDDEN
+        | StatusCode::PROXY_AUTHENTICATION_REQUIRED => ErrorCode::InternalError,
+        _ => ErrorCode::ParseError,
+    };
+    (code, format!("HTTP {status}: {err}"))
 }
 
 /// The ids of the requests `msg` carries (empty for notifications and

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -354,22 +354,32 @@ async fn send_request(
 /// the caller can tell *why* the body wasn't JSON-RPC.
 ///
 /// The code matters beyond diagnostics: `ParseError` is one of the
-/// dual-mode fallback triggers, so a protected endpoint
-/// answering `401`/`403`/`407` with an HTML page must **not** produce it —
-/// otherwise a failed authentication against a perfectly valid RC server
-/// would be read as "this peer is legacy", silently dropping the RC
-/// headers and retrying `initialize`. Authentication failures are
-/// transport-level (`InternalError`, like "Connection closed") and
-/// surface to the caller as-is.
+/// dual-mode fallback triggers (issue #84), so it must be produced *only*
+/// for replies that genuinely suggest "this peer doesn't know the RC
+/// method/route" — an allowlist, not a catch-all:
+///
+/// * any `2xx` — a legacy peer answering `server/discover` on the wire but
+///   with a body neva can't read as JSON-RPC, most notably an error code
+///   outside its `ErrorCode` set (the TS SDK's `-32000` "server not
+///   initialized" family);
+/// * `400` / `404` / `405` / `406` — routers and legacy servers rejecting
+///   the unknown method or endpoint outright.
+///
+/// Everything else is an upstream failure that says nothing about the
+/// peer's protocol generation and must surface as-is
+/// (`InternalError`, like "Connection closed"):
+/// `401`/`403`/`407` (authentication — otherwise a failed login against a
+/// valid RC server reads as "legacy"), `429` (rate limit) and every `5xx`
+/// (reverse-proxy outage, gateway timeout). Treating those as legacy
+/// evidence would silently drop the RC headers, retry `initialize` into
+/// the same outage, and bury the real cause.
 #[inline]
-fn parse_failure(status: reqwest::StatusCode, err: &reqwest::Error) -> (ErrorCode, String) {
-    use reqwest::StatusCode;
-
-    let code = match status {
-        StatusCode::UNAUTHORIZED
-        | StatusCode::FORBIDDEN
-        | StatusCode::PROXY_AUTHENTICATION_REQUIRED => ErrorCode::InternalError,
-        _ => ErrorCode::ParseError,
+fn parse_failure(status: reqwest::StatusCode, err: &impl std::fmt::Display) -> (ErrorCode, String) {
+    let unsupported_route = matches!(status.as_u16(), 400 | 404 | 405 | 406);
+    let code = if status.is_success() || unsupported_route {
+        ErrorCode::ParseError
+    } else {
+        ErrorCode::InternalError
     };
     (code, format!("HTTP {status}: {err}"))
 }
@@ -649,6 +659,42 @@ mod tests {
 
     // A minimal valid JSON-RPC notification that Message will accept
     const VALID_MSG: &str = r#"{"jsonrpc":"2.0","method":"ping"}"#;
+
+    /// Only statuses that actually suggest an unknown method/route may
+    /// yield `ParseError` — the dual-mode fallback trigger. Upstream
+    /// failures (auth, rate limit, 5xx) must stay `InternalError` so a
+    /// valid RC peer is never mistaken for a legacy one.
+    #[test]
+    fn parse_failure_classifies_statuses() {
+        let cases = [
+            // legacy evidence: the peer answered, the body just isn't JSON-RPC
+            (200, ErrorCode::ParseError),
+            (202, ErrorCode::ParseError),
+            (400, ErrorCode::ParseError),
+            (404, ErrorCode::ParseError),
+            (405, ErrorCode::ParseError),
+            (406, ErrorCode::ParseError),
+            // upstream failures: say nothing about the protocol generation
+            (401, ErrorCode::InternalError),
+            (403, ErrorCode::InternalError),
+            (407, ErrorCode::InternalError),
+            (429, ErrorCode::InternalError),
+            (500, ErrorCode::InternalError),
+            (502, ErrorCode::InternalError),
+            (503, ErrorCode::InternalError),
+            (504, ErrorCode::InternalError),
+        ];
+
+        for (status, expected) in cases {
+            let status = reqwest::StatusCode::from_u16(status).unwrap();
+            let (code, reason) = parse_failure(status, &"boom");
+            assert_eq!(code, expected, "wrong code for HTTP {status}");
+            assert!(
+                reason.contains(status.as_str()),
+                "the status must be carried in the message, got: {reason}"
+            );
+        }
+    }
 
     #[tokio::test]
     async fn it_advances_last_event_id_on_successful_delivery() {

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -300,7 +300,7 @@ async fn send_request(
         session.set_session_id(session_id);
     }
 
-    if let Message::Request(r) = req
+    if let Message::Request(r) = &req
         && r.method == crate::commands::INIT
     {
         let token = session.cancellation_token();
@@ -315,11 +315,50 @@ async fn send_request(
         }
     }
 
-    let resp = resp.json::<Message>().await;
+    match resp.json::<Message>().await {
+        Ok(msg) => {
+            if let Err(_err) = resp_tx.send(Ok(msg)).await {
+                #[cfg(feature = "tracing")]
+                tracing::error!(logger = "neva", "Failed to send response: {}", _err);
+            }
+        }
+        // A reply that is not JSON-RPC — an HTML error page, or an error
+        // code outside neva's `ErrorCode` set (e.g. the TS SDK's -32000).
+        // Complete every originating request with an id-bound `ParseError`
+        // response: a bare `Err` pushed into the channel would terminate
+        // the receive loop without ever resolving the pending request.
+        // This is also what lets `server/discover` classify such replies
+        // and fall back to `initialize`.
+        Err(err) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(logger = "neva", "Failed to parse HTTP response: {}", err);
+            let reason = err.to_string();
+            for id in request_ids(&req) {
+                let resp = crate::types::Response::error(
+                    id,
+                    Error::new(ErrorCode::ParseError, reason.clone()),
+                );
+                if resp_tx.send(Ok(Message::Response(resp))).await.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
 
-    if let Err(_err) = resp_tx.send(resp.map_err(Error::from)).await {
-        #[cfg(feature = "tracing")]
-        tracing::error!(logger = "neva", "Failed to send response: {}", _err);
+/// The ids of the requests `msg` carries (empty for notifications and
+/// notification-only batches).
+fn request_ids(msg: &Message) -> Vec<crate::types::RequestId> {
+    match msg {
+        Message::Request(r) => vec![r.id()],
+        Message::Batch(batch) => batch
+            .iter()
+            .filter_map(|envelope| match envelope {
+                crate::types::MessageEnvelope::Request(r) => Some(r.id()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
     }
 }
 
@@ -516,14 +555,23 @@ async fn handle_msg(
     let Some(data) = event.data else {
         return false;
     };
-    let msg = serde_json::from_str::<Message>(&data);
-    let parsed_ok = msg.is_ok();
-    if let Err(_err) = resp_tx.send(msg.map_err(Error::from)).await {
+    // A malformed SSE frame must not reach the receive loop as a bare
+    // `Err` (that would terminate it) — log and skip; the last event id
+    // does not advance, so a reconnect replays the event.
+    let msg = match serde_json::from_str::<Message>(&data) {
+        Ok(msg) => msg,
+        Err(_err) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(logger = "neva", "Failed to parse SSE event: {}", _err);
+            return false;
+        }
+    };
+    if let Err(_err) = resp_tx.send(Ok(msg)).await {
         #[cfg(feature = "tracing")]
         tracing::error!(logger = "neva", "Failed to send server request: {}", _err);
         return false;
     }
-    parsed_ok
+    true
 }
 
 #[inline]

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -6,17 +6,13 @@ use crate::{
     transport::http::{ClientRuntimeContext, MCP_SESSION_ID, get_mcp_session_id},
     types::Message,
 };
-// SSE-stream imports — used only by the non-RC GET stream path.
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use futures_util::{StreamExt, TryStreamExt};
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use reqwest::header::{CACHE_CONTROL, HeaderName};
 use reqwest::{
     RequestBuilder,
     header::{ACCEPT, CONTENT_TYPE},
 };
 use std::sync::Arc;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use std::time::Duration;
 
 #[cfg(feature = "client-tls")]
@@ -66,11 +62,10 @@ impl ClientAuth {
     }
 }
 
-// SSE-only constants — the standalone GET stream does not exist under the
-// stateless RC transport.
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+// SSE constants — the standalone GET stream serves legacy peers only;
+// its machinery compiles under both flags for the dual-mode client and
+// activates at runtime when a legacy `initialize` handshake happens.
 const LAST_EVENT_ID: HeaderName = HeaderName::from_static("last-event-id");
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 const SSE_RECONNECT_DELAY: Duration = Duration::from_secs(3);
 
 #[cfg(feature = "proto-2026-07-28-rc")]
@@ -91,7 +86,12 @@ fn name_param(req: &crate::types::Request) -> Option<&str> {
 }
 
 pub(super) async fn connect(rt: ClientRuntimeContext, token: CancellationToken) {
-    let session = Arc::new(McpSession::new(rt.url, token));
+    let session = Arc::new(McpSession::new(
+        rt.url,
+        token,
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        rt.peer_mode.clone(),
+    ));
 
     #[cfg(feature = "client-oauth")]
     let auth = match rt.oauth {
@@ -101,19 +101,10 @@ pub(super) async fn connect(rt: ClientRuntimeContext, token: CancellationToken) 
     #[cfg(not(feature = "client-oauth"))]
     let auth = ClientAuth::from_static(rt.access_token);
 
-    // Stateless RC transport issues only POSTs — no standalone SSE GET stream.
-    #[cfg(feature = "proto-2026-07-28-rc")]
-    handle_connection(
-        session.clone(),
-        rt.rx,
-        rt.tx.clone(),
-        auth,
-        #[cfg(feature = "client-tls")]
-        rt.tls_config.clone(),
-    )
-    .await;
-
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
+    // The SSE task arms itself only when a legacy `initialize` handshake
+    // completes (`session.initialized()` fires exclusively for the
+    // `initialize` method) — against an RC peer it stays parked until
+    // cancellation, so the stateless RC transport still issues only POSTs.
     tokio::join!(
         handle_connection(
             session.clone(),
@@ -201,29 +192,23 @@ fn build_post(
         resp = resp.header(MCP_SESSION_ID, session_id.to_string())
     }
 
-    // Routing headers are exercised end-to-end via the trace-context
-    // integration in Task 2.4. Unit-level hint extraction is tested in
+    // RC-peer routing headers: legacy servers never negotiated them, so
+    // a peer that fell back to `initialize` gets the same wire shape a
+    // pure legacy client produces (no routing headers, no RC protocol
+    // version). Routing headers are exercised end-to-end via the
+    // trace-context integration; unit-level hint extraction is tested in
     // `routing_hints_tests`.
     #[cfg(feature = "proto-2026-07-28-rc")]
-    if let Some((method, name)) = routing_hints(req) {
-        resp = resp.header(crate::transport::http::MCP_METHOD, method);
-        if let Some(n) = name {
-            resp = resp.header(crate::transport::http::MCP_NAME, n);
+    if !session.is_legacy() {
+        if let Some((method, name)) = routing_hints(req) {
+            resp = resp.header(crate::transport::http::MCP_METHOD, method);
+            if let Some(n) = name {
+                resp = resp.header(crate::transport::http::MCP_NAME, n);
+            }
         }
-    }
-
-    // Under the RC the protocol version is fixed: `with_mcp_version`
-    // is compiled out, so the client can only ever speak the latest
-    // (RC) version. Sending the last compiled version is therefore
-    // exactly the configured version on every request.
-    #[cfg(feature = "proto-2026-07-28-rc")]
-    {
         resp = resp.header(
             crate::transport::http::MCP_PROTOCOL_VERSION,
-            crate::PROTOCOL_VERSIONS
-                .last()
-                .copied()
-                .unwrap_or("2026-07-28"),
+            crate::RC_PROTOCOL_VERSION,
         );
     }
 
@@ -338,7 +323,6 @@ async fn send_request(
     }
 }
 
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 async fn start_sse_connection(
     session: Arc<McpSession>,
     resp_tx: mpsc::Sender<Result<Message, Error>>,
@@ -361,7 +345,6 @@ async fn start_sse_connection(
     }
 }
 
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 async fn handle_sse_connection(
     session: Arc<McpSession>,
     resp_tx: mpsc::Sender<Result<Message, Error>>,
@@ -499,7 +482,6 @@ async fn handle_sse_connection(
     }
 }
 
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 async fn handle_event(
     event: sse_stream::Sse,
     session: &Arc<McpSession>,
@@ -521,14 +503,12 @@ async fn handle_event(
 }
 
 #[inline]
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 fn handle_error(_err: sse_stream::Error) {
     #[cfg(feature = "tracing")]
     tracing::error!(logger = "neva", "SSE Error: {}", _err);
 }
 
 // Returns true if the message was successfully parsed and delivered.
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 async fn handle_msg(
     event: sse_stream::Sse,
     resp_tx: &mpsc::Sender<Result<Message, Error>>,
@@ -575,9 +555,9 @@ impl From<reqwest::Error> for Error {
     }
 }
 
-// These tests exercise the SSE GET stream path, which does not exist under
-// the stateless RC transport.
-#[cfg(all(test, not(feature = "proto-2026-07-28-rc")))]
+// These tests exercise the SSE GET stream path, which serves legacy
+// peers — compiled under both flags for the dual-mode client.
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::transport::http::ServiceUrl;
@@ -586,6 +566,8 @@ mod tests {
         Arc::new(McpSession::new(
             ServiceUrl::default(),
             CancellationToken::new(),
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            Default::default(),
         ))
     }
 

--- a/neva/src/transport/http/client/mcp_session.rs
+++ b/neva/src/transport/http/client/mcp_session.rs
@@ -3,18 +3,19 @@
 use crate::transport::http::ServiceUrl;
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
 use std::sync::RwLock;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 /// Represents current MCP Session
 pub(super) struct McpSession {
+    /// Dual-mode protocol switch — legacy peers get legacy headers.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    peer_mode: crate::shared::PeerMode,
     initialized: Notify,
     sse_ready: Notify,
     url: Arc<str>,
     session_id: OnceCell<uuid::Uuid>,
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     last_event_id: RwLock<Option<String>>,
     cancellation_token: CancellationToken,
 }
@@ -26,16 +27,28 @@ impl McpSession {
     /// including TLS, has settled in [`ServiceUrl`]) and cached as an
     /// [`Arc<str>`], so the per-request POST/GET paths borrow it directly
     /// instead of re-formatting the URL on every call.
-    pub(super) fn new(url: ServiceUrl, token: CancellationToken) -> Self {
+    pub(super) fn new(
+        url: ServiceUrl,
+        token: CancellationToken,
+        #[cfg(feature = "proto-2026-07-28-rc")] peer_mode: crate::shared::PeerMode,
+    ) -> Self {
         Self {
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            peer_mode,
             initialized: Notify::new(),
             sse_ready: Notify::new(),
             session_id: OnceCell::new(),
-            #[cfg(not(feature = "proto-2026-07-28-rc"))]
             last_event_id: RwLock::new(None),
             cancellation_token: token,
             url: Arc::from(url.to_url()),
         }
+    }
+
+    /// Whether the connected peer negotiated the legacy (pre-RC)
+    /// protocol via the dual-mode fallback.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    pub(super) fn is_legacy(&self) -> bool {
+        self.peer_mode.is_legacy()
     }
 
     /// Returns the pre-assembled request URL for this session.
@@ -67,13 +80,11 @@ impl McpSession {
     }
 
     /// Returns the last received SSE event ID, if any
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(super) fn last_event_id(&self) -> Option<String> {
         self.last_event_id.read().ok().and_then(|g| g.clone())
     }
 
     /// Updates the last received SSE event ID
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     pub(super) fn set_last_event_id(&self, id: String) {
         if let Ok(mut guard) = self.last_event_id.write() {
             *guard = Some(id);
@@ -87,14 +98,12 @@ impl McpSession {
     }
 
     /// Sends a signal that the SSE-connection has been initialized
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[inline]
     pub(super) fn notify_sse_initialized(&self) {
         self.sse_ready.notify_one();
     }
 
     /// Waits for MCP Session to be initialized
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[inline]
     pub(super) async fn initialized(&self) {
         self.initialized.notified().await;
@@ -111,9 +120,7 @@ impl McpSession {
 mod tests {
     use super::*;
     use crate::transport::http::HttpProto;
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     use std::sync::Arc;
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     use tokio::time::{Duration, timeout};
     use tokio_util::sync::CancellationToken;
     use uuid::Uuid;
@@ -125,7 +132,12 @@ mod tests {
             endpoint: "init".to_string(),
         };
         let token = CancellationToken::new();
-        McpSession::new(url, token)
+        McpSession::new(
+            url,
+            token,
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            Default::default(),
+        )
     }
 
     #[tokio::test]
@@ -155,14 +167,12 @@ mod tests {
         assert_eq!(session.session_id(), Some(&id));
     }
 
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[test]
     fn it_returns_none_last_event_id_by_default() {
         let session = create_session();
         assert!(session.last_event_id().is_none());
     }
 
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[test]
     fn it_sets_and_gets_last_event_id() {
         let session = create_session();
@@ -170,7 +180,6 @@ mod tests {
         assert_eq!(session.last_event_id(), Some("abc-123".to_string()));
     }
 
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[test]
     fn it_overwrites_last_event_id_on_each_set() {
         let session = create_session();
@@ -192,7 +201,6 @@ mod tests {
         assert_ne!(session.session_id(), Some(&id2));
     }
 
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     #[tokio::test]
     async fn it_notifies_and_initialized() {
         let session = Arc::new(create_session());

--- a/neva/src/transport/stdio.rs
+++ b/neva/src/transport/stdio.rs
@@ -118,6 +118,20 @@ impl StdIoSender {
     }
 }
 
+/// The direction an unreadable line has to travel — a parse failure is
+/// answered or completed depending on what the line *was*, and routing it
+/// the wrong way loses it silently.
+enum Line {
+    /// A readable message — hand it to the receive loop.
+    Message(Message),
+    /// An unreadable inbound **request**: JSON-RPC 2.0 §5 says the peer
+    /// gets an error response, so this goes straight back out the
+    /// transport's sender rather than into pending-request handling.
+    Reply(Message),
+    /// Nothing actionable — logged and dropped.
+    Drop,
+}
+
 /// Parses one stdio line into a [`Message`].
 ///
 /// A line that isn't a readable `Message` — malformed JSON, or a JSON-RPC
@@ -128,39 +142,80 @@ impl StdIoSender {
 /// died before completing the pending request, the caller saw a timeout
 /// instead of the parse failure.
 ///
-/// So when the line carries an `id`, the failure is reported as an
-/// id-bound `ParseError` response: the pending request completes with the
-/// real cause. That is also what makes the RC client's dual-mode fallback
-/// reachable over stdio — it classifies such a rejection as "legacy peer"
-/// and retries `initialize`, which a timeout never could.
+/// A malformed **response** carrying an `id` belongs to a request this side
+/// is waiting on: it is reported as an id-bound `ParseError` so the pending
+/// request completes with the real cause. That is what makes the RC
+/// client's dual-mode fallback reachable over stdio — it classifies such a
+/// rejection as "legacy peer" and retries `initialize`, which a timeout
+/// never could.
 ///
-/// A line with no usable `id` belongs to no pending request; it is logged
-/// and dropped.
-fn parse_line(line: &str) -> Option<Message> {
+/// A malformed **request** (it carries `method`) is the mirror image: no
+/// pending request to complete, so it is answered with a `ParseError`
+/// response. Routing it into pending-request handling instead would
+/// silently swallow it and leave the peer waiting out its own timeout.
+///
+/// A line whose JSON is broken outright can't be classified at all, so
+/// JSON-RPC 2.0 §5.1 prescribes the answer directly: a parse error with
+/// [`RequestId::Null`](crate::types::RequestId::Null).
+///
+/// Dropped, because no move applies:
+///
+/// * a malformed **notification** — a `method` but no `id`. JSON-RPC 2.0
+///   §4.1 forbids replying to notifications;
+/// * a response-shaped line with no usable `id` — it completes no pending
+///   request, and answering a response is not a thing.
+fn parse_line(line: &str) -> Line {
     let err = match serde_json::from_str::<Message>(line) {
-        Ok(msg) => return Some(msg),
+        Ok(msg) => return Line::Message(msg),
         Err(err) => err,
     };
 
-    let id = serde_json::from_str::<serde_json::Value>(line)
-        .ok()
-        .and_then(|line| line.get("id").cloned())
-        .and_then(|id| serde_json::from_value::<crate::types::RequestId>(id).ok());
-
-    let Some(id) = id else {
-        #[cfg(feature = "tracing")]
-        tracing::error!(
-            logger = "neva",
-            "Failed to parse an unaddressed stdio message: {}",
-            err
-        );
-        return None;
+    let reply = |id| {
+        Message::Response(crate::types::Response::error(
+            id,
+            Error::new(ErrorCode::ParseError, err.to_string()),
+        ))
     };
 
-    Some(Message::Response(crate::types::Response::error(
-        id,
-        Error::new(ErrorCode::ParseError, err.to_string()),
-    )))
+    // Broken JSON: nothing to classify, and §5.1 answers exactly this case.
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+        return Line::Reply(reply(crate::types::RequestId::Null));
+    };
+
+    // A `method` makes it a request/notification, never a response.
+    let is_request = value.get("method").is_some();
+    let id = value
+        .get("id")
+        .cloned()
+        .and_then(|id| serde_json::from_value::<crate::types::RequestId>(id).ok())
+        // An absent id and an explicit `null` are equally unaddressable.
+        .filter(|id| !matches!(id, crate::types::RequestId::Null));
+
+    match (is_request, id) {
+        // An invalid request is answered with its own id...
+        (true, Some(id)) => Line::Reply(reply(id)),
+        // ...but a notification is never answered at all.
+        (true, None) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                logger = "neva",
+                "Dropped a malformed stdio notification: {}",
+                err
+            );
+            Line::Drop
+        }
+        // A malformed response completes the request it belongs to.
+        (false, Some(id)) => Line::Message(reply(id)),
+        (false, None) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(
+                logger = "neva",
+                "Dropped an unaddressed stdio response: {}",
+                err
+            );
+            Line::Drop
+        }
+    }
 }
 
 impl StdIoReceiver {
@@ -170,10 +225,15 @@ impl StdIoReceiver {
         Self { tx, rx }
     }
 
-    /// Starts a new thread that reads from stdin asynchronously
+    /// Starts a new thread that reads from stdin asynchronously.
+    ///
+    /// `replies` is the transport's own sender: an unreadable inbound
+    /// request is answered with a JSON-RPC parse error from here, since
+    /// it never reaches the dispatch layer that would normally reply.
     pub(crate) fn start<T: AsyncRead + Unpin + Send + 'static>(
         &self,
         mut reader: BufReader<T>,
+        replies: Sender<Message>,
         token: CancellationToken,
     ) {
         let tx = self.tx.clone();
@@ -187,12 +247,21 @@ impl StdIoReceiver {
                     read_line = reader.read_line(&mut line) => {
                         match read_line {
                             Ok(0) => break, // EOF
-                            Ok(_) => {
-                                let Some(msg) = parse_line(&line) else { continue };
-                                if let Err(_e) = tx.send(Ok(msg)).await {
-                                    #[cfg(feature = "tracing")]
-                                    tracing::error!(logger = "neva", "Failed to send request: {:?}", _e);
-                                    break;
+                            Ok(_) => match parse_line(&line) {
+                                Line::Drop => continue,
+                                Line::Message(msg) => {
+                                    if let Err(_e) = tx.send(Ok(msg)).await {
+                                        #[cfg(feature = "tracing")]
+                                        tracing::error!(logger = "neva", "Failed to send request: {:?}", _e);
+                                        break;
+                                    }
+                                }
+                                Line::Reply(resp) => {
+                                    if let Err(_e) = replies.send(resp).await {
+                                        #[cfg(feature = "tracing")]
+                                        tracing::error!(logger = "neva", "Failed to reply with a parse error: {:?}", _e);
+                                        break;
+                                    }
                                 }
                             }
                             Err(err) => {
@@ -331,7 +400,8 @@ impl Transport for StdIoClient {
         let token = CancellationToken::new();
         let (reader, writer) = self.handshake(token.clone());
 
-        self.receiver.start(reader, token.clone());
+        self.receiver
+            .start(reader, self.sender.tx.clone(), token.clone());
         self.sender.start(writer, token.clone());
 
         #[cfg(feature = "tracing")]
@@ -354,7 +424,8 @@ impl Transport for StdIoServer {
         let token = CancellationToken::new();
         let (reader, writer) = StdIoServer::init();
 
-        self.receiver.start(reader, token.clone());
+        self.receiver
+            .start(reader, self.sender.tx.clone(), token.clone());
         self.sender.start(writer, token.clone());
 
         #[cfg(feature = "tracing")]
@@ -381,8 +452,9 @@ mod parse_line_tests {
     fn unknown_error_code_becomes_an_id_bound_parse_error() {
         let line = r#"{"jsonrpc":"2.0","id":7,"error":{"code":-32000,"message":"Server not initialized"}}"#;
 
-        let Some(Message::Response(crate::types::Response::Err(resp))) = parse_line(line) else {
-            panic!("an addressed parse failure must produce an error response");
+        let Line::Message(Message::Response(crate::types::Response::Err(resp))) = parse_line(line)
+        else {
+            panic!("a malformed response must complete the pending request");
         };
         assert_eq!(resp.id, RequestId::Number(7));
         assert_eq!(resp.error.code, ErrorCode::ParseError);
@@ -402,8 +474,9 @@ mod parse_line_tests {
         )
         .as_bytes();
 
+        let (replies, _replies_rx) = mpsc::channel(8);
         let mut receiver = StdIoReceiver::new();
-        receiver.start(BufReader::new(INPUT), CancellationToken::new());
+        receiver.start(BufReader::new(INPUT), replies, CancellationToken::new());
 
         let Ok(Message::Response(crate::types::Response::Err(resp))) = receiver.recv().await else {
             panic!("the legacy rejection must complete the pending request");
@@ -411,38 +484,138 @@ mod parse_line_tests {
         assert_eq!(resp.id, RequestId::Number(1));
         assert_eq!(resp.error.code, ErrorCode::ParseError);
 
-        // The unaddressed garbage line is skipped, not fatal.
+        // The garbage line is answered out-of-band (§5.1) rather than
+        // routed here, so the next thing the loop sees is the good line.
         assert!(
             matches!(receiver.recv().await, Ok(Message::Notification(_))),
             "the stream must survive both bad lines"
         );
     }
 
-    #[test]
-    fn an_id_is_salvaged_only_when_the_line_is_still_valid_json() {
-        let line = r#"{"jsonrpc":"2.0","id":"abc","result":}"#;
-        // Broken JSON — the id is salvaged from the raw text only when the
-        // document itself still parses, so this one is unaddressable.
-        assert!(parse_line(line).is_none());
+    /// End-to-end through the reader task: a malformed inbound request is
+    /// written back out the transport's sender, and never surfaces to the
+    /// receive loop that would have swallowed it.
+    #[tokio::test]
+    async fn a_malformed_request_is_written_back_to_the_peer() {
+        const INPUT: &[u8] = concat!(
+            r#"{"jsonrpc":"2.0","id":42,"method":123}"#,
+            "\n",
+            r#"{"jsonrpc":"2.0","method":"ping"}"#,
+            "\n",
+        )
+        .as_bytes();
 
+        let (replies, mut replies_rx) = mpsc::channel(8);
+        let mut receiver = StdIoReceiver::new();
+        receiver.start(BufReader::new(INPUT), replies, CancellationToken::new());
+
+        let Some(Message::Response(crate::types::Response::Err(resp))) = replies_rx.recv().await
+        else {
+            panic!("the peer must receive a JSON-RPC error for its bad request");
+        };
+        assert_eq!(resp.id, RequestId::Number(42));
+        assert_eq!(resp.error.code, ErrorCode::ParseError);
+
+        // The bad request never reaches the receive loop — the next thing
+        // it sees is the following, well-formed line.
+        assert!(
+            matches!(receiver.recv().await, Ok(Message::Notification(_))),
+            "a malformed request must not be routed into pending handling"
+        );
+    }
+
+    /// JSON-RPC 2.0 §5.1: invalid JSON is answered with a parse error
+    /// carrying `"id": null`, since there is no id to salvage.
+    #[test]
+    fn broken_json_is_answered_with_a_null_id() {
+        for line in [
+            r#"{"jsonrpc":"2.0","id":"abc","result":}"#,
+            "not json at all",
+            "{",
+        ] {
+            let Line::Reply(Message::Response(crate::types::Response::Err(resp))) =
+                parse_line(line)
+            else {
+                panic!("broken JSON must be answered per §5.1: {line}");
+            };
+            assert_eq!(resp.id, RequestId::Null);
+            assert_eq!(resp.error.code, ErrorCode::ParseError);
+            // The reply must go out with a literal JSON `null` id.
+            let wire = serde_json::to_value(&resp).unwrap();
+            assert!(wire["id"].is_null(), "id must serialize as null: {wire}");
+        }
+    }
+
+    #[test]
+    fn an_id_is_salvaged_when_the_line_is_still_valid_json() {
         // Valid JSON that simply isn't a `Message`.
         let line = r#"{"jsonrpc":"2.0","id":"abc","totally":"unknown"}"#;
-        let Some(Message::Response(crate::types::Response::Err(resp))) = parse_line(line) else {
+        let Line::Message(Message::Response(crate::types::Response::Err(resp))) = parse_line(line)
+        else {
             panic!("an addressed parse failure must produce an error response");
         };
         assert_eq!(resp.id, RequestId::String("abc".into()));
     }
 
     #[test]
-    fn unaddressed_garbage_is_dropped_not_fatal() {
-        assert!(parse_line("not json at all").is_none());
-        assert!(parse_line(r#"{"jsonrpc":"2.0","method":123}"#).is_none());
+    fn unanswerable_lines_are_dropped_not_fatal() {
+        // A `method` but no `id` — a notification, which JSON-RPC §4.1
+        // forbids replying to. An explicit `null` id is just as unaddressable.
+        for line in [
+            r#"{"jsonrpc":"2.0","method":123}"#,
+            r#"{"jsonrpc":"2.0","id":null,"method":123}"#,
+        ] {
+            assert!(
+                matches!(parse_line(line), Line::Drop),
+                "a malformed notification must never be answered: {line}"
+            );
+        }
+
+        // Response-shaped, but completes no pending request.
+        assert!(matches!(
+            parse_line(r#"{"jsonrpc":"2.0","totally":"unknown"}"#),
+            Line::Drop
+        ));
+    }
+
+    /// A malformed inbound *request* carries `method`, so it completes no
+    /// pending request. Routing it into pending-request handling would
+    /// swallow it; the peer gets a JSON-RPC parse error instead.
+    #[test]
+    fn malformed_requests_are_answered_not_swallowed() {
+        let malformed_requests = [
+            (
+                r#"{"jsonrpc":"2.0","id":3,"method":123}"#,
+                RequestId::Number(3),
+            ),
+            (
+                r#"{"jsonrpc":"2.0","id":3,"method":{"nested":"object"}}"#,
+                RequestId::Number(3),
+            ),
+            (
+                r#"{"jsonrpc":"2.0","id":"abc","method":null,"params":{}}"#,
+                RequestId::String("abc".into()),
+            ),
+        ];
+
+        for (line, expected_id) in malformed_requests {
+            let Line::Reply(Message::Response(crate::types::Response::Err(resp))) =
+                parse_line(line)
+            else {
+                panic!("a malformed request must be answered, not routed: {line}");
+            };
+            assert_eq!(resp.id, expected_id);
+            assert_eq!(resp.error.code, ErrorCode::ParseError);
+        }
     }
 
     #[test]
     fn well_formed_lines_are_unaffected() {
         let line = r#"{"jsonrpc":"2.0","method":"ping"}"#;
-        assert!(matches!(parse_line(line), Some(Message::Notification(_))));
+        assert!(matches!(
+            parse_line(line),
+            Line::Message(Message::Notification(_))
+        ));
     }
 }
 

--- a/neva/src/transport/stdio.rs
+++ b/neva/src/transport/stdio.rs
@@ -118,6 +118,51 @@ impl StdIoSender {
     }
 }
 
+/// Parses one stdio line into a [`Message`].
+///
+/// A line that isn't a readable `Message` — malformed JSON, or a JSON-RPC
+/// error whose `code` falls outside neva's [`ErrorCode`] set (the TS SDK's
+/// `-32000` "server not initialized" family) — must **not** tear down the
+/// receive loop: the peer is alive and every following line is still
+/// readable. Pushing a bare `Err` did exactly that, and since the loop
+/// died before completing the pending request, the caller saw a timeout
+/// instead of the parse failure.
+///
+/// So when the line carries an `id`, the failure is reported as an
+/// id-bound `ParseError` response: the pending request completes with the
+/// real cause. That is also what makes the RC client's dual-mode fallback
+/// reachable over stdio — it classifies such a rejection as "legacy peer"
+/// and retries `initialize`, which a timeout never could.
+///
+/// A line with no usable `id` belongs to no pending request; it is logged
+/// and dropped.
+fn parse_line(line: &str) -> Option<Message> {
+    let err = match serde_json::from_str::<Message>(line) {
+        Ok(msg) => return Some(msg),
+        Err(err) => err,
+    };
+
+    let id = serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|line| line.get("id").cloned())
+        .and_then(|id| serde_json::from_value::<crate::types::RequestId>(id).ok());
+
+    let Some(id) = id else {
+        #[cfg(feature = "tracing")]
+        tracing::error!(
+            logger = "neva",
+            "Failed to parse an unaddressed stdio message: {}",
+            err
+        );
+        return None;
+    };
+
+    Some(Message::Response(crate::types::Response::error(
+        id,
+        Error::new(ErrorCode::ParseError, err.to_string()),
+    )))
+}
+
 impl StdIoReceiver {
     /// Creates a new stdio transport receiver
     pub(crate) fn new() -> Self {
@@ -143,11 +188,8 @@ impl StdIoReceiver {
                         match read_line {
                             Ok(0) => break, // EOF
                             Ok(_) => {
-                                let req = match serde_json::from_str(&line) {
-                                    Ok(req) => Ok(req),
-                                    Err(err) => Err(err.into()),
-                                };
-                                if let Err(_e) = tx.send(req).await {
+                                let Some(msg) = parse_line(&line) else { continue };
+                                if let Err(_e) = tx.send(Ok(msg)).await {
                                     #[cfg(feature = "tracing")]
                                     tracing::error!(logger = "neva", "Failed to send request: {:?}", _e);
                                     break;
@@ -323,6 +365,84 @@ impl Transport for StdIoServer {
     #[inline]
     fn split(self) -> (Self::Sender, Self::Receiver) {
         (self.sender, self.receiver)
+    }
+}
+
+#[cfg(test)]
+mod parse_line_tests {
+    use super::*;
+    use crate::types::RequestId;
+
+    /// A JSON-RPC error whose code is outside neva's `ErrorCode` set (the
+    /// TS SDK's `-32000`) is the exact reply a legacy server sends to the
+    /// RC client's pre-initialize `server/discover`. It must complete the
+    /// pending request as an id-bound `ParseError`, not kill the loop.
+    #[test]
+    fn unknown_error_code_becomes_an_id_bound_parse_error() {
+        let line = r#"{"jsonrpc":"2.0","id":7,"error":{"code":-32000,"message":"Server not initialized"}}"#;
+
+        let Some(Message::Response(crate::types::Response::Err(resp))) = parse_line(line) else {
+            panic!("an addressed parse failure must produce an error response");
+        };
+        assert_eq!(resp.id, RequestId::Number(7));
+        assert_eq!(resp.error.code, ErrorCode::ParseError);
+    }
+
+    /// The regression the fix is really about: the bad line must not end
+    /// the stream — the pending request completes *and* the following
+    /// lines keep arriving.
+    #[tokio::test]
+    async fn a_bad_line_neither_ends_the_stream_nor_is_swallowed() {
+        const INPUT: &[u8] = concat!(
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"Server not initialized"}}"#,
+            "\n",
+            "total garbage, no id\n",
+            r#"{"jsonrpc":"2.0","method":"ping"}"#,
+            "\n",
+        )
+        .as_bytes();
+
+        let mut receiver = StdIoReceiver::new();
+        receiver.start(BufReader::new(INPUT), CancellationToken::new());
+
+        let Ok(Message::Response(crate::types::Response::Err(resp))) = receiver.recv().await else {
+            panic!("the legacy rejection must complete the pending request");
+        };
+        assert_eq!(resp.id, RequestId::Number(1));
+        assert_eq!(resp.error.code, ErrorCode::ParseError);
+
+        // The unaddressed garbage line is skipped, not fatal.
+        assert!(
+            matches!(receiver.recv().await, Ok(Message::Notification(_))),
+            "the stream must survive both bad lines"
+        );
+    }
+
+    #[test]
+    fn an_id_is_salvaged_only_when_the_line_is_still_valid_json() {
+        let line = r#"{"jsonrpc":"2.0","id":"abc","result":}"#;
+        // Broken JSON — the id is salvaged from the raw text only when the
+        // document itself still parses, so this one is unaddressable.
+        assert!(parse_line(line).is_none());
+
+        // Valid JSON that simply isn't a `Message`.
+        let line = r#"{"jsonrpc":"2.0","id":"abc","totally":"unknown"}"#;
+        let Some(Message::Response(crate::types::Response::Err(resp))) = parse_line(line) else {
+            panic!("an addressed parse failure must produce an error response");
+        };
+        assert_eq!(resp.id, RequestId::String("abc".into()));
+    }
+
+    #[test]
+    fn unaddressed_garbage_is_dropped_not_fatal() {
+        assert!(parse_line("not json at all").is_none());
+        assert!(parse_line(r#"{"jsonrpc":"2.0","method":123}"#).is_none());
+    }
+
+    #[test]
+    fn well_formed_lines_are_unaffected() {
+        let line = r#"{"jsonrpc":"2.0","method":"ping"}"#;
+        assert!(matches!(parse_line(line), Some(Message::Notification(_))));
     }
 }
 

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -822,6 +822,11 @@ impl DiscoverResult {
                 prompts: options.prompts_capability(),
                 completions: Some(CompletionsCapability::default()),
                 extensions: options.extensions(),
+                // The legacy field exists in this build only because the
+                // dual-mode client resurrects it; the RC server always
+                // advertises tasks through `extensions`.
+                #[cfg(all(feature = "tasks", feature = "client"))]
+                tasks: None,
                 experimental: None,
             },
             server_info: options.implementation.clone(),

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -23,14 +23,14 @@ use {crate::auth::Claims, http::HeaderMap, std::sync::Arc};
 
 #[cfg(not(feature = "proto-2026-07-28-rc"))]
 pub use capabilities::LoggingCapability;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 pub use capabilities::RootsCapability;
 pub use capabilities::{
     ClientCapabilities, CompletionsCapability, ElicitationCapability, ElicitationFormCapability,
     ElicitationUrlCapability, PromptsCapability, ResourcesCapability, ServerCapabilities,
     ToolsCapability,
 };
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 pub use capabilities::{SamplingCapability, SamplingContextCapability, SamplingToolsCapability};
 pub use completion::{Argument, CompleteRequestParams, CompleteResult, Completion};
 pub use content::{
@@ -119,7 +119,7 @@ pub use resource::{
     Resource, ResourceContents, ResourceTemplate, SubscribeRequestParams, TextResourceContents,
     UnsubscribeRequestParams, Uri,
 };
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 pub use sampling::{
     CreateMessageRequestParams, CreateMessageResult, SamplingMessage, StopReason, ToolChoice,
     ToolChoiceMode,
@@ -143,7 +143,7 @@ pub use task::{
 pub use prompt::PromptHandler;
 
 pub use progress::ProgressToken;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 pub use root::Root;
 
 #[cfg(feature = "proto-2026-07-28-rc")]
@@ -167,9 +167,9 @@ mod reference;
 mod request;
 pub mod resource;
 mod response;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 pub mod root;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 pub mod sampling;
 mod schema;
 pub mod schema_2020;

--- a/neva/src/types/capabilities.rs
+++ b/neva/src/types/capabilities.rs
@@ -193,7 +193,15 @@ pub struct ServerCapabilities {
     /// Under `proto-2026-07-28-rc`, tasks become an extension; this top-level
     /// field is replaced by an entry in the `extensions` map keyed by
     /// `io.modelcontextprotocol/tasks`.
-    #[cfg(all(feature = "tasks", not(feature = "proto-2026-07-28-rc")))]
+    ///
+    /// Compiled for the RC **client** too: after a dual-mode fallback a
+    /// legacy peer advertises tasks here, and the field must survive
+    /// deserialization of its `initialize` result. The RC server never
+    /// sets it, and `skip_serializing_if` keeps the RC wire unchanged.
+    #[cfg(all(
+        feature = "tasks",
+        any(not(feature = "proto-2026-07-28-rc"), feature = "client")
+    ))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tasks: Option<ServerTasksCapability>,
 

--- a/neva/src/types/capabilities.rs
+++ b/neva/src/types/capabilities.rs
@@ -15,13 +15,13 @@ pub struct ClientCapabilities {
     /// >
     /// > The server can use `RequestRoots` to request the list of
     /// > available roots from the client, which will trigger the client's `RootsHandler`.
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
+    #[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub roots: Option<RootsCapability>,
 
     /// Gets or sets the client's sampling capability, which indicates whether the client
     /// supports issuing requests to an LLM on behalf of the server.
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
+    #[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sampling: Option<SamplingCapability>,
 
@@ -35,7 +35,10 @@ pub struct ClientCapabilities {
     /// Under `proto-2026-07-28-rc`, tasks become an extension; this top-level
     /// field is replaced by an entry in the `extensions` map keyed by
     /// `io.modelcontextprotocol/tasks`.
-    #[cfg(all(feature = "tasks", not(feature = "proto-2026-07-28-rc")))]
+    #[cfg(all(
+        feature = "tasks",
+        any(not(feature = "proto-2026-07-28-rc"), feature = "client")
+    ))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tasks: Option<ClientTasksCapability>,
 
@@ -71,7 +74,7 @@ pub struct ClientCapabilities {
 /// > servers can navigate to access specific resources.
 ///
 /// See the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/) for details
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct RootsCapability {
     /// Indicates whether the client supports notifications for changes to the roots list.
@@ -91,7 +94,7 @@ pub struct RootsCapability {
 /// > using an AI model. The client must set a `SamplingHandler` to process these requests.
 ///
 /// See the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/) for details
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SamplingCapability {
     /// Indicates whether the client supports context inclusion via `includeContext` parameter.
@@ -106,7 +109,7 @@ pub struct SamplingCapability {
 /// Represents the sampling context capability.
 ///
 /// See the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/) for details
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SamplingContextCapability {
     // Currently empty in the spec, but may be extended in the future
@@ -115,7 +118,7 @@ pub struct SamplingContextCapability {
 /// Represents the sampling tools capability.
 ///
 /// See the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/) for details
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SamplingToolsCapability {
     // Currently empty in the spec, but may be extended in the future
@@ -450,7 +453,7 @@ impl PromptsCapability {
     }
 }
 
-#[cfg(all(feature = "client", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "client")]
 impl RootsCapability {
     /// Specifies whether this client supports notifications for changes to the roots list.
     ///
@@ -461,7 +464,7 @@ impl RootsCapability {
     }
 }
 
-#[cfg(all(feature = "client", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "client")]
 impl SamplingCapability {
     /// Specifies whether this client supports context inclusion.
     ///

--- a/neva/src/types/notification.rs
+++ b/neva/src/types/notification.rs
@@ -9,7 +9,7 @@ use crate::{
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 pub use log_message::{LogMessage, LoggingLevel, SetLevelRequestParams};
 
 #[cfg(feature = "server")]
@@ -24,7 +24,7 @@ pub use formatter::NotificationFormatter;
 pub mod fmt;
 #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
 mod formatter;
-#[cfg(not(feature = "proto-2026-07-28-rc"))]
+#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 mod log_message;
 mod progress;
 
@@ -37,7 +37,7 @@ pub mod commands {
     pub const CANCELLED: &str = "notifications/cancelled";
 
     /// Notification name that indicates that a new log message has been received.
-    #[cfg(not(feature = "proto-2026-07-28-rc"))]
+    #[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
     pub const MESSAGE: &str = "notifications/message";
 
     /// Notification name that indicates that a progress notification has been received.
@@ -144,7 +144,10 @@ impl Notification {
 
     /// Writes the [`Notification`]
     #[inline]
-    #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+    #[cfg(all(
+        feature = "tracing",
+        any(not(feature = "proto-2026-07-28-rc"), feature = "client")
+    ))]
     pub fn write(self) {
         let is_stderr = self.is_stderr();
         let Some(params) = self.params else {

--- a/neva_macros/Cargo.toml
+++ b/neva_macros/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 documentation.workspace = true
+homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 


### PR DESCRIPTION
## Summary
Implements the dual-mode client (#84): under `proto-2026-07-28-rc` the client now carries **both** handshakes. It tries `server/discover` first and, when the server clearly doesn't speak the RC protocol, falls back to the legacy `initialize`/`initialized` handshake and speaks legacy for that peer at runtime — which lets an RC-flagged client reach the ~90% of servers still on 2025-11-25, matching what all SDK-beta clients do.

Closes #84.

**How it works:**

* **Runtime switch, not a `#[cfg]` split.** A shared `PeerMode` (`Rc` | `Legacy`) is owned by the client options and cloned into the HTTP transport session. It flips at most once, in `connect()`'s fallback, before any other traffic — nothing races it. This is the one deliberate relaxation of "compile-time pure peer", client-side only; the server remains compile-time pure (`server-full` + RC without the client feature compiles exactly what it did before).
* **Fallback triggers** (documented on `init`): a `server/discover` reply with `MethodNotFound` (-32601), `InvalidRequest` (-32600), or a parse failure — which is how non-JSON-RPC 4xx pages and unknown error codes (e.g. the TS SDK's -32000 "server not initialized") surface. Network-level failures (timeout, connection refused) do **not** trigger the fallback: the server never answered, falling back would only mask the outage.
* **Legacy semantics per peer:** the fallback negotiates the newest pre-RC version (2025-11-25; `with_mcp_version` — available under the RC flag again — overrides it), captures `Mcp-Session-Id`, arms the standalone SSE GET stream, and drops the RC-only wire details (`MCP-Protocol-Version`, `Mcp-Method`/`Mcp-Name` routing headers). MRTR (single and batch) bypasses to the plain request path; legacy server-push sampling/roots/logging work through the un-gated client machinery.
* **Un-gating:** legacy client code now compiles (dormant) under the RC flag. Shared types use an `any(not(rc), feature = "client")` gate; the legacy fields of `ClientCapabilities` are `skip_serializing_if`, so the RC wire shape is byte-identical to before. Client-only files carry both paths unconditionally. A neat consequence: the SSE task needed no mode check at all — it arms on `session.initialized()`, which fires exclusively for the `initialize` method that an RC peer never sees.
* `TransportProto::HttpClient` is now boxed (`HttpClient` grew past clippy's `large_enum_variant` threshold).

## Type
- [ ] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers
* The fallback-trigger set is the main judgment call: `ParseError` as a trigger is deliberately broad (it's the only way TS's -32000 and non-JSON 4xx replies surface today), but it only applies to the `server/discover` response — nothing else ever falls back.
* `types/capabilities.rs`: the legacy `roots`/`sampling` fields returned to `ClientCapabilities` under `any(not(rc), client)`. They serialize only when set (fallback path), so RC `server/discover` requests are wire-identical — worth double-checking if you care about the RC shape.
* The `expected_protocol_ver()` change in `validate_server_version` is what lets the fallback accept 2025-11-25 — the legacy build's behavior is untouched.
