### PR TITLE
Generalize MRTR Input

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,6 +77,15 @@ jobs:
         run: cargo doc --no-deps --all-features
       - name: Check docs build clean with proto-2026-07-28-rc
         run: cargo doc --no-deps --features "server-full client-full proto-2026-07-28-rc"
+      # The rows above have every feature on, so every intra-doc link resolves
+      # by construction. Slim rows catch docs that link to items a smaller
+      # feature set does not compile.
+      - name: Check docs build clean on a slim server
+        run: cargo doc --no-deps --features server
+      - name: Check docs build clean on a slim client
+        run: cargo doc --no-deps --features client
+      - name: Check docs build clean on a client-only RC build
+        run: cargo doc --no-deps --features "client proto-2026-07-28-rc"
 
   build:
     environment: CICD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## 0.4.3
 
 ### Added
+* **MRTR input-request kinds: sampling + roots** (`proto-2026-07-28-rc`, #85).
+  The spec did not delete sampling and roots — it removed them as
+  capability-driven server→client *requests* and re-homed the ability onto
+  MRTR, as input-request kinds. They return here the same way, and — matching
+  the spec's own 12-month lifecycle — **already deprecated**:
+  * `ctx.sample(key, params)` and `ctx.list_roots(key)` join `ctx.elicit` on
+    the MRTR substrate, with identical re-run/replay semantics. `once` /
+    `memo` / `on_commit` cover them for free — one substrate, three kinds.
+  * `CreateMessageRequestParams`/`Result` and `ListRootsResult`/`Root` are
+    available under the RC again, now as input-request params/results. The
+    server-push `SamplingHandler` channel stays gone: the client fulfils
+    sampling from its `map_sampling` handler and roots from its configured
+    list, both on the MRTR loop.
+  * `ClientMrtrCapabilities` grows `sampling` and `roots` flags; the server
+    gates each kind on its own flag and reports a request for an undeclared
+    kind instead of stalling the round-trip. The flags are additive, so a peer
+    that only sends `elicitation` still decodes.
+  * Both new server APIs, the new `InputRequest::Sampling`/`Roots` variants and
+    the capability flags carry `#[deprecated]`. Elicitation stays first-class.
+
+  Existing deprecation notes on `Client::map_sampling`, `add_root(s)`,
+  `McpOptions::with_roots`/`with_sampling` were reworded: they described the
+  ability as *removed* in 2026-07-28, which is no longer accurate.
+* RC variants of the roots and sampling examples, alongside the legacy ones:
+  `examples/roots/rc/{server,client}` and
+  `examples/sampling/rc/{server,client}`. Each `rc/` directory is its own
+  workspace — Cargo unifies features across members built together, so keeping
+  the RC crates in the legacy workspace would switch `proto-2026-07-28-rc` on
+  for the legacy crates and stop them compiling.
+
 * `neva::shared::BoxFuture` (also in the prelude) — the return type of
   neva's object-safe async traits, now owned by neva instead of borrowed
   from `futures_util`. Implementing
@@ -20,6 +50,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   that spell out the `futures_util` path keep compiling unchanged.
 
 ### Changed
+* **Breaking (`proto-2026-07-28-rc` API, #85)** — generalizing the MRTR input
+  request reshapes three public items. The *wire* format is unchanged: an
+  envelope is still `{ method, params }` and `method` is still the
+  discriminator, so peers interoperate across the change.
+  * `mrtr::ElicitationInputRequest` (and its `ElicitationCreateMethod` tag) are
+    replaced by the `mrtr::InputRequest` union. Migration:
+    `ElicitationInputRequest { params, .. }` → `InputRequest::Elicitation(params)`.
+  * `mrtr::InputResponses` is now `HashMap<String, serde_json::Value>` rather
+    than `HashMap<String, ElicitResult>` — the result type depends on the kind
+    that was requested. Deserialize your own type out of the value.
+  * `mrtr::ClientMrtrCapabilities` gained two fields, so struct-literal
+    construction needs `..Default::default()`.
 * Updated to `volga` / `volga-oauth-core` / `volga-oauth-client` 0.9.6,
   which ships the two upstream fixes this crate was working around:
   * The token-endpoint futures (`exchange_code` / `refresh` / `token`) are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## 0.4.3
 
+### Added
+* `neva::shared::BoxFuture` (also in the prelude) — the return type of
+  neva's object-safe async traits, now owned by neva instead of borrowed
+  from `futures_util`. Implementing
+  [`AuthorizationHandler`](https://docs.rs/neva/latest/neva/auth/oauth/trait.AuthorizationHandler.html)
+  or [`RequestStateStore`](https://docs.rs/neva/latest/neva/trait.RequestStateStore.html)
+  no longer requires a `futures` dependency of your own, kept in lockstep
+  with neva's. It is a plain alias for
+  `Pin<Box<dyn Future<Output = T> + Send + 'a>>` — the same type
+  `futures_util::future::BoxFuture` denotes — so existing implementations
+  that spell out the `futures_util` path keep compiling unchanged.
+
 ### Changed
 * Updated to `volga` / `volga-oauth-core` / `volga-oauth-client` 0.9.6,
   which ships the two upstream fixes this crate was working around:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `futures_util::future::BoxFuture` denotes — so existing implementations
   that spell out the `futures_util` path keep compiling unchanged.
 
+### Documentation
+* Documented why MRTR **seals** `requestState` with ChaCha20-Poly1305 instead
+  of signing it (#82): a signed state is tamper-evident but *readable*, which
+  stops being enough once `ctx.memo` writes server-computed values — an
+  upstream response, a quoted price, a downstream token — into the state for
+  the next round to replay. The AEAD tag authenticates exactly as an HMAC
+  would, so confidentiality costs nothing. The consequence for callers is
+  spelled out at [`types::mrtr`](https://docs.rs/neva/latest/neva/types/mrtr/)
+  and at `App::with_request_state_secret`: the secret upholds confidentiality,
+  not just integrity.
+* Documented the MRTR idempotency story as a whole (#82): a re-run/replay
+  handler executes from the top every round, and the protocol leaves the
+  resulting side-effect problem to the implementation. `ctx.memo` /
+  `ctx.once` / `ctx.on_commit` plus the default `RequestStateStore`
+  (final-round replay protection for a lost HTTP response) mean a tool that
+  charges a card can be written in the obvious way.
+
 ### Changed
 * **Breaking (`proto-2026-07-28-rc` API, #85)** — generalizing the MRTR input
   request reshapes three public items. The *wire* format is unchanged: an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.4.3
+
+### Changed
+* Updated to `volga` / `volga-oauth-core` / `volga-oauth-client` 0.9.6,
+  which ships the two upstream fixes this crate was working around:
+  * The token-endpoint futures (`exchange_code` / `refresh` / `token`) are
+    now `Send`, so the internal `spawn_blocking` bridge that ran them on a
+    dedicated current-thread runtime is gone — the OAuth code exchange and
+    token refresh run inline on the caller's runtime, with no extra thread
+    or runtime per operation. A `Send` bound assertion now guards the
+    regression.
+  * `application_type` is a first-class member of the registration
+    document, so the loopback (native client) declaration no longer travels
+    as an extension field. The wire shape is unchanged.
+* Dependency updates: `serde` 1.0.229, `serde_json` 1.0.151, `tokio`
+  1.53.1, `tokio-util` 0.7.19, `futures-util` 0.3.33, `jsonschema` 0.48.2,
+  and `syn` 3.0 / `quote` 1.0.47 / `proc-macro2` 1.0.107 in `neva_macros`.
+
+### Fixed
+* A managed OAuth session could permanently lose its ability to refresh
+  non-interactively: the cached client/metadata were taken out of the
+  single-flight slot for the duration of a refresh and were not restored
+  if the (now removed) bridge itself failed, so every later request fell
+  back to interactive authorization. The cached state is now borrowed
+  rather than moved.
+
 ## 0.4.2
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -284,7 +284,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -296,7 +296,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -318,7 +318,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -335,9 +335,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -346,14 +346,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -760,7 +761,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -783,7 +784,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1111,44 +1112,44 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1304,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1338,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1607,7 +1608,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1626,7 +1627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1652,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9baf521a926fd1e6f94af6922be9686b61c8a89a5fb7e14d6a1e21b79738d4cc"
+checksum = "39d785c0683d1027839f1ac6a43b6d07c63d58ecd363d8146dda4531d53465a1"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1675,15 +1676,16 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "strum",
  "unicode-general-category",
  "uuid-simd",
 ]
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d668f4775619127513d9a4f190704d20a66d20ccf0efc258f8ed42548e5fd7cd"
+checksum = "917b3be16b2662538aafb55201790561e1f1ad1a0454baf42f33bd9de343778b"
 dependencies = [
  "regex-syntax",
 ]
@@ -1846,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64",
  "bytes",
@@ -1882,12 +1884,12 @@ dependencies = [
 
 [[package]]
 name = "neva_macros"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2125,14 +2127,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2195,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2309,14 +2311,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "referencing"
-version = "0.48.1"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df843f41f0cb459649f64a8b6b10579cf454f7a7420dc702767c81a26f23d780"
+checksum = "2d2b21a85c07fcf1cb95ff7ab8a687fcd37fa70db59975b5a032abdaadfdf42e"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2573,7 +2575,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2613,9 +2615,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2623,22 +2625,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2649,14 +2651,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2830,6 +2832,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,6 +2863,17 @@ name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2863,7 +2897,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2904,7 +2938,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2973,9 +3007,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.53.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d988bcd52dbe076d3d46903332f58c912b87a2c49b1428419a5845154762ffee"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -2996,7 +3030,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3022,13 +3056,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3099,7 +3134,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3268,9 +3303,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "volga"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "522e0013775553cda1600cc51561c5e661c10f506957480f9fea9c159fc63dd8"
+checksum = "7d4b5c91a85ce3ed86b849152056de9c5ffc9d010ef938cd673c51e7ae94f780"
 dependencies = [
  "async-stream",
  "bytes",
@@ -3302,38 +3337,38 @@ dependencies = [
 
 [[package]]
 name = "volga-dev-cert"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18231cadb6714f907d212911006d3d7d616a62233993215a740426a6c3c1bdc6"
+checksum = "c47e62dcac55a155af62a9f255aa8deb7dde33454295d818364730775e0fd300"
 dependencies = [
  "rcgen",
 ]
 
 [[package]]
 name = "volga-di"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0744ee783c50e95e8c23f0952c5b61616a16f4662626fcc3b976a209f63a6fcf"
+checksum = "ecfee2c5c6172647ee547c85306bb1b6447368f31e40df8a5ab0b1a834c32ea0"
 dependencies = [
  "http 1.4.2",
 ]
 
 [[package]]
 name = "volga-macros"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae9a02aa327d8d340cee73e3132b3fc7283f3b436423b8327784a468ea8c2707"
+checksum = "57ce98c25baa99a1aa52b0b6ea4d73e7c158b0a6d6e14ef90f4a0f3db55926ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "volga-oauth-client"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ca7f56d2060d50e1460ac24a4de60039e2834897f702cb8c43337dce8a3b95"
+checksum = "44491f1b30a7a26e1817aa91bb093a7aa6366a3d7dc44270a450df3a41f96e4d"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -3352,9 +3387,9 @@ dependencies = [
 
 [[package]]
 name = "volga-oauth-core"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6445f8f6c6fa3c8f341b4937dfec743855892107b47077260e0c296ccddf8e09"
+checksum = "1d6b60b2d632db6d120ea10b7764255ae674e1424ac9f8d7211a40322dc1c121"
 dependencies = [
  "http 1.4.2",
  "serde",
@@ -3452,7 +3487,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -3612,7 +3647,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3623,7 +3658,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3872,7 +3907,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.119",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3888,7 +3923,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3983,7 +4018,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4004,7 +4039,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4024,7 +4059,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -4045,7 +4080,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4078,7 +4113,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -29,7 +29,7 @@ categories = [
 ]
 
 [workspace.dependencies]
-neva_macros = { path = "neva_macros", version = "0.4.2" }
+neva_macros = { path = "neva_macros", version = "0.4.3" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blazingly fast and easily configurable [Model Context Protocol (MCP)](https://mo
 With simple configuration and ergonomic APIs, it provides everything you need to quickly build MCP clients and servers, 
 fully aligned with the latest MCP specification.
 
-[![latest](https://img.shields.io/badge/latest-0.4.2-d8eb34)](https://crates.io/crates/neva)
+[![latest](https://img.shields.io/badge/latest-0.4.3-d8eb34)](https://crates.io/crates/neva)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-624bd1.svg)](https://github.com/RomanEmreis/neva/blob/main/LICENSE)
 [![CI](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml)
@@ -28,7 +28,7 @@ fully aligned with the latest MCP specification.
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.4.2", features = ["client-full"] }
+neva = { version = "0.4.3", features = ["client-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -66,7 +66,7 @@ async fn main() -> Result<(), Error> {
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.4.2", features = ["server-full"] }
+neva = { version = "0.4.3", features = ["server-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 #### Code

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ fully aligned with the latest MCP specification.
 - **Tools**, **Resources** & **Prompts** - full-house support for defining and consuming the main MCP entities.
 - **Authentication & Authorization** - bearer token authentication, role-based access control, and more to fit high security standards.
 - **Structured Data** - output validation, embedded resources, and resource links out of the box.
+- **Safe Multi Round-Trip Requests** - a handler that asks the client for input mid-call re-runs from the top on every round, so neva owns the idempotency: `ctx.memo` computes once, `ctx.once` runs an effect once, `ctx.on_commit` defers it to the final result, and a built-in store makes a lost-response retry replay the committed answer instead of charging the card twice. The protocol leaves this to the implementation; you don't hand-roll it per tool.
+- **Confidential request state** - the `requestState` blob that carries progress between rounds is sealed with ChaCha20-Poly1305, not merely signed, so the server-computed values `ctx.memo` caches stay unreadable to the client that echoes them back.
 - **Spec Alignment** - designed to track the latest MCP specification and cover its core functionality.
 
 ## Quick Start

--- a/examples/roots/Cargo.toml
+++ b/examples/roots/Cargo.toml
@@ -1,5 +1,9 @@
 [workspace]
 members = ["client", "server"]
+# `rc/` is its own workspace: it enables `proto-2026-07-28-rc` on the shared
+# `neva` path dependency, and Cargo would unify that feature onto these legacy
+# members if they were built together.
+exclude = ["rc"]
 resolver = "2"
 
 [workspace.package]

--- a/examples/roots/README.md
+++ b/examples/roots/README.md
@@ -1,10 +1,47 @@
-# Example of using Roots Capability
+# Example of using Roots
 
-## Run the server
+Two variants, one per protocol generation.
+
+## Legacy (capability + `roots/list` push request)
+
+The server calls `ctx.list_roots()` and the client answers a real
+`roots/list` request pushed over the session.
+
+### Run the server
 ```
 cargo run --manifest-path examples/roots/server/Cargo.toml
 ```
-## Run the client
+### Run the client
 ```
 cargo run --manifest-path examples/roots/client/Cargo.toml
 ```
+
+## MCP 2026-07-28 RC (`roots/list` as an MRTR input request)
+
+The RC removed the capability-driven push request. The *ability* was re-homed
+onto MRTR: the server asks with `ctx.list_roots(key)`, the reply is an
+`input_required` result carrying a `roots/list` envelope, and the client echoes
+its roots back in `inputResponses` alongside the opaque `requestState`. Roots
+arrive **deprecated** — they exist for migration.
+
+### Run the server
+```
+cargo run --manifest-path examples/roots/rc/server/Cargo.toml
+```
+### Run the client
+```
+cargo run --manifest-path examples/roots/rc/client/Cargo.toml
+```
+
+The client prints `2 root(s): My Project (…), My Another Project (…)`.
+
+### What to watch
+
+`🔎 scan_workspace round starting…` is logged **twice** on the server: the
+handler re-runs from the top on the second round, with the roots replayed out
+of `requestState` instead of asked for again. Anything expensive above an input
+point belongs in `ctx.memo` / `ctx.once` for that reason — see
+[`examples/mrtr`](../mrtr) for the effect primitives.
+
+The client never registers a roots *handler*: roots are configured data, so
+having any is what makes it declare `clientCapabilities.roots`.

--- a/examples/roots/rc/Cargo.toml
+++ b/examples/roots/rc/Cargo.toml
@@ -1,0 +1,10 @@
+# The RC examples are a workspace of their own, deliberately separate from the
+# legacy one next door: Cargo unifies features across the members it builds
+# together, so a single workspace would switch `proto-2026-07-28-rc` on for the
+# legacy crates too and they would stop compiling against the RC API.
+[workspace]
+members = ["client", "server"]
+resolver = "2"
+
+[workspace.package]
+rust-version = "1.90.0"

--- a/examples/roots/rc/client/Cargo.toml
+++ b/examples/roots/rc/client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rc-client"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+neva = { path = "../../../../neva", features = ["client-macros", "http-client", "tracing", "proto-2026-07-28-rc"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.20"

--- a/examples/roots/rc/client/src/main.rs
+++ b/examples/roots/rc/client/src/main.rs
@@ -1,0 +1,41 @@
+//! New-spec (MCP 2026-07-28 RC) roots example client.
+//!
+//! Roots are configured *data*, not a handler: the client answers the server's
+//! MRTR `roots/list` input request from the list it was built with. Because the
+//! list is non-empty, the client automatically declares
+//! `clientCapabilities.roots` on every request — a server may only ask for a
+//! kind the client declared.
+//!
+//! The MRTR round-trips happen inside `call_tool`: the caller sees one call.
+
+use neva::prelude::*;
+use tracing_subscriber::prelude::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| http.bind("127.0.0.1:3001").with_endpoint("/mcp"))
+    });
+
+    // Deprecated on arrival, like the whole roots kind — the API stays for
+    // migration.
+    #[allow(deprecated)]
+    client
+        .add_root("file:///home/user/projects/my_project", "My Project")
+        .add_root(
+            "file:///home/user/projects/my_another_project",
+            "My Another Project",
+        );
+
+    // `connect()` runs `server/discover` — no `initialize` handshake under RC.
+    client.connect().await?;
+
+    let result = client.call_tool("scan_workspace", ()).await?;
+    tracing::info!("Result: {:?}", result.content);
+
+    client.disconnect().await
+}

--- a/examples/roots/rc/server/Cargo.toml
+++ b/examples/roots/rc/server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rc-server"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+neva = { path = "../../../../neva", features = ["server-macros", "http-server-volga", "tracing", "proto-2026-07-28-rc"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.20"

--- a/examples/roots/rc/server/src/main.rs
+++ b/examples/roots/rc/server/src/main.rs
@@ -1,0 +1,61 @@
+//! New-spec (MCP 2026-07-28 RC) roots example server.
+//!
+//! Under the RC there is no `roots/list` server→client *request*: the
+//! capability-driven push channel is gone. The ability was re-homed onto MRTR
+//! as an input-request kind, so the server asks for roots the same way it asks
+//! for elicitation input — `ctx.list_roots(key)` — and the answer replays from
+//! the encrypted `requestState` on the next round.
+//!
+//! Roots are **deprecated on arrival**: they exist for migration, hence the
+//! explicit `#[allow(deprecated)]` at the call site. New tools should take the
+//! paths they need as arguments instead.
+
+use neva::prelude::*;
+use tracing_subscriber::prelude::*;
+
+#[tool]
+async fn scan_workspace(mut ctx: Context) -> Result<String, Error> {
+    // Everything above an input point re-runs on every round-trip, so guard
+    // side effects with `once` / `memo` — here the log line proves the handler
+    // really does execute twice.
+    tracing::info!("🔎 scan_workspace round starting…");
+
+    // Round 1: no answer for "dirs" yet, so this unwinds the handler and the
+    // server replies `input_required` with a `roots/list` envelope.
+    // Round 2: the client's `ListRootsResult` is replayed from `requestState`.
+    #[allow(deprecated)]
+    let roots = ctx.list_roots("dirs").await?;
+
+    if roots.roots.is_empty() {
+        return Ok("The client exposes no roots.".into());
+    }
+
+    let listed = roots
+        .roots
+        .iter()
+        .map(|root| format!("{} ({})", root.name, root.uri))
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Ok(format!("{} root(s): {listed}", roots.roots.len()))
+}
+
+#[tokio::main]
+async fn main() {
+    // Under RC neva does not install a global subscriber; do it here so the
+    // per-round log above is visible.
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    App::new()
+        // In production load a stable shared secret (env/secret store); the
+        // default is an ephemeral per-process key, fine for a single instance.
+        .with_request_state_secret(b"example-shared-secret")
+        .with_options(|opt| {
+            opt.with_name("Roots Example Server (RC)")
+                .with_http(|http| http.bind("127.0.0.1:3001").with_endpoint("/mcp"))
+        })
+        .run()
+        .await;
+}

--- a/examples/sampling/Cargo.toml
+++ b/examples/sampling/Cargo.toml
@@ -1,5 +1,9 @@
 ﻿[workspace]
 members = ["client", "server"]
+# `rc/` is its own workspace: it enables `proto-2026-07-28-rc` on the shared
+# `neva` path dependency, and Cargo would unify that feature onto these legacy
+# members if they were built together.
+exclude = ["rc"]
 resolver = "2"
 
 [workspace.package]

--- a/examples/sampling/README.md
+++ b/examples/sampling/README.md
@@ -1,11 +1,57 @@
-﻿# Example of using LLM Sampling Capability
+# Example of using LLM Sampling
 
-## Run the server
+Two variants, one per protocol generation.
+
+## Legacy (capability + `sampling/createMessage` push request)
+
+The server calls `ctx.sample(params)` and the client answers a real
+`sampling/createMessage` request pushed over the session. This variant also
+shows the tool-use loop over TLS with JWT auth.
+
+### Run the server
 ```
 JWT_SECRET=a-string-secret-at-least-256-bits-long cargo run --manifest-path examples/sampling/server/Cargo.toml
 ```
 
-## Run the client
+### Run the client
 ```
 cargo run --manifest-path examples/sampling/client/Cargo.toml
 ```
+
+## MCP 2026-07-28 RC (`sampling/createMessage` as an MRTR input request)
+
+The RC removed the capability-driven push request. The *ability* was re-homed
+onto MRTR: the server borrows the client's model with `ctx.sample(key, params)`,
+the reply is an `input_required` result carrying a `sampling/createMessage`
+envelope, and the client echoes the completion back in `inputResponses`
+alongside the opaque `requestState`. Sampling arrives **deprecated** — it exists
+for migration.
+
+### Run the server
+```
+cargo run --manifest-path examples/sampling/rc/server/Cargo.toml
+```
+### Run the client
+```
+cargo run --manifest-path examples/sampling/rc/client/Cargo.toml
+```
+
+The client prints `[o3-mini] Revenue grew 12% with steady churn, …`.
+
+### What to watch
+
+The server logs show the whole point of the MRTR effect primitives:
+
+```
+📝 summarize_report round starting…   # round 1
+📚 fetching source report…            # ctx.memo — computed once
+📝 summarize_report round starting…   # round 2: the handler re-runs…
+🗄️  summary archived                  # ctx.on_commit — fires once, at the end
+```
+
+`📚 fetching source report…` appears **once** even though the handler ran
+**twice**: the memo value is replayed out of `requestState` on the second round.
+
+The handler is wired with an explicit `client.map_sampling(…)` rather than the
+`#[sampling]` attribute — that macro belongs to the legacy push model and is not
+available under `proto-2026-07-28-rc`.

--- a/examples/sampling/rc/Cargo.toml
+++ b/examples/sampling/rc/Cargo.toml
@@ -1,0 +1,10 @@
+# The RC examples are a workspace of their own, deliberately separate from the
+# legacy one next door: Cargo unifies features across the members it builds
+# together, so a single workspace would switch `proto-2026-07-28-rc` on for the
+# legacy crates too and they would stop compiling against the RC API.
+[workspace]
+members = ["client", "server"]
+resolver = "2"
+
+[workspace.package]
+rust-version = "1.90.0"

--- a/examples/sampling/rc/client/Cargo.toml
+++ b/examples/sampling/rc/client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rc-client"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+neva = { path = "../../../../neva", features = ["client-macros", "http-client", "tracing", "proto-2026-07-28-rc"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.20"

--- a/examples/sampling/rc/client/src/main.rs
+++ b/examples/sampling/rc/client/src/main.rs
@@ -1,0 +1,62 @@
+//! New-spec (MCP 2026-07-28 RC) sampling example client.
+//!
+//! The sampling handler is still a handler — but it is no longer a *push*
+//! endpoint. Under the RC it fulfils MRTR `sampling/createMessage` input
+//! requests inside the client's round-trip loop, so the caller of `call_tool`
+//! sees a single call. Registering one makes the client declare
+//! `clientCapabilities.sampling`; a server may only ask for a kind the client
+//! declared.
+//!
+//! Note the handler is wired with an explicit `map_sampling` rather than the
+//! `#[sampling]` attribute: that macro belongs to the legacy push model and is
+//! not available under `proto-2026-07-28-rc`. An explicit, `#[allow(deprecated)]`
+//! call is also honest about the fact that this kind is deprecated on arrival.
+
+use neva::prelude::*;
+use neva::types::sampling::{CreateMessageRequestParams, CreateMessageResult};
+use tracing_subscriber::prelude::*;
+
+/// Stands in for a real model call.
+async fn complete(params: CreateMessageRequestParams) -> CreateMessageResult {
+    let prompt = params
+        .messages
+        .iter()
+        .flat_map(|message| message.content.iter())
+        .filter_map(|content| content.as_text())
+        .map(|text| text.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    tracing::info!("🤖 model asked to complete: {prompt}");
+
+    CreateMessageResult::assistant()
+        .with_model("o3-mini")
+        .with_content("Revenue grew 12% with steady churn, though two outages need follow-up.")
+        .end_turn()
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| http.bind("127.0.0.1:3002").with_endpoint("/mcp"))
+    });
+
+    // Deprecated on arrival, like the whole sampling kind — the API stays for
+    // migration.
+    #[allow(deprecated)]
+    client.map_sampling(complete);
+
+    // `connect()` runs `server/discover` — no `initialize` handshake under RC.
+    client.connect().await?;
+
+    // One call from here; the MRTR round-trips happen inside.
+    let result = client
+        .call_tool("summarize_report", [("topic", "EMEA")])
+        .await?;
+    tracing::info!("Result: {:?}", result.content);
+
+    client.disconnect().await
+}

--- a/examples/sampling/rc/server/Cargo.toml
+++ b/examples/sampling/rc/server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rc-server"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+neva = { path = "../../../../neva", features = ["server-macros", "http-server-volga", "tracing", "proto-2026-07-28-rc"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = "0.3.20"

--- a/examples/sampling/rc/server/src/main.rs
+++ b/examples/sampling/rc/server/src/main.rs
@@ -1,0 +1,80 @@
+//! New-spec (MCP 2026-07-28 RC) sampling example server.
+//!
+//! Under the RC there is no `sampling/createMessage` server→client *request*:
+//! the capability-driven push channel is gone. The ability was re-homed onto
+//! MRTR as an input-request kind, so the server borrows the client's model the
+//! same way it asks for elicitation input — `ctx.sample(key, params)` — and the
+//! completion replays from the encrypted `requestState` on the next round.
+//!
+//! Sampling is **deprecated on arrival**: it exists for migration, hence the
+//! explicit `#[allow(deprecated)]` at the call site.
+//!
+//! Because the handler re-runs from the top on every round-trip, the expensive
+//! work around the sampling point is guarded with the MRTR effect primitives —
+//! exactly as it would be around an elicitation point.
+
+use neva::prelude::*;
+use neva::types::sampling::{CreateMessageRequestParams, SamplingMessage};
+use tracing_subscriber::prelude::*;
+
+#[tool]
+async fn summarize_report(mut ctx: Context, topic: String) -> Result<String, Error> {
+    tracing::info!("📝 summarize_report round starting…");
+
+    // memo: the "fetch" happens once and is replayed on the second round,
+    // even though everything above the sampling point re-executes.
+    let report: String = ctx
+        .memo("report", async {
+            tracing::info!("📚 fetching source report…");
+            Ok(format!(
+                "Q3 numbers for {topic}: revenue up 12%, churn flat, two outages."
+            ))
+        })
+        .await?;
+
+    let params = CreateMessageRequestParams::new()
+        .with_sys_prompt("You are a concise analyst. Answer in one sentence.")
+        .with_message(SamplingMessage::user().with(format!("Summarize: {report}")))
+        .with_max_tokens(200);
+
+    // Round 1: no answer for "summary" yet, so this unwinds the handler and
+    // the server replies `input_required` with a `sampling/createMessage`
+    // envelope. Round 2: the client's `CreateMessageResult` is replayed.
+    #[allow(deprecated)]
+    let completion = ctx.sample("summary", params).await?;
+
+    let summary = completion
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|text| text.text.clone())
+        .unwrap_or_else(|| "(the client returned no text)".into());
+
+    // on_commit: runs exactly once, on the final round.
+    ctx.on_commit(async {
+        tracing::info!("🗄️  summary archived");
+        Ok(())
+    });
+
+    Ok(format!("[{}] {summary}", completion.model))
+}
+
+#[tokio::main]
+async fn main() {
+    // Under RC neva does not install a global subscriber; do it here so the
+    // per-round logs above are visible.
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    App::new()
+        // In production load a stable shared secret (env/secret store); the
+        // default is an ephemeral per-process key, fine for a single instance.
+        .with_request_state_secret(b"example-shared-secret")
+        .with_options(|opt| {
+            opt.with_name("Sampling Example Server (RC)")
+                .with_http(|http| http.bind("127.0.0.1:3002").with_endpoint("/mcp"))
+        })
+        .run()
+        .await;
+}

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -22,30 +22,30 @@ bytes = "1.12.1"
 sha2 = { version = "0.11.0", optional = true }
 chrono = { version = "0.4.45", features = ["serde"] }
 dashmap = "6.2.1"
-futures-util = { version = "0.3.32", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.33", default-features = false, features = ["alloc"] }
 http = "1.4.2"
 memchr = "2.8.3"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.150"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_json = "1.0.151"
 schemars = { version = "1.2.1" }
-tokio = { version = "1.53.0", features = ["sync", "io-std", "io-util", "rt", "time", "macros"] }
-tokio-util = "0.7.18"
+tokio = { version = "1.53.1", features = ["sync", "io-std", "io-util", "rt", "time", "macros"] }
+tokio-util = "0.7.19"
 uuid = { version = "1.24.0", features = ["v4", "serde"] }
 
 # optional
 chacha20poly1305 = { version = "0.11.0", optional = true }
 inventory = { version = "0.3.24", optional = true }
-jsonschema = { version = "0.48.0", optional = true }
+jsonschema = { version = "0.48.2", optional = true }
 once_cell = { version = "1.21.4", features = ["std"], optional = true }
 reqwest = { version = "0.13.4", features = ["stream", "json"], optional = true }
 sse-stream = { version = "0.2.4", optional = true }
 tokio-stream = { version = "0.1.18", optional = true }
 tracing = { version = "0.1.44", optional = true }
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "json"], optional = true }
-volga = { version = "0.9.5", features = ["di", "jwt-auth-full"], optional = true }
-volga-di = { version = "0.9.5", optional = true }
-volga-oauth-core = { version = "0.9.5", optional = true }
-volga-oauth-client = { version = "0.9.5", optional = true }
+volga = { version = "0.9.6", features = ["di", "jwt-auth-full"], optional = true }
+volga-di = { version = "0.9.6", optional = true }
+volga-oauth-core = { version = "0.9.6", optional = true }
+volga-oauth-client = { version = "0.9.6", optional = true }
 
 # neva
 neva_macros = { workspace = true, optional = true }
@@ -57,7 +57,7 @@ windows = { version = "0.62.0", features = ["Win32_Foundation", "Win32_System_Jo
 nix = { version = "0.31.1", features = ["signal"], optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.53.0", features = ["rt", "rt-multi-thread", "macros"] }
+tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros"] }
 tokio-stream = { version = "0.1.18" }
 
 [features]

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -1467,11 +1467,10 @@ fn seed_mrtr_ctx(
     use crate::types::mrtr::state::{StateCodec, now_secs, request_binding};
 
     let meta = req.meta();
-    let elicitation_allowed = meta
+    let client_capabilities = meta
         .as_ref()
         .and_then(|m| m.client_capabilities)
-        .map(|c| c.elicitation)
-        .unwrap_or(false);
+        .unwrap_or_default();
 
     let mut answers = std::collections::HashMap::new();
     let mut memos = std::collections::HashMap::new();
@@ -1493,22 +1492,26 @@ fn seed_mrtr_ctx(
                 "requestState exceeds the configured maximum size",
             ));
         }
+
         let payload = StateCodec::new(options.request_state_keys()).decode(&state)?;
         if payload.exp < now_secs() {
             return Err(Error::new(ErrorCode::InvalidParams, "requestState expired"));
         }
+
         if payload.req != request_binding(method, salient) {
             return Err(Error::new(
                 ErrorCode::InvalidParams,
                 "requestState does not match this request",
             ));
         }
+
         if payload.principal.as_deref() != principal {
             return Err(Error::new(
                 ErrorCode::InvalidParams,
                 "requestState principal mismatch",
             ));
         }
+
         answers = payload.answers;
         memos = payload.memos;
         effects = payload.effects;
@@ -1527,6 +1530,7 @@ fn seed_mrtr_ctx(
                 "inputResponses supplied without a requestState",
             ));
         };
+
         for (key, value) in responses {
             if answers.contains_key(&key) {
                 return Err(Error::new(
@@ -1547,7 +1551,7 @@ fn seed_mrtr_ctx(
     Ok(std::sync::Arc::new(crate::app::context::MrtrCtx {
         answers,
         pending: Default::default(),
-        elicitation_allowed,
+        client_capabilities,
         memos: std::sync::Mutex::new(memos),
         effects: std::sync::Mutex::new(effects),
         commits: Default::default(),
@@ -1567,20 +1571,29 @@ fn build_input_required(
     use crate::types::mrtr::InputRequiredResult;
     use crate::types::mrtr::state::{StateCodec, StatePayload, now_secs, request_binding};
 
-    if !arc.elicitation_allowed {
-        return Err(Error::new(
-            ErrorCode::InvalidRequest,
-            "server requested elicitation but the client did not declare support",
-        ));
-    }
-    let (key, params) = arc
+    let (key, request) = arc
         .pending
         .lock()
         .ok()
         .and_then(|mut p| p.take())
         .ok_or_else(|| Error::new(ErrorCode::InternalError, "missing pending MRTR input"))?;
+
+    // Each kind is gated on its own flag: a client that fulfils elicitation
+    // need not fulfil the deprecated sampling/roots kinds, and asking for one
+    // it never declared would otherwise stall the round-trip.
+    if !arc.client_capabilities.allows(&request) {
+        return Err(Error::new(
+            ErrorCode::InvalidRequest,
+            format!(
+                "server requested `{}` but the client did not declare support",
+                request.method()
+            ),
+        ));
+    }
+
     let memos = arc.memos.lock().map(|m| m.clone()).unwrap_or_default();
     let effects = arc.effects.lock().map(|e| e.clone()).unwrap_or_default();
+
     let payload = StatePayload {
         answers: arc.answers.clone(),
         // Bind the key we are requesting into the signed state so the next
@@ -1592,6 +1605,7 @@ fn build_input_required(
         req: request_binding(method, salient),
         principal,
     };
+
     let state = StateCodec::new(options.request_state_keys()).encode(&payload)?;
     if state.len() > options.max_state_bytes() {
         return Err(Error::new(
@@ -1599,7 +1613,8 @@ fn build_input_required(
             "requestState too large",
         ));
     }
-    Ok(InputRequiredResult::elicitation(key, params, state))
+
+    Ok(InputRequiredResult::single(key, request, state))
 }
 
 /// Returns `true` only when `resp` is a genuine success that should trigger the
@@ -1783,7 +1798,12 @@ mod tests {
             use crate::types::elicitation::ElicitResult;
             let answers = answers
                 .iter()
-                .map(|k| ((*k).to_owned(), ElicitResult::accept()))
+                .filter_map(|k| {
+                    Some((
+                        (*k).to_owned(),
+                        serde_json::to_value(ElicitResult::accept()).ok()?,
+                    ))
+                })
                 .collect();
             let payload = StatePayload {
                 answers,

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -337,6 +337,11 @@ impl App {
     /// This is the single-key shorthand (kid `"0"`); for key rotation use
     /// [`with_request_state_keys`](Self::with_request_state_keys).
     ///
+    /// Because the state is sealed rather than signed, this value protects the
+    /// *confidentiality* of memoized values, not just their integrity — treat
+    /// it as a secret. See the [state codec docs](crate::types::mrtr) for why
+    /// MRTR encrypts instead of signing.
+    ///
     /// # Example
     /// ```no_run
     /// # #[cfg(feature = "proto-2026-07-28-rc")] {

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -74,13 +74,18 @@ pub(crate) type CommitFut =
 pub(crate) struct MrtrCtx {
     /// Answers available this round (prior answers decoded from
     /// `requestState`, merged with this round's `inputResponses`).
-    pub(crate) answers: std::collections::HashMap<String, crate::types::elicitation::ElicitResult>,
+    ///
+    /// Raw [`serde_json::Value`]s: the result type depends on which kind of
+    /// input was requested, so each helper deserializes its own — the same
+    /// arrangement [`Context::memo`] uses.
+    pub(crate) answers: std::collections::HashMap<String, serde_json::Value>,
 
-    /// The newly-requested input (v1: at most one), recorded on a cache miss.
-    pub(crate) pending: std::sync::Mutex<Option<(String, ElicitRequestParams)>>,
+    /// The newly-requested input (at most one per round), recorded on a
+    /// cache miss.
+    pub(crate) pending: std::sync::Mutex<Option<(String, crate::types::mrtr::InputRequest)>>,
 
-    /// Whether the client declared elicitation support this round.
-    pub(crate) elicitation_allowed: bool,
+    /// Which input-request kinds the client declared support for this round.
+    pub(crate) client_capabilities: crate::types::mrtr::ClientMrtrCapabilities,
 
     /// Cached `ctx.memo` values (seeded from `requestState`, grown on miss).
     pub(crate) memos: std::sync::Mutex<std::collections::HashMap<String, serde_json::Value>>,
@@ -99,7 +104,7 @@ impl std::fmt::Debug for MrtrCtx {
         f.debug_struct("MrtrCtx")
             .field("answers", &self.answers)
             .field("pending", &self.pending)
-            .field("elicitation_allowed", &self.elicitation_allowed)
+            .field("client_capabilities", &self.client_capabilities)
             .field("memos", &self.memos)
             .field("effects", &self.effects)
             .finish_non_exhaustive()
@@ -110,16 +115,30 @@ impl std::fmt::Debug for MrtrCtx {
 impl MrtrCtx {
     /// Returns the cached answer for `key`, or records the request and returns
     /// the MRTR "input required" sentinel error to unwind the handler.
-    pub(crate) fn resolve(
+    ///
+    /// The answer is stored raw, so it is deserialized into `T` — the result
+    /// type the requested kind implies — on the replay round. A stored answer
+    /// that does not fit `T` means the client answered the right key with the
+    /// wrong kind of result, which is a protocol violation rather than a
+    /// reason to re-ask (re-asking would loop).
+    pub(crate) fn resolve<T: serde::de::DeserializeOwned>(
         &self,
         key: String,
-        params: ElicitRequestParams,
-    ) -> Result<ElicitResult, Error> {
+        request: crate::types::mrtr::InputRequest,
+    ) -> Result<T, Error> {
         if let Some(answer) = self.answers.get(&key) {
-            return Ok(answer.clone());
+            return serde_json::from_value(answer.clone()).map_err(|err| {
+                Error::new(
+                    ErrorCode::InvalidParams,
+                    format!(
+                        "the answer for `{key}` is not a valid {} result: {err}",
+                        request.method()
+                    ),
+                )
+            });
         }
         if let Ok(mut pending) = self.pending.lock() {
-            *pending = Some((key, params));
+            *pending = Some((key, request));
         }
         Err(Error::input_required())
     }
@@ -987,6 +1006,7 @@ impl Context {
     /// ```no_run
     /// # #[cfg(all(feature = "server-macros", feature = "proto-2026-07-28-rc"))] {
     /// use neva::{Context, error::Error, types::elicitation::ElicitRequestParams, tool};
+    ///
     /// #[tool]
     /// async fn greet(mut ctx: Context) -> Result<String, Error> {
     ///     let params = ElicitRequestParams::form("Your name?")
@@ -1008,7 +1028,10 @@ impl Context {
         // the explicit `ctx.task().elicit(...)` builder instead — the two never
         // mix (see [`ExecMode`]).
         match &self.exec {
-            ExecMode::Mrtr(mrtr) => mrtr.resolve(key.into(), params),
+            ExecMode::Mrtr(mrtr) => mrtr.resolve(
+                key.into(),
+                crate::types::mrtr::InputRequest::Elicitation(params),
+            ),
             #[cfg(feature = "tasks")]
             ExecMode::Task(_) => Err(Error::new(
                 ErrorCode::InvalidRequest,
@@ -1017,6 +1040,122 @@ impl Context {
             _ => Err(Error::new(
                 ErrorCode::InvalidRequest,
                 "elicitation is not available for this request",
+            )),
+        }
+    }
+
+    /// Requests an LLM completion from the client (MRTR, `proto-2026-07-28-rc`).
+    ///
+    /// Same re-run/replay semantics as [`Self::elicit`]: on the first dispatch
+    /// the answer for `key` is absent, so the request is recorded and the
+    /// handler unwinds; when the client retries with the result, the handler
+    /// re-runs and this returns the cached [`CreateMessageResult`](crate::types::sampling::CreateMessageResult).
+    ///
+    /// **Important:** code before this point re-executes on every round-trip —
+    /// keep it side-effect-free, or guard it with [`Self::once`] /
+    /// [`Self::memo`] / [`Self::on_commit`], which work here exactly as they do
+    /// for elicitation.
+    ///
+    /// # Deprecated on arrival
+    /// MCP 2026-07-28 removed sampling as a capability-driven server→client
+    /// request and re-homed the *ability* onto MRTR — already on its
+    /// deprecation path (a 12-month lifecycle shared with roots and logging).
+    /// It exists for migration; prefer tools that do not need the client's
+    /// model.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # #[cfg(all(feature = "server-macros", feature = "proto-2026-07-28-rc"))] {
+    /// use neva::{Context, error::Error, tool};
+    /// use neva::types::sampling::{CreateMessageRequestParams, SamplingMessage};
+    ///
+    /// #[tool]
+    /// async fn summarize(mut ctx: Context, text: String) -> Result<String, Error> {
+    ///     let params = CreateMessageRequestParams::new()
+    ///         .with_message(SamplingMessage::user().with(format!("Summarize: {text}")));
+    ///     # #[allow(deprecated)]
+    ///     let res = ctx.sample("summary", params).await?;
+    ///     Ok(format!("{:?}", res.content))
+    /// }
+    /// # }
+    /// ```
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[deprecated(
+        note = "sampling is deprecated in MCP 2026-07-28; it returns as an MRTR input-request kind only for migration"
+    )]
+    pub async fn sample(
+        &mut self,
+        key: impl Into<String>,
+        params: crate::types::sampling::CreateMessageRequestParams,
+    ) -> Result<crate::types::sampling::CreateMessageResult, Error> {
+        #[allow(deprecated)]
+        self.request_input(
+            key,
+            crate::types::mrtr::InputRequest::Sampling(Box::new(params)),
+            "sampling",
+        )
+    }
+
+    /// Asks the client which filesystem roots it exposes (MRTR,
+    /// `proto-2026-07-28-rc`).
+    ///
+    /// Same re-run/replay semantics as [`Self::elicit`] — see [`Self::sample`]
+    /// for the round-trip caveat.
+    ///
+    /// # Deprecated on arrival
+    /// As with [`Self::sample`]: the capability-driven `roots/list` request is
+    /// gone in MCP 2026-07-28 and the ability returns re-homed onto MRTR,
+    /// already deprecated.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # #[cfg(all(feature = "server-macros", feature = "proto-2026-07-28-rc"))] {
+    /// use neva::{Context, error::Error, tool};
+    ///
+    /// #[tool]
+    /// async fn scan(mut ctx: Context) -> Result<String, Error> {
+    ///     # #[allow(deprecated)]
+    ///     let roots = ctx.list_roots("roots").await?;
+    ///     Ok(format!("{} roots", roots.roots.len()))
+    /// }
+    /// # }
+    /// ```
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[deprecated(
+        note = "roots are deprecated in MCP 2026-07-28; they return as an MRTR input-request kind only for migration"
+    )]
+    pub async fn list_roots(
+        &mut self,
+        key: impl Into<String>,
+    ) -> Result<crate::types::root::ListRootsResult, Error> {
+        #[allow(deprecated)]
+        self.request_input(
+            key,
+            crate::types::mrtr::InputRequest::Roots(Default::default()),
+            "roots",
+        )
+    }
+
+    /// The shared body behind [`Self::elicit`] / [`Self::sample`] /
+    /// [`Self::list_roots`]: every input kind rides the same MRTR substrate,
+    /// so only the envelope and the result type differ.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    fn request_input<T: serde::de::DeserializeOwned>(
+        &self,
+        key: impl Into<String>,
+        request: crate::types::mrtr::InputRequest,
+        kind: &str,
+    ) -> Result<T, Error> {
+        match &self.exec {
+            ExecMode::Mrtr(mrtr) => mrtr.resolve(key.into(), request),
+            #[cfg(feature = "tasks")]
+            ExecMode::Task(_) => Err(Error::new(
+                ErrorCode::InvalidRequest,
+                format!("this is a task-augmented call; {kind} is only available on the MRTR path"),
+            )),
+            _ => Err(Error::new(
+                ErrorCode::InvalidRequest,
+                format!("{kind} is not available for this request"),
             )),
         }
     }
@@ -1655,32 +1794,98 @@ mod mrtr_tests {
             .into()
     }
 
+    fn elicitation() -> crate::types::mrtr::InputRequest {
+        crate::types::mrtr::InputRequest::Elicitation(params())
+    }
+
+    fn mrtr_with(answers: std::collections::HashMap<String, serde_json::Value>) -> MrtrCtx {
+        MrtrCtx {
+            answers,
+            pending: Default::default(),
+            client_capabilities: crate::types::mrtr::ClientMrtrCapabilities {
+                elicitation: true,
+                sampling: true,
+                roots: true,
+            },
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn resolve_replays_cached_answer_and_records_pending_on_miss() {
         let mut answers = std::collections::HashMap::new();
         answers.insert(
             "known".to_string(),
-            ElicitResult {
+            serde_json::to_value(ElicitResult {
                 action: ElicitationAction::Accept,
                 content: Some(serde_json::json!({ "x": 1 })),
                 meta: None,
-            },
+            })
+            .unwrap(),
         );
-        let mrtr = MrtrCtx {
-            answers,
-            pending: Default::default(),
-            elicitation_allowed: true,
-            ..Default::default()
-        };
+        let mrtr = mrtr_with(answers);
 
-        // Hit: returns the cached answer.
-        let got = mrtr.resolve("known".into(), params()).expect("cached");
+        // Hit: returns the cached answer, deserialized into the kind's result.
+        let got: ElicitResult = mrtr.resolve("known".into(), elicitation()).expect("cached");
         assert_eq!(got.action, ElicitationAction::Accept);
 
         // Miss: returns the sentinel and records pending.
-        let miss = mrtr.resolve("unknown".into(), params());
+        let miss = mrtr.resolve::<ElicitResult>("unknown".into(), elicitation());
         assert_eq!(miss.unwrap_err().code, ErrorCode::InputRequired);
         assert!(mrtr.pending.lock().unwrap().is_some());
+    }
+
+    /// Every kind replays through the same slot — only the result type differs.
+    #[test]
+    fn resolve_replays_each_input_kind_as_its_own_result_type() {
+        use crate::types::mrtr::InputRequest;
+        use crate::types::root::ListRootsResult;
+        use crate::types::sampling::CreateMessageResult;
+
+        let mut answers = std::collections::HashMap::new();
+        answers.insert(
+            "poem".to_string(),
+            serde_json::to_value(CreateMessageResult::assistant()).unwrap(),
+        );
+        answers.insert(
+            "dirs".to_string(),
+            serde_json::json!({ "roots": [{ "uri": "file:///work", "name": "work" }] }),
+        );
+        let mrtr = mrtr_with(answers);
+
+        #[allow(deprecated)]
+        let sampled: CreateMessageResult = mrtr
+            .resolve("poem".into(), InputRequest::Sampling(Box::default()))
+            .expect("cached sampling result");
+        assert_eq!(sampled.role, crate::types::Role::Assistant);
+
+        #[allow(deprecated)]
+        let roots: ListRootsResult = mrtr
+            .resolve("dirs".into(), InputRequest::Roots(Default::default()))
+            .expect("cached roots result");
+        assert_eq!(roots.roots.len(), 1);
+    }
+
+    /// A key answered with the wrong kind of result is a protocol violation:
+    /// re-asking would loop forever, so it must surface as an error.
+    #[test]
+    fn resolve_rejects_a_mismatched_answer_instead_of_re_asking() {
+        let mut answers = std::collections::HashMap::new();
+        answers.insert("k".to_string(), serde_json::json!({ "not": "an elicit" }));
+        let mrtr = mrtr_with(answers);
+
+        let err = mrtr
+            .resolve::<ElicitResult>("k".into(), elicitation())
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidParams);
+        assert!(
+            err.to_string().contains("elicitation/create"),
+            "the error must name the kind that was asked for, got: {err}"
+        );
+        assert!(
+            mrtr.pending.lock().unwrap().is_none(),
+            "a mismatched answer must not re-request the input"
+        );
     }
 
     #[test]

--- a/neva/src/app/extension.rs
+++ b/neva/src/app/extension.rs
@@ -5,7 +5,7 @@
 //! capability value under `capabilities.extensions[id]`, and brings its own
 //! request handlers. This module defines the [`Extension`] trait that wires
 //! such a feature into an [`App`]; concrete extensions live in submodules
-//! (e.g. the built-in [`TasksExtension`]).
+//! (e.g. the built-in `TasksExtension`, under the `tasks` feature).
 
 use super::App;
 

--- a/neva/src/app/handler.rs
+++ b/neva/src/app/handler.rs
@@ -3,11 +3,11 @@
 use crate::Context;
 use crate::app::options::RuntimeMcpOptions;
 use crate::error::{Error, ErrorCode};
+use crate::shared::BoxFuture;
 use crate::types::{
     CallToolRequestParams, CompleteRequestParams, GetPromptRequestParams, IntoResponse,
     ListResourcesRequestParams, ReadResourceRequestParams, Request, RequestId, Response,
 };
-use futures_util::future::BoxFuture;
 use std::future::Future;
 use std::sync::Arc;
 

--- a/neva/src/app/mrtr_store.rs
+++ b/neva/src/app/mrtr_store.rs
@@ -18,6 +18,13 @@
 //! echoes the same blob and answers (same key), so the cached response is
 //! returned verbatim and the handler never re-executes.
 //!
+//! The protocol does not mandate any of this — final-round deduplication is
+//! left to the implementation, and an SDK may reasonably leave it to the
+//! application author. neva ships it on by default, so a tool that charges a
+//! card or sends a receipt is safe to write in the obvious way. See the
+//! [`mrtr`](crate::types::mrtr) module docs for how it fits with `once` /
+//! `memo` / `on_commit`.
+//!
 //! The default [`InMemoryStateStore`] is per-process. A multi-instance
 //! deployment should supply a shared implementation (e.g. Redis) via
 //! [`App::with_request_state_store`](crate::App::with_request_state_store) — for

--- a/neva/src/app/mrtr_store.rs
+++ b/neva/src/app/mrtr_store.rs
@@ -24,9 +24,9 @@
 //! the same reason such a deployment must share the MRTR secret (a retry routed
 //! to a different instance must see the same committed state).
 
+use crate::shared::BoxFuture;
 use crate::types::Response;
 use crate::types::mrtr::state::now_secs;
-use futures_util::future::BoxFuture;
 use std::sync::Arc;
 
 /// A store that remembers the final response of a committed MRTR `requestState`

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1161,13 +1161,17 @@ impl Client {
     ) {
         let mut meta = req.meta().unwrap_or_default();
         meta.client_info = Some(self.options.implementation.clone());
-        // Each flag reflects what this client can actually fulfil right now:
-        // a configured handler for elicitation/sampling, and — since roots are
-        // data rather than a handler — a non-empty roots list.
+        // Each flag reflects what this client can actually fulfil right now: a
+        // configured handler for elicitation/sampling, and — since roots are
+        // data rather than a handler — a declared roots capability. That is
+        // either an explicit `with_roots(..)` or simply having roots, and it
+        // deliberately stays true for an empty list: an empty
+        // `ListRootsResult` is a valid answer, so a client that opted in must
+        // not be gated out of being asked.
         meta.client_capabilities = Some(crate::types::mrtr::ClientMrtrCapabilities {
             elicitation: self.options.elicitation_handler.is_some(),
             sampling: self.options.sampling_handler.is_some(),
-            roots: !self.options.roots().is_empty(),
+            roots: self.options.roots_capability().is_some(),
         });
 
         if input_responses.is_some() {

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -118,7 +118,7 @@ impl Client {
     /// # }
     /// ```
     #[deprecated(
-        note = "Roots are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
+        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR — see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
     )]
     #[allow(deprecated)]
     pub fn add_root(&mut self, uri: impl Into<Uri>, name: impl Into<String>) -> &mut Self {
@@ -145,7 +145,7 @@ impl Client {
     /// # }
     /// ```
     #[deprecated(
-        note = "Roots are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
+        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR — see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
     )]
     #[allow(deprecated)]
     pub fn add_roots<T, I>(&mut self, roots: I) -> &mut Self
@@ -160,7 +160,7 @@ impl Client {
 
     /// Sends the "notifications/roots/list_changed" notification to the server
     #[deprecated(
-        note = "Roots are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
+        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR — see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
     )]
     pub fn publish_roots_changed(&mut self) {
         if let Some(handler) = self.handler.as_mut() {
@@ -171,7 +171,7 @@ impl Client {
 
     /// Registers a handler that will be running when a "sampling/createMessage" request is received
     #[deprecated(
-        note = "Sampling are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
+        note = "Sampling is deprecated in MCP 2026-07-28: the capability-driven `sampling/createMessage` request is gone and the ability is re-homed onto MRTR — see `Context::sample`. Under the RC this handler fulfils MRTR `sampling/createMessage` input requests."
     )]
     pub fn map_sampling<F, R>(&mut self, handler: F) -> &mut Self
     where
@@ -1127,9 +1127,8 @@ impl Client {
 
             let mut input_responses = crate::types::mrtr::InputResponses::new();
             if let Some(reqs) = ir.input_requests {
-                for (key, envelope) in reqs {
-                    let result = self.fulfil_elicitation(envelope.params).await?;
-                    input_responses.insert(key, result);
+                for (key, request) in reqs {
+                    input_responses.insert(key, self.fulfil_input(request).await?);
                 }
             }
 
@@ -1162,21 +1161,30 @@ impl Client {
     ) {
         let mut meta = req.meta().unwrap_or_default();
         meta.client_info = Some(self.options.implementation.clone());
+        // Each flag reflects what this client can actually fulfil right now:
+        // a configured handler for elicitation/sampling, and — since roots are
+        // data rather than a handler — a non-empty roots list.
         meta.client_capabilities = Some(crate::types::mrtr::ClientMrtrCapabilities {
             elicitation: self.options.elicitation_handler.is_some(),
+            sampling: self.options.sampling_handler.is_some(),
+            roots: !self.options.roots().is_empty(),
         });
+
         if input_responses.is_some() {
             meta.input_responses = input_responses;
         }
+
         if request_state.is_some() {
             meta.request_state = request_state;
         }
+
         if let Some(provider) = self.options.trace_context_provider.as_ref()
             && let Some(tc) = provider()
         {
             meta.traceparent = Some(tc.traceparent);
             meta.tracestate = tc.tracestate;
         }
+
         req.set_meta(meta);
     }
 
@@ -1194,19 +1202,39 @@ impl Client {
         }
     }
 
-    /// Fulfils a server-requested elicitation via the configured handler.
+    /// Fulfils one server-requested input, whatever its kind, and returns the
+    /// raw result to echo back under the request's key.
+    ///
+    /// Sampling and roots are fulfilled here, on the MRTR loop — *not* as
+    /// server-initiated pushes: under the RC there is no such channel. The
+    /// client only ever gets asked for a kind it declared in
+    /// [`ClientMrtrCapabilities`](crate::types::mrtr::ClientMrtrCapabilities),
+    /// so a missing handler here means the server ignored those flags.
     #[cfg(feature = "proto-2026-07-28-rc")]
-    async fn fulfil_elicitation(
+    async fn fulfil_input(
         &self,
-        params: crate::types::elicitation::ElicitRequestParams,
-    ) -> Result<crate::types::elicitation::ElicitResult, Error> {
-        match self.options.elicitation_handler.clone() {
-            Some(handler) => Ok(handler(params).await),
-            None => Err(Error::new(
-                ErrorCode::InvalidRequest,
-                "server requested elicitation but no handler is configured",
-            )),
-        }
+        request: crate::types::mrtr::InputRequest,
+    ) -> Result<serde_json::Value, Error> {
+        use crate::types::mrtr::InputRequest;
+
+        #[allow(deprecated)]
+        let value = match request {
+            InputRequest::Elicitation(params) => match self.options.elicitation_handler.clone() {
+                Some(handler) => serde_json::to_value(handler(params).await)?,
+                None => return Err(no_fulfiller("elicitation")),
+            },
+            InputRequest::Sampling(params) => match self.options.sampling_handler.clone() {
+                Some(handler) => serde_json::to_value(handler(*params).await)?,
+                None => return Err(no_fulfiller("sampling")),
+            },
+            // Roots are configured data, not a handler: the client answers
+            // from the list it was built with.
+            InputRequest::Roots(_) => serde_json::to_value(crate::types::root::ListRootsResult {
+                roots: self.options.roots(),
+                meta: None,
+            })?,
+        };
+        Ok(value)
     }
 
     /// Creates a [`BatchBuilder`] for sending multiple requests in a single batch.
@@ -1391,6 +1419,7 @@ impl Client {
             if round == 0 {
                 envelopes.append(&mut extras);
             }
+
             let mut round_slots: Vec<usize> = Vec::new();
             for (i, slot) in slots.iter_mut().enumerate() {
                 if let Slot::Pending { req, .. } = slot
@@ -1400,6 +1429,7 @@ impl Client {
                     envelopes.push(MessageEnvelope::Request(request));
                 }
             }
+
             if round_slots.is_empty() {
                 break;
             }
@@ -1409,6 +1439,7 @@ impl Client {
                 .handler
                 .as_mut()
                 .ok_or_else(|| Error::new(ErrorCode::InternalError, "Connection closed"))?;
+
             let request_timeout = handler.timeout();
             let pending = handler.pending().clone();
             let token = handler.cancellation();
@@ -1437,6 +1468,7 @@ impl Client {
                             if ok.result.get("resultType")
                                 == Some(&serde_json::json!("input_required"))
                     );
+
                 if !is_input_required {
                     slots[slot_i] = Slot::Done(resp);
                     continue;
@@ -1452,15 +1484,16 @@ impl Client {
 
                 let mut input_responses = crate::types::mrtr::InputResponses::new();
                 if let Some(reqs) = ir.input_requests {
-                    for (key, envelope) in reqs {
-                        let result = self.fulfil_elicitation(envelope.params).await?;
-                        input_responses.insert(key, result);
+                    for (key, request) in reqs {
+                        input_responses.insert(key, self.fulfil_input(request).await?);
                     }
                 }
 
                 let new_id = self.generate_id()?;
                 let mut retry = Request::new(Some(new_id), method, original_params);
+
                 self.apply_client_meta(&mut retry, Some(input_responses), ir.request_state);
+
                 if let Slot::Pending { req, .. } = &mut slots[slot_i] {
                     *req = Some(retry);
                 }
@@ -1692,6 +1725,17 @@ async fn collect_batch_responses(
     });
 
     join_all(futures).await
+}
+
+/// The error for an input kind the server asked for but this client has no
+/// fulfiller for — only reachable if the server ignored the declared
+/// [`ClientMrtrCapabilities`](crate::types::mrtr::ClientMrtrCapabilities).
+#[cfg(feature = "proto-2026-07-28-rc")]
+fn no_fulfiller(kind: &str) -> Error {
+    Error::new(
+        ErrorCode::InvalidRequest,
+        format!("server requested {kind} but no handler is configured"),
+    )
 }
 
 /// Whether a `server/discover` failure means "this server doesn't speak

--- a/neva/src/client/options.rs
+++ b/neva/src/client/options.rs
@@ -416,6 +416,24 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
 
+    /// An explicit `with_roots(..)` must survive an empty roots list: the MRTR
+    /// flag is derived from this, and an empty `ListRootsResult` is a perfectly
+    /// valid answer — a client that opted in must still be askable.
+    #[test]
+    fn an_explicit_roots_capability_survives_an_empty_list() {
+        #[allow(deprecated)]
+        let opts = McpOptions::default().with_roots(|roots| roots);
+        assert!(opts.roots().is_empty(), "no roots were added");
+        assert!(
+            opts.roots_capability().is_some(),
+            "an explicit opt-in must not be dropped just because the list is empty"
+        );
+
+        // …and with neither an opt-in nor any roots there is nothing to declare.
+        let bare = McpOptions::default();
+        assert!(bare.roots_capability().is_none());
+    }
+
     /// Implicit sampling/elicitation capabilities follow the *installed
     /// handler*: advertising one a client cannot serve makes a legacy
     /// server send requests answered with `MethodNotFound`, while hiding

--- a/neva/src/client/options.rs
+++ b/neva/src/client/options.rs
@@ -208,7 +208,7 @@ impl McpOptions {
 
     /// Configures Roots capability
     #[deprecated(
-        note = "Roots are removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
+        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR — see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
     )]
     pub fn with_roots<T>(mut self, config: T) -> Self
     where
@@ -220,7 +220,7 @@ impl McpOptions {
 
     /// Configures Sampling capability
     #[deprecated(
-        note = "Sampling is removed in MCP 2026-07-28; this method will be removed when the legacy flag is dropped."
+        note = "Sampling is deprecated in MCP 2026-07-28: the capability-driven `sampling/createMessage` request is gone and the ability is re-homed onto MRTR — see `Context::sample`."
     )]
     pub fn with_sampling<T>(mut self, config: T) -> Self
     where

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -235,6 +235,7 @@ pub mod prelude {
 
     pub use crate::error::*;
     pub use crate::json::*;
+    pub use crate::shared::BoxFuture;
     pub use crate::types::*;
 
     #[cfg(feature = "http-server-volga")]

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -117,7 +117,8 @@ compile_error!("Only one `proto-*` feature flag may be enabled per build");
 
 #[cfg(any(feature = "http-server", feature = "client-oauth"))]
 pub mod auth {
-    //! Authentication utilities: neva's engine-neutral [`Claims`] trait,
+    //! Authentication utilities: neva's engine-neutral `Claims` trait
+    //! (under the HTTP server features),
     //! the bearer-auth configuration types (under the Volga adapter),
     //! and the OAuth 2.1 building blocks for both sides of the
     //! Streamable HTTP transport (under the OAuth features).
@@ -185,7 +186,7 @@ pub mod auth {
     pub mod oauth {
         //! OAuth 2.1 / OIDC building blocks.
         //!
-        //! Server side (`server-oauth`): [`OAuthResourceOptions`]
+        //! Server side (`server-oauth`): `OAuthResourceOptions`
         //! configures the RFC 9728 Protected Resource Metadata document
         //! through `HttpServer::with_oauth_metadata`; the protocol-level
         //! types are re-exported from
@@ -194,8 +195,8 @@ pub mod auth {
         //! framework, so they are available to every `HttpEngine`.
         //!
         //! Client side (`client-oauth`): the pluggable
-        //! [`AuthorizationHandler`] contract with the default
-        //! [`LoopbackHandler`], plus the [`TokenStore`] persistence
+        //! `AuthorizationHandler` contract with the default
+        //! `LoopbackHandler`, plus the `TokenStore` persistence
         //! abstraction — configured through `HttpClient::with_oauth`.
 
         #[cfg(feature = "server-oauth")]

--- a/neva/src/middleware.rs
+++ b/neva/src/middleware.rs
@@ -1,10 +1,10 @@
 //! MCP Server middleware utilities
 
+use crate::shared::BoxFuture;
 use crate::{
     app::context::ServerRuntime,
     types::{Message, Request, RequestId, Response, notification::Notification},
 };
-use futures_util::future::BoxFuture;
 use std::fmt::Debug;
 use std::sync::Arc;
 

--- a/neva/src/shared.rs
+++ b/neva/src/shared.rs
@@ -48,8 +48,8 @@ mod task_tracker;
 /// The future returned by neva's object-safe async traits — a boxed,
 /// `Send` future borrowing for `'a`.
 ///
-/// Traits like [`AuthorizationHandler`](crate::auth::oauth::AuthorizationHandler)
-/// and [`RequestStateStore`](crate::RequestStateStore) are stored behind
+/// Traits like `AuthorizationHandler` (client OAuth) and `RequestStateStore`
+/// (MRTR idempotency) are stored behind
 /// `Arc<dyn …>`, which rules out `async fn` in the trait (not dyn-compatible),
 /// so their methods return this instead. Owning the alias here means
 /// implementing such a trait needs no `futures` dependency of your own — and

--- a/neva/src/shared.rs
+++ b/neva/src/shared.rs
@@ -45,6 +45,38 @@ mod task_api;
 #[cfg(feature = "tasks")]
 mod task_tracker;
 
+/// The future returned by neva's object-safe async traits — a boxed,
+/// `Send` future borrowing for `'a`.
+///
+/// Traits like [`AuthorizationHandler`](crate::auth::oauth::AuthorizationHandler)
+/// and [`RequestStateStore`](crate::RequestStateStore) are stored behind
+/// `Arc<dyn …>`, which rules out `async fn` in the trait (not dyn-compatible),
+/// so their methods return this instead. Owning the alias here means
+/// implementing such a trait needs no `futures` dependency of your own — and
+/// no version of it kept in lockstep with neva's.
+///
+/// It is a plain alias for `Pin<Box<dyn Future<Output = T> + Send + 'a>>`
+/// (identical to `futures_util::future::BoxFuture`), so `Box::pin(async { … })`
+/// is all an implementation has to write.
+///
+/// # Example
+/// ```
+/// use neva::shared::BoxFuture;
+///
+/// trait Greeter {
+///     fn greet(&self) -> BoxFuture<'_, String>;
+/// }
+///
+/// struct English;
+///
+/// impl Greeter for English {
+///     fn greet(&self) -> BoxFuture<'_, String> {
+///         Box::pin(async { "hello".into() })
+///     }
+/// }
+/// ```
+pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
 #[inline]
 #[cfg(any(feature = "server", feature = "client"))]
 pub(crate) fn wait_for_shutdown_signal(token: CancellationToken) {
@@ -144,4 +176,37 @@ pub(crate) fn is_mrtr_method(method: &str) -> bool {
             | crate::types::prompt::commands::GET
             | crate::types::resource::commands::READ
     )
+}
+
+#[cfg(test)]
+mod box_future_tests {
+    use super::BoxFuture;
+
+    /// The alias must stay *the same type* as `futures_util`'s, not merely
+    /// a similar one: downstream code that already spells out
+    /// `futures_util::future::BoxFuture` in its trait impls keeps compiling,
+    /// so adopting neva's own alias is not a breaking change. Passing a
+    /// value of one type where the other is expected only compiles if they
+    /// are identical.
+    #[test]
+    fn it_is_the_same_type_as_the_futures_util_alias() {
+        fn ours<'a, T: 'a>(fut: futures_util::future::BoxFuture<'a, T>) -> BoxFuture<'a, T> {
+            fut
+        }
+        fn theirs<'a, T: 'a>(fut: BoxFuture<'a, T>) -> futures_util::future::BoxFuture<'a, T> {
+            fut
+        }
+
+        let fut: BoxFuture<'_, u8> = Box::pin(async { 42 });
+        let fut = theirs(fut);
+        let mut fut = ours(fut);
+
+        let waker = std::task::Waker::noop();
+        let mut cx = std::task::Context::from_waker(waker);
+        assert_eq!(
+            fut.as_mut().poll(&mut cx),
+            std::task::Poll::Ready(42),
+            "the boxed future must still drive to completion"
+        );
+    }
 }

--- a/neva/src/transport/http/client/oauth.rs
+++ b/neva/src/transport/http/client/oauth.rs
@@ -16,7 +16,7 @@
 //! the default [`LoopbackHandler`] serves desktop/CLI clients by opening
 //! the system browser and capturing the redirect on a loopback listener.
 
-use futures_util::future::BoxFuture;
+use crate::shared::BoxFuture;
 use std::sync::{Arc, RwLock};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -151,11 +151,17 @@ fn percent_decode(s: &str) -> Option<String> {
 /// headless embedder implements this trait to route the URL through its
 /// own UI and deliver the callback parameters however they arrive.
 ///
+/// Both methods return a [`BoxFuture`] rather than being `async fn`: the
+/// handler is stored behind `Arc<dyn AuthorizationHandler>`, and `async fn`
+/// in a trait is not dyn-compatible. `Box::pin(async move { … })` is all an
+/// implementation needs — and the alias is neva's own, so implementing this
+/// trait pulls in no `futures` dependency.
+///
 /// # Example
 /// ```no_run
-/// use futures_util::future::BoxFuture;
 /// use neva::auth::oauth::{AuthorizationHandler, CallbackParams};
 /// use neva::error::Error;
+/// use neva::shared::BoxFuture;
 ///
 /// struct MyUi;
 ///
@@ -712,7 +718,7 @@ impl OAuthSession {
                 OAuthClient::from_registration(&response).map_err(flow_error)?
             }
         };
-        
+
         Ok(client
             .with_config(self.config.client_config())
             .with_redirect_uri(redirect_uri)

--- a/neva/src/transport/http/client/oauth.rs
+++ b/neva/src/transport/http/client/oauth.rs
@@ -17,7 +17,6 @@
 //! the system browser and capturing the redirect on a loopback listener.
 
 use futures_util::future::BoxFuture;
-use std::future::Future;
 use std::sync::{Arc, RwLock};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
@@ -577,34 +576,17 @@ impl OAuthSession {
     /// `OAuthClient::token`). Returns `None` when interactive
     /// authorization is required or no flow has completed yet.
     async fn maintain(&self, state: &mut Option<FlowState>) -> Option<Arc<str>> {
-        let FlowState { client, metadata } = state.take()?;
-        let key = self.resource.clone();
-        let outcome = run_non_send(move || async move {
-            let result = client.token(&key, &metadata).await;
-            Ok((client, metadata, result))
-        })
-        .await;
-
-        match outcome {
-            Ok((client, metadata, result)) => {
-                *state = Some(FlowState { client, metadata });
-                match result {
-                    Ok(Some(tokens)) => {
-                        let token: Arc<str> = tokens.access_token.into();
-                        self.set_token(token.clone());
-                        Some(token)
-                    }
-                    // Nothing renewable — interactive authorization it is.
-                    Ok(None) => None,
-                    // Transient failure (issuer unreachable): keep the
-                    // current token and let the request outcome decide.
-                    Err(_err) => {
-                        #[cfg(feature = "tracing")]
-                        tracing::warn!(logger = "neva", "token refresh failed: {_err}");
-                        None
-                    }
-                }
+        let FlowState { client, metadata } = state.as_ref()?;
+        match client.token(&self.resource, metadata).await {
+            Ok(Some(tokens)) => {
+                let token: Arc<str> = tokens.access_token.into();
+                self.set_token(token.clone());
+                Some(token)
             }
+            // Nothing renewable — interactive authorization it is.
+            Ok(None) => None,
+            // Transient failure (issuer unreachable): keep the current
+            // token and let the request outcome decide.
             Err(_err) => {
                 #[cfg(feature = "tracing")]
                 tracing::warn!(logger = "neva", "token refresh failed: {_err}");
@@ -688,8 +670,10 @@ impl OAuthSession {
         }
         validate_issuer(&params, &server_metadata)?;
 
-        let (client, server_metadata, tokens) =
-            exchange_code(client, server_metadata, params, request).await?;
+        let tokens = client
+            .exchange_code(&server_metadata, &params.code, &request)
+            .await
+            .map_err(flow_error)?;
 
         self.config.store.put(&self.resource, &tokens);
         // Keep the client + metadata so future refreshes stay
@@ -728,6 +712,7 @@ impl OAuthSession {
                 OAuthClient::from_registration(&response).map_err(flow_error)?
             }
         };
+        
         Ok(client
             .with_config(self.config.client_config())
             .with_redirect_uri(redirect_uri)
@@ -749,9 +734,11 @@ fn registration_metadata(redirect_uri: &str) -> ClientMetadata {
         .with_response_types(["code"])
         .with_token_endpoint_auth_method("none")
         .with_client_name(DEFAULT_CLIENT_NAME);
+
     if is_loopback_redirect(redirect_uri) {
-        metadata = metadata.with_additional_field("application_type", "native");
+        metadata = metadata.with_application_type("native");
     }
+
     metadata
 }
 
@@ -810,51 +797,6 @@ fn validate_issuer(
     }
 }
 
-/// Exchanges the authorization code for tokens, returning the client
-/// and metadata back for the session's refresh cache.
-async fn exchange_code(
-    client: OAuthClient,
-    server_metadata: AuthorizationServerMetadata,
-    params: CallbackParams,
-    request: volga_oauth_client::AuthorizationRequest,
-) -> Result<(OAuthClient, AuthorizationServerMetadata, TokenSet), Error> {
-    run_non_send(move || async move {
-        let tokens = client
-            .exchange_code(&server_metadata, &params.code, &request)
-            .await
-            .map_err(flow_error)?;
-        Ok((client, server_metadata, tokens))
-    })
-    .await
-}
-
-/// Runs a token-endpoint future to completion on a dedicated
-/// current-thread runtime.
-///
-/// `OAuthClient::exchange_code` / `refresh` in volga-oauth-client 0.9.5
-/// hold a `form_urlencoded::Serializer` across an `.await`, which makes
-/// their futures `!Send` — they cannot run inside neva's spawned request
-/// tasks directly. These are single short round-trips (end of an
-/// interactive flow, or a rare refresh), so bridging them through
-/// `spawn_blocking` is invisible in practice. Drop this bridge once
-/// upstream ships `Send` token-endpoint futures.
-async fn run_non_send<T, F, Fut>(f: F) -> Result<T, Error>
-where
-    F: FnOnce() -> Fut + Send + 'static,
-    Fut: Future<Output = Result<T, Error>>,
-    T: Send + 'static,
-{
-    tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(Error::from)?;
-        rt.block_on(f())
-    })
-    .await
-    .map_err(|err| Error::new(ErrorCode::InternalError, err.to_string()))?
-}
-
 /// Maps a `volga-oauth-client` failure onto neva's error type.
 fn flow_error(err: ClientError) -> Error {
     Error::new(
@@ -890,6 +832,30 @@ mod tests {
         assert!(CallbackParams::from_query("state=xyz").is_err());
     }
 
+    /// The token-endpoint futures must stay `Send`: neva drives them from
+    /// spawned request tasks. volga-oauth-client 0.9.5 held a non-`Sync`
+    /// `form_urlencoded::Serializer` across the await, which forced a
+    /// `spawn_blocking` bridge here; 0.9.6 scopes it. Asserting the bound
+    /// directly means a regression fails here rather than at some distant
+    /// `tokio::spawn` call site.
+    #[test]
+    fn token_endpoint_futures_are_send() {
+        fn assert_send<T: Send>(_: T) {}
+
+        let client = OAuthClient::new("client-id");
+        let metadata = as_metadata(None)
+            .with_authorization_endpoint("https://auth.example.com/authorize")
+            .with_token_endpoint("https://auth.example.com/token");
+        let request = client
+            .authorization_request(&metadata)
+            .with_scopes(["openid"])
+            .build()
+            .unwrap();
+
+        assert_send(client.exchange_code(&metadata, "code", &request));
+        assert_send(client.refresh(&metadata, "refresh-token"));
+    }
+
     #[test]
     fn loopback_redirects_are_detected() {
         assert!(is_loopback_redirect("http://127.0.0.1:8919/callback"));
@@ -902,17 +868,20 @@ mod tests {
     #[test]
     fn loopback_registration_declares_a_native_client() {
         let metadata = registration_metadata("http://127.0.0.1:8919/callback");
-        assert_eq!(
-            metadata.additional_fields.get("application_type"),
-            Some(&serde_json::Value::from("native"))
-        );
+        assert_eq!(metadata.application_type.as_deref(), Some("native"));
         assert_eq!(metadata.token_endpoint_auth_method.as_deref(), Some("none"));
+        // The wire shape is what the AS actually reads — it must stay a
+        // top-level member, not an extension field.
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert_eq!(json["application_type"], serde_json::json!("native"));
     }
 
     #[test]
     fn web_registration_stays_a_web_client() {
         let metadata = registration_metadata("https://my.app/oauth/callback");
-        assert!(!metadata.additional_fields.contains_key("application_type"));
+        assert!(metadata.application_type.is_none());
+        let json = serde_json::to_value(&metadata).unwrap();
+        assert!(json.get("application_type").is_none());
     }
 
     fn as_metadata(supported: Option<bool>) -> AuthorizationServerMetadata {

--- a/neva/src/transport/http/core/engine.rs
+++ b/neva/src/transport/http/core/engine.rs
@@ -44,23 +44,20 @@ use super::{
 ///
 /// # OAuth resource metadata contract (feature `server-oauth`)
 ///
-/// When the transport is configured through
-/// `HttpServer::with_oauth_metadata`, the engine receives the resolved
-/// document via [`HttpContext`] and is responsible for two things:
+/// When the transport is configured through `HttpServer::with_oauth_metadata`,
+/// the engine receives the resolved document via [`HttpContext`] and is
+/// responsible for two things:
 ///
-/// 1. Mount a GET route on
-///    [`HttpContext::oauth_metadata_path`](super::context::HttpContext::oauth_metadata_path)
-///    and serve it with
-///    [`handlers::handle_oauth_metadata`](super::handlers::handle_oauth_metadata)
-///    — this is the RFC 9728 Protected Resource Metadata document,
-///    reachable without authentication.
+/// 1. Mount a GET route on `HttpContext::oauth_metadata_path` and serve it
+///    with `handlers::handle_oauth_metadata` — this is the RFC 9728 Protected
+///    Resource Metadata document, reachable without authentication.
 /// 2. Answer requests that fail token validation with
-///    [`handlers::handle_unauthorized`](super::handlers::handle_unauthorized),
-///    so the 401 carries the `WWW-Authenticate` challenge pointing at
-///    that document and clients can start the OAuth discovery flow.
+///    `handlers::handle_unauthorized`, so the 401 carries the
+///    `WWW-Authenticate` challenge pointing at that document and clients can
+///    start the OAuth discovery flow.
 ///
-/// Both helpers return neva's neutral [`HttpResponse`] — pass it
-/// through `adapt_response` like any other reply.
+/// Both helpers return neva's neutral [`HttpResponse`] — pass it through
+/// `adapt_response` like any other reply.
 ///
 /// [`dispatch_post`]: super::handlers::dispatch_post
 ///

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -167,9 +167,11 @@ mod reference;
 mod request;
 pub mod resource;
 mod response;
-#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
+// Under the RC these are no longer capability-driven server→client requests,
+// but the types did not go away: they are the params/results of the deprecated
+// `roots/list` and `sampling/createMessage` MRTR input-request kinds (#85), so
+// both peers need them in every build.
 pub mod root;
-#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 pub mod sampling;
 mod schema;
 pub mod schema_2020;

--- a/neva/src/types/mrtr.rs
+++ b/neva/src/types/mrtr.rs
@@ -9,35 +9,34 @@
 //!
 //! # `requestState`: sealed, not merely signed
 //!
-//! MRTR is stateless — all cross-round progress travels through the client,
-//! which echoes the opaque `requestState` blob back on each retry. How that
-//! blob is protected is therefore a design decision, not a detail. neva
-//! **seals** it with ChaCha20-Poly1305 (AEAD) rather than **signing** it
-//! (HMAC).
+//! MRTR is stateless — all cross-round progress travels through the client, which
+//! echoes the opaque `requestState` blob back on each retry. How that blob is
+//! protected is therefore a design decision, not a detail. neva **seals** it with
+//! ChaCha20-Poly1305 (AEAD) rather than **signing** it (HMAC).
 //!
-//! A signed state is tamper-*evident*: the client cannot alter it undetected,
-//! but it can **read** it. That suffices while the state carries only what the
-//! client already knows — the answers it supplied itself. It stops sufficing
-//! the moment the server puts its *own* data in there, which is precisely what
-//! [`Context::memo`](crate::Context::memo) does: a memoized value is
-//! server-computed — an upstream API response, a quoted price, a record looked
-//! up under the caller's identity, a downstream token — and it is written into
-//! the state so the next round replays it instead of recomputing it. Signing
-//! alone would publish every such value to the client, and to anything that
-//! logs a request body in between.
+//! A signed state is tamper-*evident*: the client cannot alter it undetected, but
+//! it can **read** it. That suffices while the state carries only what the client
+//! already knows — the answers it supplied itself. It stops sufficing the moment
+//! the server puts its *own* data in there, which is precisely what
+//! `Context::memo` does: a memoized value is
+//! server-computed — an upstream API response, a quoted price, a record looked up
+//! under the caller's identity, a downstream token — and it is written into the
+//! state so the next round replays it instead of recomputing it. Signing alone
+//! would publish every such value to the client, and to anything that logs a
+//! request body in between.
 //!
-//! Nothing is traded away for that confidentiality: the AEAD tag authenticates
-//! the payload exactly as an HMAC would, and the `v1.{kid}` header is bound in
-//! as associated data so no segment can be transplanted between blobs. The
-//! payload additionally carries a TTL, a binding to the originating request,
-//! and a binding to the authenticated principal.
+//! Nothing is traded away for that confidentiality: the AEAD tag authenticates the
+//! payload exactly as an HMAC would, and the `v1.{kid}` header is bound in as
+//! associated data so no segment can be transplanted between blobs. The payload
+//! additionally carries a TTL, a binding to the originating request, and a binding
+//! to the authenticated principal.
 //!
 //! Two practical consequences:
 //! * `ctx.memo` is safe to use for values the client must not see.
 //! * The shared secret set via
-//!   [`App::with_request_state_secret`](crate::App::with_request_state_secret)
+//!   `App::with_request_state_secret`
 //!   (rotated via
-//!   [`App::with_request_state_keys`](crate::App::with_request_state_keys))
+//!   `App::with_request_state_keys`)
 //!   upholds confidentiality, not just integrity — treat it as a secret.
 //!
 //! # Side effects across rounds are the framework's problem
@@ -45,26 +44,26 @@
 //! Re-run + replay means a handler executes from the top on *every* round, so
 //! anything with a side effect between rounds is at risk of running more than
 //! once. The protocol itself says nothing about this — it is left to each
-//! implementation, and an SDK may reasonably hand the problem to the
-//! application author. neva does not:
+//! implementation, and an SDK may reasonably hand the problem to the application
+//! author. neva does not:
 //!
-//! * [`Context::memo`](crate::Context::memo) — compute once, replay the value
-//!   on later rounds (sealed into `requestState`, hence the section above).
-//! * [`Context::once`](crate::Context::once) — run an effect at most once
-//!   across the whole chain.
-//! * [`Context::on_commit`](crate::Context::on_commit) — defer an effect until
-//!   the handler actually reaches its final result, so an abandoned or failed
-//!   chain never applies it.
-//! * [`RequestStateStore`](crate::RequestStateStore) — close the one gap the
+//! * `Context::memo` — compute once, replay the value on
+//!   later rounds (sealed into `requestState`, hence the section above).
+//! * `Context::once` — run an effect at most once across
+//!   the whole chain.
+//! * `Context::on_commit` — defer an effect until the
+//!   handler actually reaches its final result, so an abandoned or failed chain
+//!   never applies it.
+//! * `RequestStateStore` — close the one gap the
 //!   sealed state structurally cannot: the final round mints no new state, so a
 //!   lost HTTP response would otherwise re-run the handler and its commits on
-//!   retry. The store caches the committed final response and replays it
-//!   verbatim. It is on by default (in-process); a multi-instance deployment
-//!   supplies a shared implementation.
+//!   retry. The store caches the committed final response and replays it verbatim.
+//!   It is on by default (in-process); a multi-instance deployment supplies a
+//!   shared implementation.
 //!
-//! Together these make an MRTR handler safe to write in the obvious way —
-//! charge the card, send the receipt — without hand-rolling idempotency keys
-//! per tool. See `docs/specs/2026-05-30-mrtr-design.md` for the full design.
+//! Together these make an MRTR handler safe to write in the obvious way — charge
+//! the card, send the receipt — without hand-rolling idempotency keys per tool.
+//! See `docs/specs/2026-05-30-mrtr-design.md` for the full design.
 
 // The encrypted `requestState` codec is server-only: the client treats
 // `requestState` as opaque and never encodes/decodes it.
@@ -113,7 +112,7 @@ pub type InputRequests = HashMap<String, InputRequest>;
 /// [`CreateMessageResult`](crate::types::sampling::CreateMessageResult),
 /// [`ListRootsResult`](crate::types::root::ListRootsResult)). Each server-side
 /// helper deserializes its own type out of the replay log, exactly like
-/// [`Context::memo`](crate::Context::memo) does.
+/// `ctx.memo` does.
 pub type InputResponses = HashMap<String, serde_json::Value>;
 
 /// One `{ method, params }` input-request envelope — the kind of input the

--- a/neva/src/types/mrtr.rs
+++ b/neva/src/types/mrtr.rs
@@ -5,7 +5,66 @@
 //! completing. The kind of input is the [`InputRequest`] union: elicitation
 //! (first-class), plus the deprecated-on-arrival sampling and roots kinds the
 //! spec re-homed here when it removed their capability-driven server→client
-//! requests. See `docs/specs/2026-05-30-mrtr-design.md`.
+//! requests.
+//!
+//! # `requestState`: sealed, not merely signed
+//!
+//! MRTR is stateless — all cross-round progress travels through the client,
+//! which echoes the opaque `requestState` blob back on each retry. How that
+//! blob is protected is therefore a design decision, not a detail. neva
+//! **seals** it with ChaCha20-Poly1305 (AEAD) rather than **signing** it
+//! (HMAC).
+//!
+//! A signed state is tamper-*evident*: the client cannot alter it undetected,
+//! but it can **read** it. That suffices while the state carries only what the
+//! client already knows — the answers it supplied itself. It stops sufficing
+//! the moment the server puts its *own* data in there, which is precisely what
+//! [`Context::memo`](crate::Context::memo) does: a memoized value is
+//! server-computed — an upstream API response, a quoted price, a record looked
+//! up under the caller's identity, a downstream token — and it is written into
+//! the state so the next round replays it instead of recomputing it. Signing
+//! alone would publish every such value to the client, and to anything that
+//! logs a request body in between.
+//!
+//! Nothing is traded away for that confidentiality: the AEAD tag authenticates
+//! the payload exactly as an HMAC would, and the `v1.{kid}` header is bound in
+//! as associated data so no segment can be transplanted between blobs. The
+//! payload additionally carries a TTL, a binding to the originating request,
+//! and a binding to the authenticated principal.
+//!
+//! Two practical consequences:
+//! * `ctx.memo` is safe to use for values the client must not see.
+//! * The shared secret set via
+//!   [`App::with_request_state_secret`](crate::App::with_request_state_secret)
+//!   (rotated via
+//!   [`App::with_request_state_keys`](crate::App::with_request_state_keys))
+//!   upholds confidentiality, not just integrity — treat it as a secret.
+//!
+//! # Side effects across rounds are the framework's problem
+//!
+//! Re-run + replay means a handler executes from the top on *every* round, so
+//! anything with a side effect between rounds is at risk of running more than
+//! once. The protocol itself says nothing about this — it is left to each
+//! implementation, and an SDK may reasonably hand the problem to the
+//! application author. neva does not:
+//!
+//! * [`Context::memo`](crate::Context::memo) — compute once, replay the value
+//!   on later rounds (sealed into `requestState`, hence the section above).
+//! * [`Context::once`](crate::Context::once) — run an effect at most once
+//!   across the whole chain.
+//! * [`Context::on_commit`](crate::Context::on_commit) — defer an effect until
+//!   the handler actually reaches its final result, so an abandoned or failed
+//!   chain never applies it.
+//! * [`RequestStateStore`](crate::RequestStateStore) — close the one gap the
+//!   sealed state structurally cannot: the final round mints no new state, so a
+//!   lost HTTP response would otherwise re-run the handler and its commits on
+//!   retry. The store caches the committed final response and replays it
+//!   verbatim. It is on by default (in-process); a multi-instance deployment
+//!   supplies a shared implementation.
+//!
+//! Together these make an MRTR handler safe to write in the obvious way —
+//! charge the card, send the receipt — without hand-rolling idempotency keys
+//! per tool. See `docs/specs/2026-05-30-mrtr-design.md` for the full design.
 
 // The encrypted `requestState` codec is server-only: the client treats
 // `requestState` as opaque and never encodes/decodes it.

--- a/neva/src/types/mrtr.rs
+++ b/neva/src/types/mrtr.rs
@@ -128,7 +128,10 @@ pub type InputResponses = HashMap<String, serde_json::Value>;
 /// `{ method, params }` (the per-key id is the map key), whereas `Request`
 /// has required `jsonrpc`/`id` fields — emitting it would add non-spec fields
 /// and deserializing a conformant peer's bare `{method,params}` would fail.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Deserialization is hand-written rather than derived (see the `impl` below):
+/// the adjacent tag would make `params` mandatory, and a conforming peer may
+/// omit it for a kind that needs none.
+#[derive(Debug, Clone, Serialize)]
 #[serde(tag = "method", content = "params")]
 pub enum InputRequest {
     /// `elicitation/create` — ask the end user for structured input.
@@ -154,6 +157,51 @@ pub enum InputRequest {
         note = "roots are deprecated in MCP 2026-07-28; they return as an MRTR input-request kind only for migration"
     )]
     Roots(Box<ListRootsRequestParams>),
+}
+
+impl<'de> Deserialize<'de> for InputRequest {
+    /// Decodes a `{ method, params }` envelope, dispatching on `method`.
+    ///
+    /// `params` is optional on the wire: `roots/list` takes none, so a
+    /// conforming peer may send a bare `{"method": "roots/list"}` (or an
+    /// explicit `null`). An absent value is read as an empty object rather
+    /// than as "use the default", so each kind's own params type still decides
+    /// what is acceptable — `roots/list` decodes (every field is optional)
+    /// while a paramless `elicitation/create` or `sampling/createMessage`
+    /// fails with that type's own error, as it should.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use crate::types::{elicitation, root, sampling};
+        use serde::de::Error as DeError;
+
+        #[derive(Deserialize)]
+        struct Envelope {
+            method: String,
+            #[serde(default)]
+            params: Option<serde_json::Value>,
+        }
+
+        let envelope = Envelope::deserialize(deserializer)?;
+        let params = envelope
+            .params
+            .filter(|params| !params.is_null())
+            .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
+
+        fn parse<T: serde::de::DeserializeOwned, E: DeError>(
+            value: serde_json::Value,
+        ) -> Result<T, E> {
+            serde_json::from_value(value).map_err(E::custom)
+        }
+
+        #[allow(deprecated)]
+        match envelope.method.as_str() {
+            elicitation::commands::CREATE => parse(params).map(Self::Elicitation),
+            sampling::commands::CREATE => parse(params).map(Self::Sampling),
+            root::commands::LIST => parse(params).map(Self::Roots),
+            unknown => Err(D::Error::custom(format!(
+                "unknown MRTR input request method `{unknown}`"
+            ))),
+        }
+    }
 }
 
 impl InputRequest {
@@ -311,10 +359,40 @@ mod tests {
     /// A peer's `roots/list` envelope may omit `params` entirely; the
     /// params type is all-optional, so it must still decode.
     #[test]
-    fn a_roots_envelope_decodes_without_params() {
-        let json = serde_json::json!({ "method": "roots/list", "params": {} });
-        let parsed: InputRequest = serde_json::from_value(json).unwrap();
-        assert_eq!(parsed.method(), "roots/list");
+    fn a_roots_envelope_decodes_with_or_without_params() {
+        for json in [
+            serde_json::json!({ "method": "roots/list", "params": {} }),
+            // A conforming peer may omit the empty object entirely.
+            serde_json::json!({ "method": "roots/list" }),
+            serde_json::json!({ "method": "roots/list", "params": null }),
+        ] {
+            let parsed: InputRequest = serde_json::from_value(json.clone())
+                .unwrap_or_else(|err| panic!("{json} must decode: {err}"));
+            assert_eq!(parsed.method(), "roots/list");
+        }
+    }
+
+    /// Absent params is *not* a blanket "use the default": a kind whose params
+    /// carry required fields still fails, with its own error.
+    #[test]
+    fn a_paramless_envelope_still_fails_for_kinds_that_need_params() {
+        for method in ["elicitation/create", "sampling/createMessage"] {
+            let json = serde_json::json!({ "method": method });
+            assert!(
+                serde_json::from_value::<InputRequest>(json).is_err(),
+                "{method} must not decode without params"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unknown_input_kind_is_rejected_by_name() {
+        let json = serde_json::json!({ "method": "sorcery/summon", "params": {} });
+        let err = serde_json::from_value::<InputRequest>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("sorcery/summon"),
+            "the error must name the unknown method, got: {err}"
+        );
     }
 
     // `allows` is the server's gate, so it only exists in server builds.

--- a/neva/src/types/mrtr.rs
+++ b/neva/src/types/mrtr.rs
@@ -1,9 +1,11 @@
 //! Multi Round-Trip Request (MRTR) wire types (MCP `proto-2026-07-28-rc`).
 //!
 //! A server processing `tools/call` / `prompts/get` / `resources/read` may
-//! reply with [`InputRequiredResult`] to request additional input (v1:
-//! elicitation only) before completing. See
-//! `docs/specs/2026-05-30-mrtr-design.md`.
+//! reply with [`InputRequiredResult`] to request additional input before
+//! completing. The kind of input is the [`InputRequest`] union: elicitation
+//! (first-class), plus the deprecated-on-arrival sampling and roots kinds the
+//! spec re-homed here when it removed their capability-driven server→client
+//! requests. See `docs/specs/2026-05-30-mrtr-design.md`.
 
 // The encrypted `requestState` codec is server-only: the client treats
 // `requestState` as opaque and never encodes/decodes it.
@@ -13,7 +15,9 @@ pub(crate) mod state;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::types::elicitation::{ElicitRequestParams, ElicitResult};
+use crate::types::elicitation::ElicitRequestParams;
+use crate::types::root::ListRootsRequestParams;
+use crate::types::sampling::CreateMessageRequestParams;
 use crate::types::{IntoResponse, RequestId, Response};
 
 /// A result indicating the server needs more input before it can complete the
@@ -39,32 +43,108 @@ pub struct InputRequiredResult {
     pub request_state: Option<String>,
 }
 
-/// Map of server-assigned key → elicitation request envelope.
-pub type InputRequests = HashMap<String, ElicitationInputRequest>;
+/// Map of server-assigned key → the input request envelope the client must
+/// fulfil.
+pub type InputRequests = HashMap<String, InputRequest>;
 
-/// Map of key (matching an [`InputRequests`] key) → the client's result.
-pub type InputResponses = HashMap<String, ElicitResult>;
+/// Map of key (matching an [`InputRequests`] key) → the client's raw result.
+///
+/// The value stays a [`serde_json::Value`] because the result *type* depends on
+/// the kind of input that was requested ([`ElicitResult`](crate::types::elicitation::ElicitResult),
+/// [`CreateMessageResult`](crate::types::sampling::CreateMessageResult),
+/// [`ListRootsResult`](crate::types::root::ListRootsResult)). Each server-side
+/// helper deserializes its own type out of the replay log, exactly like
+/// [`Context::memo`](crate::Context::memo) does.
+pub type InputResponses = HashMap<String, serde_json::Value>;
 
-/// The `{ method, params }` envelope for one elicitation input request.
+/// One `{ method, params }` input-request envelope — the kind of input the
+/// server is asking the client for.
+///
+/// The spec did not delete sampling and roots when the capability-driven
+/// server→client requests went away: it re-homed them here, as MRTR input
+/// request kinds, keyed by `method`. Elicitation stays first-class; the other
+/// two arrive **already deprecated** (see the variant docs), matching the
+/// spec's own 12-month lifecycle for roots/sampling/logging.
 ///
 /// Intentionally *not* [`crate::types::Request`]: the wire shape is exactly
 /// `{ method, params }` (the per-key id is the map key), whereas `Request`
 /// has required `jsonrpc`/`id` fields — emitting it would add non-spec fields
 /// and deserializing a conformant peer's bare `{method,params}` would fail.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ElicitationInputRequest {
-    /// Always `"elicitation/create"`.
-    pub method: ElicitationCreateMethod,
-    /// The elicitation parameters.
-    pub params: ElicitRequestParams,
+#[serde(tag = "method", content = "params")]
+pub enum InputRequest {
+    /// `elicitation/create` — ask the end user for structured input.
+    #[serde(rename = "elicitation/create")]
+    Elicitation(ElicitRequestParams),
+
+    /// `sampling/createMessage` — ask the client's LLM for a completion.
+    ///
+    /// **Deprecated on arrival.** The ability returns re-homed onto MRTR, but
+    /// it stays on the spec's deprecation path; prefer designing tools that do
+    /// not need the client's model.
+    #[serde(rename = "sampling/createMessage")]
+    #[deprecated(
+        note = "sampling is deprecated in MCP 2026-07-28; it returns as an MRTR input-request kind only for migration"
+    )]
+    Sampling(Box<CreateMessageRequestParams>),
+
+    /// `roots/list` — ask the client which filesystem roots it exposes.
+    ///
+    /// **Deprecated on arrival**, same as [`Self::Sampling`].
+    #[serde(rename = "roots/list")]
+    #[deprecated(
+        note = "roots are deprecated in MCP 2026-07-28; they return as an MRTR input-request kind only for migration"
+    )]
+    Roots(Box<ListRootsRequestParams>),
 }
 
-/// Per-request client capability flags relevant to MRTR (v1: elicitation).
+impl InputRequest {
+    /// The JSON-RPC method name this envelope carries.
+    pub fn method(&self) -> &'static str {
+        #[allow(deprecated)]
+        match self {
+            Self::Elicitation(_) => crate::types::elicitation::commands::CREATE,
+            Self::Sampling(_) => crate::types::sampling::commands::CREATE,
+            Self::Roots(_) => crate::types::root::commands::LIST,
+        }
+    }
+}
+
+/// Per-request client capability flags relevant to MRTR.
+///
+/// The server gates each input-request kind on the matching flag: asking for an
+/// input the client never declared is a server bug, and is reported as such
+/// rather than stalling the round-trip.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct ClientMrtrCapabilities {
     /// Whether the client can fulfil `elicitation/create` input requests.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub elicitation: bool,
+
+    /// Whether the client can fulfil `sampling/createMessage` input requests.
+    ///
+    /// A **deprecated** request kind — see [`InputRequest::Sampling`].
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub sampling: bool,
+
+    /// Whether the client can fulfil `roots/list` input requests.
+    ///
+    /// A **deprecated** request kind — see [`InputRequest::Roots`].
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub roots: bool,
+}
+
+#[cfg(feature = "server")]
+impl ClientMrtrCapabilities {
+    /// Whether the client declared support for the kind `request` asks for.
+    pub(crate) fn allows(&self, request: &InputRequest) -> bool {
+        #[allow(deprecated)]
+        match request {
+            InputRequest::Elicitation(_) => self.elicitation,
+            InputRequest::Sampling(_) => self.sampling,
+            InputRequest::Roots(_) => self.roots,
+        }
+    }
 }
 
 /// Unit tag serializing as the constant string `"input_required"`.
@@ -75,28 +155,14 @@ pub enum InputRequiredTag {
     InputRequired,
 }
 
-/// Unit tag serializing as the constant string `"elicitation/create"`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub enum ElicitationCreateMethod {
-    /// The only variant.
-    #[serde(rename = "elicitation/create")]
-    ElicitationCreate,
-}
-
 // Server-only: only the server constructs `InputRequiredResult`; the client
 // deserializes it from the wire.
 #[cfg(feature = "server")]
 impl InputRequiredResult {
-    /// Builds an `InputRequiredResult` for a single elicitation request.
-    pub(crate) fn elicitation(key: String, params: ElicitRequestParams, state: String) -> Self {
+    /// Builds an `InputRequiredResult` for a single input request of any kind.
+    pub(crate) fn single(key: String, request: InputRequest, state: String) -> Self {
         let mut input_requests = HashMap::with_capacity(1);
-        input_requests.insert(
-            key,
-            ElicitationInputRequest {
-                method: ElicitationCreateMethod::ElicitationCreate,
-                params,
-            },
-        );
+        input_requests.insert(key, request);
         Self {
             result_type: InputRequiredTag::InputRequired,
             input_requests: Some(input_requests),
@@ -150,5 +216,88 @@ mod tests {
             back["inputRequests"]["ask_name"]["method"],
             serde_json::json!("elicitation/create")
         );
+    }
+
+    /// The union must keep the flat `{ method, params }` envelope for every
+    /// kind — the `method` is the discriminator, not a nested tag.
+    #[test]
+    fn every_input_kind_roundtrips_as_a_method_params_envelope() {
+        #[allow(deprecated)]
+        let cases = [
+            (
+                InputRequest::Elicitation(ElicitRequestParams::form("Your name?").into()),
+                "elicitation/create",
+            ),
+            (
+                InputRequest::Sampling(Box::default()),
+                "sampling/createMessage",
+            ),
+            (InputRequest::Roots(Box::default()), "roots/list"),
+        ];
+
+        for (request, method) in cases {
+            assert_eq!(request.method(), method);
+
+            let json = serde_json::to_value(&request).unwrap();
+            assert_eq!(json["method"], serde_json::json!(method));
+            assert!(
+                json.get("params").is_some(),
+                "the envelope must carry `params` for {method}: {json}"
+            );
+
+            let back: InputRequest = serde_json::from_value(json).unwrap();
+            assert_eq!(back.method(), method, "kind must survive the round trip");
+        }
+    }
+
+    /// A peer's `roots/list` envelope may omit `params` entirely; the
+    /// params type is all-optional, so it must still decode.
+    #[test]
+    fn a_roots_envelope_decodes_without_params() {
+        let json = serde_json::json!({ "method": "roots/list", "params": {} });
+        let parsed: InputRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.method(), "roots/list");
+    }
+
+    // `allows` is the server's gate, so it only exists in server builds.
+    #[cfg(feature = "server")]
+    #[test]
+    fn capabilities_gate_each_kind_independently() {
+        #[allow(deprecated)]
+        let sampling = InputRequest::Sampling(Box::default());
+        let elicitation = InputRequest::Elicitation(ElicitRequestParams::form("m").into());
+
+        let only_elicitation = ClientMrtrCapabilities {
+            elicitation: true,
+            ..Default::default()
+        };
+        assert!(only_elicitation.allows(&elicitation));
+        assert!(
+            !only_elicitation.allows(&sampling),
+            "a client that only does elicitation must not be asked to sample"
+        );
+
+        let all = ClientMrtrCapabilities {
+            elicitation: true,
+            sampling: true,
+            roots: true,
+        };
+        assert!(all.allows(&sampling));
+    }
+
+    /// The flags are additive on the wire: a peer that predates
+    /// sampling/roots sends only `elicitation`, and the absent flags must
+    /// decode as "not supported" rather than failing.
+    #[test]
+    fn capabilities_decode_from_an_older_peer() {
+        let caps: ClientMrtrCapabilities =
+            serde_json::from_value(serde_json::json!({ "elicitation": true })).unwrap();
+        assert!(caps.elicitation);
+        assert!(!caps.sampling);
+        assert!(!caps.roots);
+
+        // …and a default set serializes to nothing at all.
+        let json = serde_json::to_value(ClientMrtrCapabilities::default()).unwrap();
+        assert_eq!(json, serde_json::json!({}));
     }
 }

--- a/neva/src/types/mrtr/state.rs
+++ b/neva/src/types/mrtr/state.rs
@@ -1,10 +1,10 @@
 //! Encode/verify the opaque, encrypted `requestState` blob.
 //!
-//! The blob is sealed with ChaCha20-Poly1305 (AEAD): the AEAD tag provides
-//! integrity (replacing the former HMAC) *and* the payload is encrypted, so
-//! server-side values a handler caches via [`crate::Context::memo`] — API
-//! responses, PII, tokens — are confidential rather than merely signed and
-//! readable by the client that echoes the blob.
+//! The blob is sealed with ChaCha20-Poly1305 (AEAD) rather than signed; the
+//! rationale is user-facing and lives in the [`mrtr`](crate::types::mrtr)
+//! module docs. Beyond confidentiality and the authentication tag, the payload
+//! carries a TTL, a binding to the originating request and a binding to the
+//! authenticated principal — see [`StatePayload`].
 
 use chacha20poly1305::aead::{Aead, Generate, KeyInit, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};

--- a/neva/src/types/mrtr/state.rs
+++ b/neva/src/types/mrtr/state.rs
@@ -591,12 +591,15 @@ mod tests {
         );
     }
 
-    fn answer(content: serde_json::Value) -> crate::types::elicitation::ElicitResult {
-        crate::types::elicitation::ElicitResult {
+    /// An answer as it is stored in the replay log: raw JSON, since the result
+    /// type depends on which input kind was requested.
+    fn answer(content: serde_json::Value) -> serde_json::Value {
+        serde_json::to_value(crate::types::elicitation::ElicitResult {
             action: crate::types::elicitation::ElicitationAction::Accept,
             content: Some(content),
             meta: None,
-        }
+        })
+        .expect("an ElicitResult always serializes")
     }
 
     #[test]

--- a/neva/src/types/prompt.rs
+++ b/neva/src/types/prompt.rs
@@ -6,13 +6,13 @@ use super::helpers::TypeCategory;
 use crate::error::{Error, ErrorCode};
 use crate::shared;
 #[cfg(feature = "server")]
+use crate::shared::BoxFuture;
+#[cfg(feature = "server")]
 use crate::types::FromRequest;
 use crate::types::request::RequestParamsMeta;
 use crate::types::{Cursor, Icon};
 #[cfg(feature = "server")]
 use crate::types::{IntoResponse, Page, PropertyType, Request, RequestId, Response};
-#[cfg(feature = "server")]
-use futures_util::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;

--- a/neva/src/types/resource/template.rs
+++ b/neva/src/types/resource/template.rs
@@ -5,7 +5,7 @@ use crate::app::handler::{FromHandlerParams, GenericHandler, Handler, HandlerPar
 #[cfg(feature = "server")]
 use crate::error::Error;
 #[cfg(feature = "server")]
-use futures_util::future::BoxFuture;
+use crate::shared::BoxFuture;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fmt::Debug;

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -11,12 +11,12 @@ use std::fmt::{Debug, Formatter};
 #[cfg(feature = "server")]
 use {
     super::helpers::TypeCategory,
+    crate::shared::BoxFuture,
     crate::types::{FromRequest, IntoResponse, Page, Request, RequestId, Response},
     crate::{
         Context,
         app::handler::{FromHandlerParams, GenericHandler, Handler, HandlerParams, RequestHandler},
     },
-    futures_util::future::BoxFuture,
     std::{future::Future, sync::Arc},
 };
 

--- a/neva/tests/mrtr_rc.rs
+++ b/neva/tests/mrtr_rc.rs
@@ -1455,6 +1455,50 @@ async fn client_drives_sampling_and_roots_end_to_end() {
     handle.abort();
 }
 
+/// A client that opted into roots but exposes none must still be askable — an
+/// empty `ListRootsResult` is a valid answer, and gating it out would leave the
+/// server unable to complete the call at all.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_client_with_an_empty_roots_list_still_answers() {
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let mut app = App::new()
+        .with_request_state_secret(b"test-secret")
+        .with_options(|o| o.with_http(|h| h.bind(&addr).with_endpoint("/mcp")));
+
+    app.map_tool("scan", |mut ctx: Context| async move {
+        #[allow(deprecated)]
+        let roots = ctx.list_roots("dirs").await?;
+        Ok::<String, Error>(format!("{} root(s)", roots.roots.len()))
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    // Explicit opt-in, no roots added.
+    #[allow(deprecated)]
+    let mut client = Client::new().with_options(|o| {
+        o.with_http(|h| h.bind(&addr).with_endpoint("/mcp"))
+            .with_roots(|roots| roots)
+    });
+    client.connect().await.expect("client connects");
+
+    let resp = client
+        .call_tool("scan", ())
+        .await
+        .expect("the round-trip must complete");
+    let text = resp
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.as_str());
+    assert_eq!(text, Some("0 root(s)"));
+    assert!(!resp.is_error, "an empty roots list is a valid answer");
+
+    client.disconnect().await.ok();
+    handle.abort();
+}
+
 /// The server must not ask for a kind the client never declared: a client with
 /// no sampling handler declares `sampling: false`, and the request is rejected
 /// rather than stalling the loop.

--- a/neva/tests/mrtr_rc.rs
+++ b/neva/tests/mrtr_rc.rs
@@ -1200,6 +1200,318 @@ async fn one_retry_budget_completes_a_single_question_flow() {
     handle.abort();
 }
 
+/// #85: sampling returns as an MRTR input-request kind. The wire contract is
+/// the same two rounds elicitation uses — only the envelope's `method` and the
+/// result type differ.
+#[tokio::test(flavor = "multi_thread")]
+async fn tool_samples_then_completes_over_two_rounds() {
+    use neva::types::sampling::{CreateMessageRequestParams, SamplingMessage};
+
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let mut app = App::new()
+        .with_request_state_secret(b"test-secret")
+        .with_options(|o| o.with_http(|h| h.bind(&addr).with_endpoint("/mcp")));
+
+    app.map_tool("summarize", |mut ctx: Context| async move {
+        let params = CreateMessageRequestParams::new()
+            .with_message(SamplingMessage::user().with("Summarize the repo"));
+        #[allow(deprecated)]
+        let res = ctx.sample("summary", params).await?;
+        let text = res
+            .content
+            .first()
+            .and_then(|c| c.as_text())
+            .map(|t| t.text.clone())
+            .unwrap_or_default();
+        Ok::<String, Error>(format!("summary: {text}"))
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/mcp");
+
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": { "name": "summarize", "arguments": {},
+            "_meta": { "clientCapabilities": { "sampling": true } } }
+    });
+    let r1: serde_json::Value = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .json(&call)
+        .send()
+        .await
+        .expect("round 1 send")
+        .json()
+        .await
+        .expect("round 1 json");
+    assert_eq!(
+        r1["result"]["resultType"],
+        serde_json::json!("input_required"),
+        "round 1 must request input: {r1}"
+    );
+    let state = r1["result"]["requestState"]
+        .as_str()
+        .expect("requestState present")
+        .to_string();
+    let requests = r1["result"]["inputRequests"]
+        .as_object()
+        .expect("inputRequests object");
+    let key = requests.keys().next().expect("one input request").clone();
+    assert_eq!(
+        requests[&key]["method"],
+        serde_json::json!("sampling/createMessage"),
+        "the envelope must name the sampling method: {r1}"
+    );
+
+    let retry = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "summarize", "arguments": {},
+            "_meta": {
+                "clientCapabilities": { "sampling": true },
+                "requestState": state,
+                "inputResponses": { key: {
+                    "role": "assistant",
+                    "content": { "type": "text", "text": "it is a Rust MCP SDK" },
+                    "model": "test-model"
+                } }
+            } }
+    });
+    let r2: serde_json::Value = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .json(&retry)
+        .send()
+        .await
+        .expect("round 2 send")
+        .json()
+        .await
+        .expect("round 2 json");
+    assert_eq!(
+        r2.pointer("/result/content/0/text")
+            .and_then(|v| v.as_str()),
+        Some("summary: it is a Rust MCP SDK"),
+        "round 2 must complete with the sampled text: {r2}"
+    );
+
+    handle.abort();
+}
+
+/// #85: roots likewise. The envelope carries `roots/list` and the answer is a
+/// `ListRootsResult`.
+#[tokio::test(flavor = "multi_thread")]
+async fn tool_lists_roots_then_completes_over_two_rounds() {
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let mut app = App::new()
+        .with_request_state_secret(b"test-secret")
+        .with_options(|o| o.with_http(|h| h.bind(&addr).with_endpoint("/mcp")));
+
+    app.map_tool("scan", |mut ctx: Context| async move {
+        #[allow(deprecated)]
+        let roots = ctx.list_roots("dirs").await?;
+        let names = roots
+            .roots
+            .iter()
+            .map(|r| r.uri.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        Ok::<String, Error>(format!("scanning {names}"))
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/mcp");
+
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": { "name": "scan", "arguments": {},
+            "_meta": { "clientCapabilities": { "roots": true } } }
+    });
+    let r1: serde_json::Value = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .json(&call)
+        .send()
+        .await
+        .expect("round 1 send")
+        .json()
+        .await
+        .expect("round 1 json");
+    let state = r1["result"]["requestState"]
+        .as_str()
+        .unwrap_or_else(|| panic!("requestState present: {r1}"))
+        .to_string();
+    let requests = r1["result"]["inputRequests"]
+        .as_object()
+        .expect("inputRequests object");
+    let key = requests.keys().next().expect("one input request").clone();
+    assert_eq!(
+        requests[&key]["method"],
+        serde_json::json!("roots/list"),
+        "the envelope must name the roots method: {r1}"
+    );
+
+    let retry = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "scan", "arguments": {},
+            "_meta": {
+                "clientCapabilities": { "roots": true },
+                "requestState": state,
+                "inputResponses": { key: {
+                    "roots": [{ "uri": "file:///work", "name": "work" }]
+                } }
+            } }
+    });
+    let r2: serde_json::Value = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .json(&retry)
+        .send()
+        .await
+        .expect("round 2 send")
+        .json()
+        .await
+        .expect("round 2 json");
+    assert_eq!(
+        r2.pointer("/result/content/0/text")
+            .and_then(|v| v.as_str()),
+        Some("scanning file:///work"),
+        "round 2 must complete with the listed roots: {r2}"
+    );
+
+    handle.abort();
+}
+
+/// The real client fulfils both deprecated kinds through the MRTR loop —
+/// sampling from its configured handler, roots from its configured list — with
+/// no server→client push channel involved.
+#[tokio::test(flavor = "multi_thread")]
+async fn client_drives_sampling_and_roots_end_to_end() {
+    use neva::types::sampling::{CreateMessageRequestParams, CreateMessageResult, SamplingMessage};
+
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let mut app = App::new()
+        .with_request_state_secret(b"test-secret")
+        .with_options(|o| o.with_http(|h| h.bind(&addr).with_endpoint("/mcp")));
+
+    // Two different kinds in one call: each is a separate round, and both
+    // replay from the same `requestState` log.
+    app.map_tool("audit", |mut ctx: Context| async move {
+        #[allow(deprecated)]
+        let roots = ctx.list_roots("dirs").await?;
+        let params = CreateMessageRequestParams::new()
+            .with_message(SamplingMessage::user().with("Describe these roots"));
+        #[allow(deprecated)]
+        let sampled = ctx.sample("describe", params).await?;
+        let text = sampled
+            .content
+            .first()
+            .and_then(|c| c.as_text())
+            .map(|t| t.text.clone())
+            .unwrap_or_default();
+        Ok::<String, Error>(format!("{} root(s): {text}", roots.roots.len()))
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let mut client =
+        Client::new().with_options(|o| o.with_http(|h| h.bind(&addr).with_endpoint("/mcp")));
+    // Roots are configured data, so declaring the capability is implied by
+    // having any: no handler is registered for them.
+    #[allow(deprecated)]
+    client.add_root("file:///work", "work");
+    #[allow(deprecated)]
+    client.map_sampling(|_params: CreateMessageRequestParams| async move {
+        CreateMessageResult::assistant().with_content("looks fine")
+    });
+    client.connect().await.expect("client connects");
+
+    let resp = client
+        .call_tool("audit", ())
+        .await
+        .expect("tool call completes through the MRTR loop");
+
+    let text = resp
+        .content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.as_str());
+    assert_eq!(
+        text,
+        Some("1 root(s): looks fine"),
+        "the client must fulfil both deprecated kinds"
+    );
+    assert!(!resp.is_error, "final result must not be an error");
+
+    client.disconnect().await.ok();
+    handle.abort();
+}
+
+/// The server must not ask for a kind the client never declared: a client with
+/// no sampling handler declares `sampling: false`, and the request is rejected
+/// rather than stalling the loop.
+#[tokio::test(flavor = "multi_thread")]
+async fn sampling_without_declared_capability_is_rejected() {
+    use neva::types::sampling::{CreateMessageRequestParams, SamplingMessage};
+
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let mut app = App::new()
+        .with_request_state_secret(b"test-secret")
+        .with_options(|o| o.with_http(|h| h.bind(&addr).with_endpoint("/mcp")));
+
+    app.map_tool("summarize", |mut ctx: Context| async move {
+        let params =
+            CreateMessageRequestParams::new().with_message(SamplingMessage::user().with("hi"));
+        #[allow(deprecated)]
+        let res = ctx.sample("summary", params).await?;
+        Ok::<String, Error>(format!("{:?}", res.content))
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/mcp");
+
+    // Elicitation is declared, sampling is not.
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": { "name": "summarize", "arguments": {},
+            "_meta": { "clientCapabilities": { "elicitation": true } } }
+    });
+    let r1: serde_json::Value = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .json(&call)
+        .send()
+        .await
+        .expect("send")
+        .json()
+        .await
+        .expect("json");
+
+    let message = r1
+        .pointer("/result/content/0/text")
+        .or_else(|| r1.pointer("/error/message"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert!(
+        message.contains("sampling/createMessage"),
+        "the rejection must name the kind the client did not declare: {r1}"
+    );
+
+    handle.abort();
+}
+
 fn pick_free_port() -> u16 {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();

--- a/neva_macros/Cargo.toml
+++ b/neva_macros/Cargo.toml
@@ -20,10 +20,10 @@ proc-macro = true
 workspace = true
 
 [dependencies]
-quote = "1.0.46"
-syn = { version = "2.0.119", features = ["full"] }
-proc-macro2 = "1.0.106"
-serde_json = "1.0.150"
+quote = "1.0.47"
+syn = { version = "3.0.3", features = ["full"] }
+proc-macro2 = "1.0.107"
+serde_json = "1.0.151"
 
 [features]
 default = []


### PR DESCRIPTION
## Summary

Prepares the **0.4.3** release. Four threads, in dependency order:

**1. volga 0.9.6 + dependency bumps.** The two upstream fixes this crate was working around have landed, so the workarounds are gone:
- `exchange_code` / `refresh` / `token` futures are now `Send` (upstream scopes the non-`Sync` `form_urlencoded::Serializer` so it is dropped before the await). The internal `spawn_blocking` bridge that ran them on a dedicated current-thread runtime is removed — the OAuth code exchange and token refresh now run inline, with no extra thread or runtime per operation. A `Send` bound assertion guards the regression.
- `application_type` is a first-class member of `ClientMetadata`, so the loopback (native client) declaration no longer travels as an extension field. Wire shape unchanged.

Removing the bridge also fixed a latent bug: the cached client/metadata were *moved* out of the single-flight slot for the duration of a refresh and were not restored if the bridge itself failed, so a managed OAuth session could permanently lose non-interactive refresh and fall back to interactive authorization forever. The state is now borrowed.

**2. `neva::shared::BoxFuture`.** neva's object-safe async traits (`AuthorizationHandler`, `RequestStateStore`, middleware) returned `futures_util::future::BoxFuture`, so implementing one required a `futures` dependency of your own, kept in lockstep with neva's. The alias is now neva's. It denotes the identical type, so this is **not** a breaking change — a test asserts type identity by passing values between both spellings.

**3. #85 — generalize MRTR input-request kinds: sampling + roots.** The spec did not delete sampling and roots; it removed them as capability-driven server→client *requests* and re-homed the ability onto MRTR as input-request kinds. They return the same way here, and — matching the spec's own 12-month lifecycle — **already deprecated**:
- `ctx.sample(key, params)` and `ctx.list_roots(key)` join `ctx.elicit` on the same substrate. `once` / `memo` / `on_commit` cover them for free.
- The client fulfils sampling from its `map_sampling` handler and roots from its configured list, both on the MRTR loop. The server-push channel stays gone.
- `ClientMrtrCapabilities` grows `sampling` / `roots`; the server gates each kind on its own flag and reports an undeclared kind instead of stalling the round.

Plus RC variants of both examples: `examples/{roots,sampling}/rc/{server,client}`.

**4. #82 — documentation.** Why MRTR *seals* `requestState` (ChaCha20-Poly1305) rather than *signing* it, and the idempotency story (`memo` / `once` / `on_commit` / `RequestStateStore`) as a differentiator.

## Type
- [x] Bug fix
- [x] Feature
- [x] Enhancement
- [x] Performance
- [x] Documentation
- [ ] Refactor
- [ ] Security
- [x] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [ ] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

**Breaking (RC API only, #85).** The *wire* format is unchanged — an envelope is still `{ method, params }` with `method` as the discriminator, so peers interoperate across this change. Three public items move:
- `mrtr::ElicitationInputRequest` (+ its `ElicitationCreateMethod` tag) → `mrtr::InputRequest` union. Migration:
  `ElicitationInputRequest { params, .. }` → `InputRequest::Elicitation(params)`.
- `mrtr::InputResponses` is now `HashMap<String, serde_json::Value>` — the result type depends on the kind that was requested; deserialize your own out of it.
- `mrtr::ClientMrtrCapabilities` gained two fields → struct literals need `..Default::default()`.

## Notes for reviewers

**Deprecation scope was deliberately narrowed.** The issue asks for the returning `CreateMessage*` / `ListRoots*` *types* to carry `#[deprecated]`. I marked what users call (`ctx.sample`, `ctx.list_roots`, the new `InputRequest::Sampling`/`Roots` variants) but **not** the types themselves: they are fully supported in the legacy build, so a `#[deprecated]` on the type would fire warnings there and fail `-D warnings` CI. Happy to revisit.

**Mismatched answers are an error, not a re-ask.** If a client answers a key with the wrong kind of result, `resolve` returns `InvalidParams` naming the requested method. Re-asking would loop forever. Covered by a test.

**Docs are plain doc comments, not `cfg_attr`.** I first gated the new feature-specific sections with `#[cfg_attr(feature = "…", doc = "…")]` to keep intra-doc links resolving in slim builds. RustRover does not expand that on hover, so the text was invisible where people actually read it. Reverted to unconditional docs with code spans for feature-gated items — visibility beats clickable links.