### PR TITLE
Feaure/rc spec updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.4.4
+
+### Added
+* **Request-scoped logging** (`proto-2026-07-28-rc`, #93). The 2026-07-28 draft
+  removes only `logging/setLevel`; it keeps `notifications/message` as a
+  deprecated, request-scoped log notification. neva had compiled the whole
+  logging surface out under the RC -- this brings the kept part back:
+  * The desired level rides per-request on
+    `_meta["io.modelcontextprotocol/logLevel"]` (`RequestParamsMeta`) instead of
+    a global `setLevel` handshake. While the server handles a request, it emits
+    `notifications/message` at or above that severity and suppresses the rest;
+    with no requested level it emits none.
+  * Both emission paths honor the level: the HTTP `MpscLayer`
+    (`notification::fmt::layer()`) and the stdio `NotificationFormatter`. A new
+    `notification::fmt::span_context()` layer records the request context for
+    the stdio formatter to read.
+  * Client API: `McpOptions::with_log_level` (via `Client::with_options`),
+    `#[deprecated]` on arrival to mirror the schema. `LoggingLevel`/`LogMessage`
+    stay undecorated.
+  * `logging/setLevel` and `with_logging`/`set_log_level` stay removed under the
+    RC.
+
 ## 0.4.3
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `notifications/message` at or above that severity and suppresses the rest;
     with no requested level it emits none.
   * Both emission paths honor the level: the HTTP `MpscLayer`
-    (`notification::fmt::layer()`) and the stdio `NotificationFormatter`. A new
-    `notification::fmt::span_context()` layer records the request context for
-    the stdio formatter to read.
+    (`notification::fmt::layer()`) and the stdio `NotificationFormatter`. Every
+    supported stdio setup works unchanged -- the formatter resolves the
+    request-scoped level on its own, including from a formatter-only subscriber.
+    A new `notification::fmt::span_context()` layer can be added alongside to
+    resolve it from a typed span extension instead.
   * Client API: `McpOptions::with_log_level` (via `Client::with_options`),
     `#[deprecated]` on arrival to mirror the schema. `LoggingLevel`/`LogMessage`
     stay undecorated.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## 0.4.4
+## 0.5.0
 
 ### Changed (breaking)
 * **Unified streaming-capable POST seam** for HTTP engine adapters. Streamable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 * **MRTR input-request kinds: sampling + roots** (`proto-2026-07-28-rc`, #85).
-  The spec did not delete sampling and roots — it removed them as
-  capability-driven server→client *requests* and re-homed the ability onto
-  MRTR, as input-request kinds. They return here the same way, and — matching
-  the spec's own 12-month lifecycle — **already deprecated**:
+  The spec did not delete sampling and roots -- it removed them as
+  capability-driven server->client *requests* and re-homed the ability onto
+  MRTR, as input-request kinds. They return here the same way, and -- matching
+  the spec's own 12-month lifecycle -- **already deprecated**:
   * `ctx.sample(key, params)` and `ctx.list_roots(key)` join `ctx.elicit` on
     the MRTR substrate, with identical re-run/replay semantics. `once` /
-    `memo` / `on_commit` cover them for free — one substrate, three kinds.
+    `memo` / `on_commit` cover them for free -- one substrate, three kinds.
   * `CreateMessageRequestParams`/`Result` and `ListRootsResult`/`Root` are
     available under the RC again, now as input-request params/results. The
     server-push `SamplingHandler` channel stays gone: the client fulfils
@@ -34,26 +34,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * RC variants of the roots and sampling examples, alongside the legacy ones:
   `examples/roots/rc/{server,client}` and
   `examples/sampling/rc/{server,client}`. Each `rc/` directory is its own
-  workspace — Cargo unifies features across members built together, so keeping
+  workspace -- Cargo unifies features across members built together, so keeping
   the RC crates in the legacy workspace would switch `proto-2026-07-28-rc` on
   for the legacy crates and stop them compiling.
 
-* `neva::shared::BoxFuture` (also in the prelude) — the return type of
+* `neva::shared::BoxFuture` (also in the prelude) -- the return type of
   neva's object-safe async traits, now owned by neva instead of borrowed
   from `futures_util`. Implementing
   [`AuthorizationHandler`](https://docs.rs/neva/latest/neva/auth/oauth/trait.AuthorizationHandler.html)
   or [`RequestStateStore`](https://docs.rs/neva/latest/neva/trait.RequestStateStore.html)
   no longer requires a `futures` dependency of your own, kept in lockstep
   with neva's. It is a plain alias for
-  `Pin<Box<dyn Future<Output = T> + Send + 'a>>` — the same type
-  `futures_util::future::BoxFuture` denotes — so existing implementations
+  `Pin<Box<dyn Future<Output = T> + Send + 'a>>` -- the same type
+  `futures_util::future::BoxFuture` denotes -- so existing implementations
   that spell out the `futures_util` path keep compiling unchanged.
 
 ### Documentation
 * Documented why MRTR **seals** `requestState` with ChaCha20-Poly1305 instead
   of signing it (#82): a signed state is tamper-evident but *readable*, which
-  stops being enough once `ctx.memo` writes server-computed values — an
-  upstream response, a quoted price, a downstream token — into the state for
+  stops being enough once `ctx.memo` writes server-computed values -- an
+  upstream response, a quoted price, a downstream token -- into the state for
   the next round to replay. The AEAD tag authenticates exactly as an HMAC
   would, so confidentiality costs nothing. The consequence for callers is
   spelled out at [`types::mrtr`](https://docs.rs/neva/latest/neva/types/mrtr/)
@@ -67,15 +67,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   charges a card can be written in the obvious way.
 
 ### Changed
-* **Breaking (`proto-2026-07-28-rc` API, #85)** — generalizing the MRTR input
+* **Breaking (`proto-2026-07-28-rc` API, #85)** -- generalizing the MRTR input
   request reshapes three public items. The *wire* format is unchanged: an
   envelope is still `{ method, params }` and `method` is still the
   discriminator, so peers interoperate across the change.
   * `mrtr::ElicitationInputRequest` (and its `ElicitationCreateMethod` tag) are
     replaced by the `mrtr::InputRequest` union. Migration:
-    `ElicitationInputRequest { params, .. }` → `InputRequest::Elicitation(params)`.
+    `ElicitationInputRequest { params, .. }` -> `InputRequest::Elicitation(params)`.
   * `mrtr::InputResponses` is now `HashMap<String, serde_json::Value>` rather
-    than `HashMap<String, ElicitResult>` — the result type depends on the kind
+    than `HashMap<String, ElicitResult>` -- the result type depends on the kind
     that was requested. Deserialize your own type out of the value.
   * `mrtr::ClientMrtrCapabilities` gained two fields, so struct-literal
     construction needs `..Default::default()`.
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   which ships the two upstream fixes this crate was working around:
   * The token-endpoint futures (`exchange_code` / `refresh` / `token`) are
     now `Send`, so the internal `spawn_blocking` bridge that ran them on a
-    dedicated current-thread runtime is gone — the OAuth code exchange and
+    dedicated current-thread runtime is gone -- the OAuth code exchange and
     token refresh run inline on the caller's runtime, with no extra thread
     or runtime per operation. A `Send` bound assertion now guards the
     regression.
@@ -110,14 +110,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `server/discover` and, when the server clearly doesn't speak the RC
   protocol (`MethodNotFound`, `InvalidRequest`, or a non-JSON-RPC /
   unknown-code reply), falls back to the legacy `initialize`/`initialized`
-  handshake — negotiating the newest pre-RC version (override with
-  `with_mcp_version`) — and speaks legacy for that peer at runtime:
+  handshake -- negotiating the newest pre-RC version (override with
+  `with_mcp_version`) -- and speaks legacy for that peer at runtime:
   `Mcp-Session-Id` header, the standalone SSE GET stream, legacy
   server-push sampling/roots/logging, no MRTR and no RC routing headers.
   Network-level failures do not trigger the fallback. The switch is
   per-connection, monotonic, and decided before any other traffic; the
   server side remains compile-time pure. The legacy client machinery now
-  compiles (dormant) under the RC flag for this — the legacy build is
+  compiles (dormant) under the RC flag for this -- the legacy build is
   unchanged. (#84)
 * Client-side OAuth 2.1 authorization behind the new `client-oauth`
   feature (included in `client-full`), built on `volga-oauth-client`:
@@ -130,7 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     with the fresh token, concurrent `401`s share a single flow.
   * The callback is validated for `state` and the RFC 9207 `iss`
     parameter (required when the server advertises support) before the
-    code exchange — mix-up-attack responses abort the flow.
+    code exchange -- mix-up-attack responses abort the flow.
   * The interactive step is pluggable via `AuthorizationHandler`; the
     default `LoopbackHandler` opens the system browser and captures the
     redirect on a loopback listener. Tokens persist through the
@@ -138,19 +138,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   * Token lifecycle: an access token about to expire (30s leeway) is
     refreshed proactively before the next request, and a `401` tries the
     refresh-token grant before falling back to interactive
-    authorization — refresh-token rotation and dead-entry pruning
+    authorization -- refresh-token rotation and dead-entry pruning
     included. Both paths are non-interactive and single-flight.
   * Everything exported under `neva::auth::oauth`.
 * OAuth examples: `examples/oauth-server` (resource server with explicit
   RFC 9728 metadata), `examples/oauth-client` (fully automatic flow),
   `examples/oauth-with-keycloak` (end-to-end walkthrough with a
-  ready-to-import realm), and `examples/oauth-hyper-engine` — a custom
+  ready-to-import realm), and `examples/oauth-hyper-engine` -- a custom
   `HttpEngine` on bare hyper serving the well-known document, the
   `WWW-Authenticate` challenge and per-tool role gates through the
   engine-neutral primitives, without Volga.
 * Engine-neutral OAuth 2.1 resource-server primitives behind the new
   `server-oauth` feature (included in `server-full`), built on
-  `volga-oauth-core` — protocol types only, no Volga framework dependency,
+  `volga-oauth-core` -- protocol types only, no Volga framework dependency,
   so they work with any `HttpEngine`:
   * `HttpServer::with_oauth_metadata(...)` configures the RFC 9728
     Protected Resource Metadata document (`OAuthResourceOptions`:
@@ -161,19 +161,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `oauth_metadata_url()`.
   * `handlers::handle_oauth_metadata` serves the well-known document;
     `handlers::handle_unauthorized` answers 401 with the
-    `WWW-Authenticate: Bearer resource_metadata="…"` challenge.
+    `WWW-Authenticate: Bearer resource_metadata="..."` challenge.
   * The default Volga engine mounts the document on its well-known path
-    automatically (publicly reachable — auth enforcement is scoped to the
+    automatically (publicly reachable -- auth enforcement is scoped to the
     MCP endpoint group) and, when bearer auth is configured, advertises it
     as `resource_metadata` on Volga's own 401 challenges.
   * Protocol types re-exported under `neva::auth::oauth`
-    (`ProtectedResourceMetadata`, `BearerChallenge`, `OAuthError`, …).
+    (`ProtectedResourceMetadata`, `BearerChallenge`, `OAuthError`, ...).
 * **OAuth 2.1/OIDC issuer mode for the default Volga engine** (#69):
-  `with_auth(|auth| auth.with_oauth(|oauth| oauth.with_issuer(…)))` replaces
+  `with_auth(|auth| auth.with_oauth(|oauth| oauth.with_issuer(...)))` replaces
   the static decoding key with issuer-discovered JWKS validation (RFC 8414
   discovery with OIDC fallback, key rotation, refresh cooldown / max key age
   via Volga). MCP defaults applied unless overridden: the token's `aud` must
-  contain the server's canonical resource URI (RFC 8707 — `aud` becomes
+  contain the server's canonical resource URI (RFC 8707 -- `aud` becomes
   required) and its `iss` must match the configured issuer. The Protected
   Resource Metadata document is derived from the issuer automatically when
   `with_oauth_metadata` was not called (#68), so discovery, challenge and
@@ -182,27 +182,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   indicators) for overriding the audience explicitly.
 * **MRTR `requestState` key rotation.** New `App::with_request_state_keys(active_kid, keys)`
   configures a keyring: new blobs are sealed under the active key id, inbound
-  blobs decrypt with whichever accepted key their kid names — enabling
+  blobs decrypt with whichever accepted key their kid names -- enabling
   zero-downtime rotation. `with_request_state_secret` remains the single-key
   shorthand (kid `"0"`). (#81)
 
 ### Fixed
 * A client whose transport died (e.g. the OAuth flow failed against an
-  unreachable issuer) sat out the full request timeout — and `Ctrl+C`
+  unreachable issuer) sat out the full request timeout -- and `Ctrl+C`
   appeared ignored, since the shutdown handler only cancels the
   transport token. Pending request awaits now race that token and abort
   with `Connection closed` the moment it fires, so both transport death
   and shutdown signals interrupt `connect()`/requests immediately.
 * Client-only feature sets (e.g. `http-client` alone) failed to build:
   the client's notification handler uses `tokio::task::block_in_place`,
-  but nothing enabled `tokio/rt-multi-thread` — now the `client` feature
+  but nothing enabled `tokio/rt-multi-thread` -- now the `client` feature
   does.
 * The legacy `initialize` result no longer advertises the `logging` capability
   in builds without the `tracing` feature, where the `logging/setLevel`
-  handler is not registered — capability-trusting clients (e.g. newer MCP
+  handler is not registered -- capability-trusting clients (e.g. newer MCP
   Inspector) would call it and hit `Method not found`.
 * Per-tool/prompt/resource role and permission gates now receive the claims
-  Volga's `authorize` middleware already validated (`Authenticated<…>` from
+  Volga's `authorize` middleware already validated (`Authenticated<...>` from
   the request) instead of re-decoding the `Authorization` header. With
   Volga's default `strip_token_from_request = true` the header is removed
   before the route runs, so the old re-decode lost the claims and protected
@@ -236,7 +236,7 @@ This release adds opt-in support for the **MCP 2026-07-28 Release Candidate**
 spec behind the compile-time `proto-2026-07-28-rc` flag. The legacy spec
 remains the default and is unchanged for users who don't opt in. Once the RC
 graduates the flag will invert: the RC path becomes the default and the
-current default moves under a `legacy-spec` flag — a deliberate breaking
+current default moves under a `legacy-spec` flag -- a deliberate breaking
 change, mirroring the spec itself.
 
 ### Added
@@ -247,18 +247,18 @@ change, mirroring the spec itself.
   replaced by a single `server/discover` request returning `DiscoverResult`
   (with `Client::discover()`; `Client::init()` kept as a back-compat alias).
   No `Mcp-Session-Id` on the wire; the GET (SSE) and DELETE routes are not
-  registered. Every POST carries a required `MCP-Protocol-Version` header —
+  registered. Every POST carries a required `MCP-Protocol-Version` header --
   the client injects automatically; the server rejects missing/unsupported
   values with `InvalidRequest`.
-* **JSON Schema 2020-12 for tools.** New `schema_2020::InputSchema` —
-  `#[serde(transparent)]` newtype over `serde_json::Value` — and a per-flag
+* **JSON Schema 2020-12 for tools.** New `schema_2020::InputSchema` --
+  `#[serde(transparent)]` newtype over `serde_json::Value` -- and a per-flag
   `ToolInputSchema` alias on `Tool.input_schema`/`output_schema`. The
   `#[tool]` macro now emits full 2020-12 documents: primitive args become
   inline primitive schemas, structured `Json<T>` args derive a rich inlined
   schema when `T: JsonSchema` (graceful `{"type":"object"}` fallback
   otherwise), and the return type drives `outputSchema`.
   `input_schema`/`output_schema` string literals are validated at compile
-  time on every feature configuration. `schemars` is re-exported by neva —
+  time on every feature configuration. `schemars` is re-exported by neva --
   user crates don't need a direct dep.
 * **Multi Round-Trip Requests (MRTR) for elicitation.** Handlers call
   `ctx.elicit(key, params).await?`; on a miss the framework returns an
@@ -272,21 +272,21 @@ change, mirroring the spec itself.
   (run-at-most-once side effect), `ctx.memo(key, fut)` (computed-and-cached
   value, written into the sealed `requestState`), `ctx.on_commit(fut)` (runs
   exactly once when the handler reaches its final result). At-most-once
-  *within a single chain* — pair non-idempotent effects with a downstream
+  *within a single chain* -- pair non-idempotent effects with a downstream
   idempotency key.
 * **MRTR final-round idempotency store.** `RequestStateStore` trait
   (`neva::app::mrtr_store`) with a default per-process `InMemoryStateStore`,
   wired via `App::with_request_state_store`. Caches the final response keyed
   by the incoming state's integrity tag + answers digest, so a lost-response
   retry returns the cached result instead of re-running the handler. Implement
-  over a shared backend (e.g. Redis) for multi-instance — same constraint as
+  over a shared backend (e.g. Redis) for multi-instance -- same constraint as
   a shared signing secret.
 * **Task-augmented elicit.** Two execution substrates that never mix: a bare
   call uses MRTR re-run (`ctx.elicit(key, params)`); a task-augmented call
   genuinely suspends (`ctx.task().elicit(params)`, no replay key). New
   `ctx.task()` builder and `ctx.is_task()` switch for `TaskSupport::Optional`
   tools that elicit on both substrates. Resuming a parked task-elicit requires
-  the answer to reach the instance running the task — same instance-affinity
+  the answer to reach the instance running the task -- same instance-affinity
   tasks already have.
 * **Protocol extensions framework.** `Extension` trait
   (`neva::app::extension`) registered via `App::with_extension`; extensions
@@ -302,7 +302,7 @@ change, mirroring the spec itself.
   recording.
 * **Configuration knobs.** `App::with_max_state_bytes` (default 8 KiB) caps
   encoded `requestState`; client `McpOptions::with_max_mrtr_rounds` (default
-    8) caps MRTR re-issue rounds — counted as retries, the initial send is
+    8) caps MRTR re-issue rounds -- counted as retries, the initial send is
        always made on top.
 * **Startup deployment warn.** When `http-server` + `tracing` are enabled and
   `with_request_state_secret` was never called, `App::run` logs at
@@ -311,11 +311,11 @@ change, mirroring the spec itself.
 
 #### Spec-neutral
 
-* `ErrorCode::RESOURCE_NOT_FOUND` — helper constant emitting `-32002` under
+* `ErrorCode::RESOURCE_NOT_FOUND` -- helper constant emitting `-32002` under
   the legacy spec and `-32602` (`InvalidParams`) under RC. In-tree emitters
   route through it; recommended migration path off
   `ErrorCode::ResourceNotFound`.
-* `ToolSchema::from_value`, `from_schema::<T>`, `from_schemars` — legacy-side
+* `ToolSchema::from_value`, `from_schema::<T>`, `from_schemars` -- legacy-side
   constructors symmetric with `InputSchema`.
 
 ### Changed
@@ -325,7 +325,7 @@ change, mirroring the spec itself.
   invoking the validator, so the same validator path covers both flavours.
 * `PROTOCOL_VERSIONS` advertises `"2026-07-28"` only when the RC flag is
   enabled.
-* CI matrix extended with `proto-2026-07-28-rc` × `server-full,client-full`
+* CI matrix extended with `proto-2026-07-28-rc` x `server-full,client-full`
   under clippy, doc, and test jobs.
 
 #### Under `proto-2026-07-28-rc` only
@@ -337,7 +337,7 @@ change, mirroring the spec itself.
 * **Tasks capability** is advertised under
   `capabilities.extensions["io.modelcontextprotocol/tasks"]` instead of the
   top-level `capabilities.tasks`. The `with_tasks` API and `tasks/*` wire
-  methods are unchanged — `with_tasks` now thinly wraps the extension
+  methods are unchanged -- `with_tasks` now thinly wraps the extension
   registration. Legacy builds keep the top-level field.
 * **HTTP transport is request/response only.** Server-initiated notifications
   (progress, resource-updated, list-changed, task-status, elicitation) are
@@ -355,20 +355,20 @@ change, mirroring the spec itself.
 * `logging/setLevel`, `notifications/message`,
   `LoggingLevel`/`LogMessage`/`SetLevelRequestParams`, and
   `NotificationFormatter`.
-* The typed `ToolSchema` (with `from_json_str` / `with_required`) — replaced
+* The typed `ToolSchema` (with `from_json_str` / `with_required`) -- replaced
   by `InputSchema`.
-* `McpOptions::with_mcp_version` on both server and client builders — the RC
+* `McpOptions::with_mcp_version` on both server and client builders -- the RC
   build is a pure 2026-07-28 peer, so the version is fixed. Version selection
   returns under the legacy flag once the RC graduates.
 
 ### Deprecated
 
-* `ErrorCode::ResourceNotFound` — use `ErrorCode::RESOURCE_NOT_FOUND` for
+* `ErrorCode::ResourceNotFound` -- use `ErrorCode::RESOURCE_NOT_FOUND` for
   per-flag wire mapping.
 * `Client::add_root`, `add_roots`, `publish_roots_changed`, `map_sampling`,
-  and `McpOptions::with_logging` — removed in MCP 2026-07-28. Available under
+  and `McpOptions::with_logging` -- removed in MCP 2026-07-28. Available under
   the legacy spec; cfg-gated out under RC.
-* `ToolSchema::from_schema(schemars::Schema)` — renamed to `from_schemars`
+* `ToolSchema::from_schema(schemars::Schema)` -- renamed to `from_schemars`
   for symmetry. Previous name kept as `from_schema_legacy` for a transition
   window.
 
@@ -386,12 +386,12 @@ change, mirroring the spec itself.
 * `Dc<T>` dependency-injection extractors now work as handler arguments for
   tools and prompts (previously resources only). They were classified as
   unknown `"object"` types and failed the `TypeCategory` bound; now treated
-  like `Context`/`Meta<_>` — injected from request context, never listed as
+  like `Context`/`Meta<_>` -- injected from request context, never listed as
   an argument.
 
 ### Known limitations
 
-* `#[tool]`'s `annotations = "…"` (and `#[prompt]`/`#[resource]` JSON-string
+* `#[tool]`'s `annotations = "..."` (and `#[prompt]`/`#[resource]` JSON-string
   attributes) still parse at runtime and panic on malformed JSON; compile-time
   validation there is a planned follow-up. `input_schema`/`output_schema`
   literals are already validated at compile time.
@@ -399,7 +399,7 @@ change, mirroring the spec itself.
   `--all-targets`) fails on `tokio::task::block_in_place` because the
   `client` feature alone doesn't pull `tokio/rt-multi-thread`. Pre-existing
   tokio-features issue. CI runs the `--all-targets` variant (pulls dev-deps
-  → `rt-multi-thread`) and remains green.
+  -> `rt-multi-thread`) and remains green.
 
 ## 0.3.4
 
@@ -414,7 +414,7 @@ change, mirroring the spec itself.
 ### Added
 * **Pluggable HTTP server.** Introduced the `HttpEngine` trait so non-Volga HTTP stacks (axum, hyper, custom adapters) can plug into neva's Streamable HTTP transport. The engine declares its native request/response/SSE-event types and supplies four bridge methods plus a `run` loop; everything else (JSON-RPC framing, SSE replay & dedup, batch fast-path, pending-oneshot routing) stays in neva.
 * New feature flags: `http-server` (engine-agnostic abstractions, no framework dependency) and `http-server-volga` (default Volga adapter). `server-full` enables the Volga variant for backwards compatibility.
-* `dispatch_post` / `dispatch_delete` / `dispatch_get_sse` engine-generic route helpers — adapter handlers collapse to one-liners.
+* `dispatch_post` / `dispatch_delete` / `dispatch_get_sse` engine-generic route helpers -- adapter handlers collapse to one-liners.
 * Reference engine adapters under `examples/`: `axum` (Send-friendly types, the canonical pattern), `hyper` (raw protocol layer, no router), and `actix-web` (handles actix's `!Send` request/response types and its dedicated-runtime requirements).
 * `neva::auth::Claims` is now neva's engine-neutral typed-claims contract. Any HTTP engine adapter can wrap its own decoded claims in `Arc<dyn Claims>` and insert them into request extensions to enable `with_roles` / `with_permissions` gating across tools, prompts, and resources.
 * CI `doc_check` job gating on `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"`.
@@ -459,7 +459,7 @@ change, mirroring the spec itself.
 ## 0.2.8
 
 ### Fixed
-* Fixed JSON-RPC 2.0 protocol violation: server no longer sends a response to client notifications (§4 — notifications must never be replied to)
+* Fixed JSON-RPC 2.0 protocol violation: server no longer sends a response to client notifications (section 4 -- notifications must never be replied to)
 * Fixed `notifications/cancelled`: request cancellation now actually fires for both stdio and Streamable HTTP transports
 * Fixed Streamable HTTP transport silently dropping notifications without processing them
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## 0.4.4
 
+### Changed (breaking)
+* **Unified streaming-capable POST seam** for HTTP engine adapters. Streamable
+  HTTP has allowed a POST reply to be either a single JSON body or an SSE
+  stream since spec revision 2025-03-26; neva's engine seam only modeled the
+  JSON shape. Now:
+  * `SseResponse` is renamed to `StreamResponse` and its `Status` variant to
+    `Complete` (it carries full JSON replies, not just error statuses). A
+    deprecated `SseResponse` type alias remains for one release.
+  * `handlers::dispatch_post` returns
+    `StreamResponse<impl Stream<Item = E::SseEvent>>` instead of
+    `E::Response`: engines handle the same two-arm match their GET route
+    already has. Under `proto-2026-07-28-rc` + `tracing` the `Stream` arm
+    carries request-scoped notifications followed by the response; other
+    builds always produce `Complete` (no behavior change).
+  * `handle_post` stays available as the JSON-only building block.
+  * The default Volga adapter now goes through `dispatch_post` like every
+    other engine (claims moved into `VolgaEngine::adapt_request`, per the
+    `HttpEngine` contract); the axum/hyper/actix engine examples were updated
+    to the two-arm match.
+
 ### Added
 * **Request-scoped logging** (`proto-2026-07-28-rc`, #93). The 2026-07-28 draft
   removes only `logging/setLevel`; it keeps `notifications/message` as a
@@ -26,6 +46,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     stay undecorated.
   * `logging/setLevel` and `with_logging`/`set_log_level` stay removed under the
     RC.
+  * Delivery: request-scoped notifications flow on the originating request's
+    response stream, per the spec. Over **stdio** they interleave on stdout.
+    Over the stateless **HTTP** transport, a `POST` that opts in (carries
+    `io.modelcontextprotocol/logLevel` or a `progressToken` in `_meta`) gets a
+    `text/event-stream` reply carrying its `notifications/message` /
+    `notifications/progress` followed by the response; other `POST`s stay a
+    single JSON object. The layer routes each request's notifications to a
+    per-`POST` sink (keyed by the per-`POST` session id); the client parses the
+    SSE reply and dispatches notifications before resolving the request. The
+    suppression rule ("no `logLevel` => no `notifications/message`") holds on
+    every transport.
 
 ## 0.4.3
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,7 +14,7 @@ Examples of behavior that contributes to a positive environment include:
 - Being kind and respectful to others
 - Giving constructive and actionable feedback
 - Being open to different viewpoints and experiences
-- Focusing on what’s best for the project
+- Focusing on what's best for the project
 
 ## Unacceptable behavior
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,9 +12,9 @@ so please keep that in mind when interacting or proposing changes.
 Before opening an issue:
 - Please check if a similar issue already exists.
 - Include clear steps to reproduce (if applicable).
-- For feature requests, describe the problem you’re trying to solve.
+- For feature requests, describe the problem you're trying to solve.
 
-If you’re unsure, feel free to open a discussion first.
+If you're unsure, feel free to open a discussion first.
 
 ## Pull Requests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1653,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39d785c0683d1027839f1ac6a43b6d07c63d58ecd363d8146dda4531d53465a1"
+checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1667,6 +1667,7 @@ dependencies = [
  "idna",
  "itoa",
  "jsonschema-regex",
+ "jsonschema-value",
  "num-cmp",
  "num-traits",
  "percent-encoding",
@@ -1683,11 +1684,25 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917b3be16b2662538aafb55201790561e1f1ad1a0454baf42f33bd9de343778b"
+checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
 dependencies = [
  "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
 ]
 
 [[package]]
@@ -1848,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "base64",
  "bytes",
@@ -1884,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "neva_macros"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2316,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.48.2"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2b21a85c07fcf1cb95ff7ab8a687fcd37fa70db59975b5a032abdaadfdf42e"
+checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2814,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -3045,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "base64",
  "bytes",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "neva_macros"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.4"
+version = "0.5.0"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -29,7 +29,7 @@ categories = [
 ]
 
 [workspace.dependencies]
-neva_macros = { path = "neva_macros", version = "0.4.4" }
+neva_macros = { path = "neva_macros", version = "0.5.0" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -29,7 +29,7 @@ categories = [
 ]
 
 [workspace.dependencies]
-neva_macros = { path = "neva_macros", version = "0.4.3" }
+neva_macros = { path = "neva_macros", version = "0.4.4" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blazingly fast and easily configurable [Model Context Protocol (MCP)](https://mo
 With simple configuration and ergonomic APIs, it provides everything you need to quickly build MCP clients and servers, 
 fully aligned with the latest MCP specification.
 
-[![latest](https://img.shields.io/badge/latest-0.4.4-d8eb34)](https://crates.io/crates/neva)
+[![latest](https://img.shields.io/badge/latest-0.5.0-d8eb34)](https://crates.io/crates/neva)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-624bd1.svg)](https://github.com/RomanEmreis/neva/blob/main/LICENSE)
 [![CI](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml)
@@ -30,7 +30,7 @@ fully aligned with the latest MCP specification.
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.4.4", features = ["client-full"] }
+neva = { version = "0.5.0", features = ["client-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Error> {
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.4.4", features = ["server-full"] }
+neva = { version = "0.5.0", features = ["server-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 #### Code

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blazingly fast and easily configurable [Model Context Protocol (MCP)](https://mo
 With simple configuration and ergonomic APIs, it provides everything you need to quickly build MCP clients and servers, 
 fully aligned with the latest MCP specification.
 
-[![latest](https://img.shields.io/badge/latest-0.4.3-d8eb34)](https://crates.io/crates/neva)
+[![latest](https://img.shields.io/badge/latest-0.4.4-d8eb34)](https://crates.io/crates/neva)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-624bd1.svg)](https://github.com/RomanEmreis/neva/blob/main/LICENSE)
 [![CI](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml)
@@ -30,7 +30,7 @@ fully aligned with the latest MCP specification.
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.4.3", features = ["client-full"] }
+neva = { version = "0.4.4", features = ["client-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Error> {
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.4.3", features = ["server-full"] }
+neva = { version = "0.4.4", features = ["server-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 #### Code

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,16 +14,16 @@ latest released version**.
 
 In practice, security fixes are published as part of the next release.  
 If a fix is important, we may ship a quick patch release, but we typically
-won’t maintain intermediate versions once a newer release is available.
+won't maintain intermediate versions once a newer release is available.
 
 ## Reporting a Vulnerability
 
-If you believe you’ve found a security issue, please **do not open a public issue**
+If you believe you've found a security issue, please **do not open a public issue**
 right away.
 
 Instead, report it privately:
 - Open a **GitHub Security Advisory** (preferred), or
-- Contact the maintainer via the repository’s listed contact channels.
+- Contact the maintainer via the repository's listed contact channels.
 
 Please include:
 - A clear description of the issue

--- a/examples/actix/src/main.rs
+++ b/examples/actix/src/main.rs
@@ -6,7 +6,7 @@
 //! cargo run -p example-actix
 //! ```
 //!
-//! This example shows how to plug a non-default HTTP stack — here, actix-web —
+//! This example shows how to plug a non-default HTTP stack -- here, actix-web --
 //! into neva's Streamable HTTP transport. It pulls in `neva` with only the
 //! engine-agnostic `http-server` feature, implements
 //! the [`HttpEngine`] contract for an `ActixEngine`, and wires it into
@@ -23,7 +23,7 @@ use tokio_util::sync::CancellationToken;
 
 /// HTTP engine backed by [actix-web](https://docs.rs/actix-web).
 ///
-/// `Request` / `Response` are actix's own native types — they're `!Send`
+/// `Request` / `Response` are actix's own native types -- they're `!Send`
 /// but the `HttpEngine` trait doesn't require Send there, and actix
 /// handlers never cross a `tokio::spawn` boundary so the `!Send` future
 /// produced by `dispatch_*` is fine.
@@ -35,7 +35,7 @@ impl HttpEngine for ActixEngine {
     /// separate extractor arguments, so we wrap them in a tuple.
     type Request = (ActixHttpRequest, ActixBytes);
     type Response = ActixHttpResponse;
-    /// Pre-formatted SSE wire bytes — actix-web's `streaming(...)`
+    /// Pre-formatted SSE wire bytes -- actix-web's `streaming(...)`
     /// consumes a stream of `Result<Bytes, _>`, and we wrap each event
     /// in `Ok` because neva never produces SSE errors.
     type SseEvent = Result<Bytes, std::convert::Infallible>;

--- a/examples/actix/src/main.rs
+++ b/examples/actix/src/main.rs
@@ -129,9 +129,29 @@ async fn post_handler(
     req: ActixHttpRequest,
     body: ActixBytes,
 ) -> ActixHttpResponse {
-    handlers::dispatch_post::<ActixEngine>((req, body), &ctx)
-        .await
-        .unwrap_or_else(internal_error)
+    // Same two-arm shape as `get_handler`: a POST reply is either a single
+    // body (`Complete`) or a request-scoped SSE stream (`Stream`) carrying
+    // the request's notifications followed by its response.
+    let outcome = match handlers::dispatch_post::<ActixEngine>((req, body), &ctx).await {
+        Ok(outcome) => outcome,
+        Err(e) => return internal_error(e),
+    };
+    match outcome {
+        StreamResponse::Stream { headers, stream } => {
+            let mut builder = ActixHttpResponse::Ok();
+            builder.content_type("text/event-stream");
+            for (name, value) in headers.iter() {
+                if let (Ok(n), Ok(v)) = (
+                    actix_web::http::header::HeaderName::from_bytes(name.as_str().as_bytes()),
+                    actix_web::http::header::HeaderValue::from_bytes(value.as_bytes()),
+                ) {
+                    builder.append_header((n, v));
+                }
+            }
+            builder.streaming(stream)
+        }
+        StreamResponse::Complete(resp) => ActixEngine::adapt_response(resp),
+    }
 }
 
 async fn delete_handler(
@@ -154,7 +174,7 @@ async fn get_handler(
         Err(e) => return internal_error(e),
     };
     match outcome {
-        SseResponse::Stream { headers, stream } => {
+        StreamResponse::Stream { headers, stream } => {
             let mut builder = ActixHttpResponse::Ok();
             builder.content_type("text/event-stream");
             for (name, value) in headers.iter() {
@@ -167,7 +187,7 @@ async fn get_handler(
             }
             builder.streaming(stream)
         }
-        SseResponse::Status(resp) => ActixEngine::adapt_response(resp),
+        StreamResponse::Complete(resp) => ActixEngine::adapt_response(resp),
     }
 }
 

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -107,9 +107,24 @@ impl HttpEngine for AxumEngine {
 }
 
 async fn post_handler(State(ctx): State<HttpContext>, req: axum::http::Request<Body>) -> Response {
-    handlers::dispatch_post::<AxumEngine>(req, &ctx)
-        .await
-        .unwrap_or_else(internal_error)
+    // Same two-arm shape as `get_handler`: a POST reply is either a single
+    // body (`Complete`) or a request-scoped SSE stream (`Stream`) carrying
+    // the request's notifications followed by its response.
+    let outcome = match handlers::dispatch_post::<AxumEngine>(req, &ctx).await {
+        Ok(outcome) => outcome,
+        Err(e) => return internal_error(e),
+    };
+    match outcome {
+        StreamResponse::Stream { headers, stream } => {
+            let sse = Sse::new(stream).keep_alive(KeepAlive::default());
+            let mut response: Response = sse.into_response();
+            for (name, value) in headers.iter() {
+                response.headers_mut().insert(name, value.clone());
+            }
+            response
+        }
+        StreamResponse::Complete(resp) => AxumEngine::adapt_response(resp),
+    }
 }
 
 async fn delete_handler(State(ctx): State<HttpContext>, req: http::Request<Body>) -> Response {
@@ -124,7 +139,7 @@ async fn get_handler(State(ctx): State<HttpContext>, req: http::Request<Body>) -
         Err(e) => return internal_error(e),
     };
     match outcome {
-        SseResponse::Stream { headers, stream } => {
+        StreamResponse::Stream { headers, stream } => {
             let sse = Sse::new(stream).keep_alive(KeepAlive::default());
             let mut response: Response = sse.into_response();
             for (name, value) in headers.iter() {
@@ -132,7 +147,7 @@ async fn get_handler(State(ctx): State<HttpContext>, req: http::Request<Body>) -
             }
             response
         }
-        SseResponse::Status(resp) => AxumEngine::adapt_response(resp),
+        StreamResponse::Complete(resp) => AxumEngine::adapt_response(resp),
     }
 }
 

--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -6,12 +6,12 @@
 //! cargo run -p example-axum
 //! ```
 //!
-//! This example shows how to plug a non-default HTTP stack — here, axum —
+//! This example shows how to plug a non-default HTTP stack -- here, axum --
 //! into neva's Streamable HTTP transport. It pulls in `neva` with only the
 //! engine-agnostic `http-server` feature, implements
 //! the [`HttpEngine`] contract for an `AxumEngine`, and wires it into
-//! `HttpServer::from_engine`. All adapter surfaces — HTTP request /
-//! response conversion *and* SSE event construction — live on the
+//! `HttpServer::from_engine`. All adapter surfaces -- HTTP request /
+//! response conversion *and* SSE event construction -- live on the
 //! engine, so route handlers are one-liners.
 
 use axum::{

--- a/examples/batch/client/src/main.rs
+++ b/examples/batch/client/src/main.rs
@@ -1,4 +1,4 @@
-//! Batch example — client side
+//! Batch example -- client side
 //!
 //! Run the server first, then:
 //! ```no_rust

--- a/examples/batch/server/src/main.rs
+++ b/examples/batch/server/src/main.rs
@@ -1,4 +1,4 @@
-//! Batch example — server side
+//! Batch example -- server side
 //!
 //! Run with:
 //! ```no_rust

--- a/examples/hyper/src/main.rs
+++ b/examples/hyper/src/main.rs
@@ -6,12 +6,12 @@
 //! cargo run -p example-hyper
 //! ```
 //!
-//! This example shows how to plug a non-default HTTP stack — here, raw
-//! hyper — into neva's Streamable HTTP transport. It pulls in `neva`
+//! This example shows how to plug a non-default HTTP stack -- here, raw
+//! hyper -- into neva's Streamable HTTP transport. It pulls in `neva`
 //! with only the engine-agnostic `http-server` feature, implements the [`HttpEngine`] contract for a `HyperEngine`,
 //! and wires it into `HttpServer::from_engine`.
 //!
-//! Unlike axum / actix-web, hyper ships no router — the engine's
+//! Unlike axum / actix-web, hyper ships no router -- the engine's
 //! accept loop dispatches on `(method, path)` directly.
 
 use std::convert::Infallible;
@@ -28,7 +28,7 @@ use hyper_util::rt::TokioIo;
 use neva::prelude::*;
 use tokio_util::sync::CancellationToken;
 
-/// Boxed body type used uniformly by every response this engine builds —
+/// Boxed body type used uniformly by every response this engine builds --
 /// `BoxBody` lets the SSE-streaming branch and the buffered-JSON branch
 /// share a single response type.
 type BoxedBody = BoxBody<Bytes, Infallible>;

--- a/examples/hyper/src/main.rs
+++ b/examples/hyper/src/main.rs
@@ -119,19 +119,15 @@ async fn dispatch(req: http::Request<Incoming>, ctx: HttpContext) -> http::Respo
         return status_only(http::StatusCode::NOT_FOUND);
     }
     match *req.method() {
-        Method::POST => handlers::dispatch_post::<HyperEngine>(req, &ctx)
-            .await
-            .unwrap_or_else(|_| status_only(http::StatusCode::INTERNAL_SERVER_ERROR)),
-        Method::DELETE => handlers::dispatch_delete::<HyperEngine>(req, &ctx)
-            .await
-            .unwrap_or_else(|_| status_only(http::StatusCode::INTERNAL_SERVER_ERROR)),
-        Method::GET => {
-            let outcome = match handlers::dispatch_get_sse::<HyperEngine>(req, &ctx).await {
+        // Same two-arm shape as the GET arm below: a POST reply is either a
+        // single body (`Complete`) or a request-scoped SSE stream (`Stream`).
+        Method::POST => {
+            let outcome = match handlers::dispatch_post::<HyperEngine>(req, &ctx).await {
                 Ok(outcome) => outcome,
                 Err(_) => return status_only(http::StatusCode::INTERNAL_SERVER_ERROR),
             };
             match outcome {
-                SseResponse::Stream { headers, stream } => {
+                StreamResponse::Stream { headers, stream } => {
                     let body = StreamBody::new(stream).boxed();
                     let mut resp = http::Response::builder()
                         .status(http::StatusCode::OK)
@@ -143,7 +139,31 @@ async fn dispatch(req: http::Request<Incoming>, ctx: HttpContext) -> http::Respo
                     }
                     resp
                 }
-                SseResponse::Status(resp) => HyperEngine::adapt_response(resp),
+                StreamResponse::Complete(resp) => HyperEngine::adapt_response(resp),
+            }
+        }
+        Method::DELETE => handlers::dispatch_delete::<HyperEngine>(req, &ctx)
+            .await
+            .unwrap_or_else(|_| status_only(http::StatusCode::INTERNAL_SERVER_ERROR)),
+        Method::GET => {
+            let outcome = match handlers::dispatch_get_sse::<HyperEngine>(req, &ctx).await {
+                Ok(outcome) => outcome,
+                Err(_) => return status_only(http::StatusCode::INTERNAL_SERVER_ERROR),
+            };
+            match outcome {
+                StreamResponse::Stream { headers, stream } => {
+                    let body = StreamBody::new(stream).boxed();
+                    let mut resp = http::Response::builder()
+                        .status(http::StatusCode::OK)
+                        .header(http::header::CONTENT_TYPE, "text/event-stream")
+                        .body(body)
+                        .expect("valid response");
+                    for (name, value) in headers.iter() {
+                        resp.headers_mut().insert(name, value.clone());
+                    }
+                    resp
+                }
+                StreamResponse::Complete(resp) => HyperEngine::adapt_response(resp),
             }
         }
         _ => status_only(http::StatusCode::METHOD_NOT_ALLOWED),

--- a/examples/mrtr/README.md
+++ b/examples/mrtr/README.md
@@ -1,4 +1,4 @@
-# MRTR (Multi Round-Trip Requests) Example — MCP 2026-07-28 RC
+# MRTR (Multi Round-Trip Requests) Example -- MCP 2026-07-28 RC
 
 A new-spec checkout flow over **stateless HTTP**. The server's single
 `place_order` tool elicits shipping details mid-handler and uses the MRTR effect
@@ -10,14 +10,14 @@ the top on every round-trip.
 Two terminals, from this directory (`examples/mrtr/`):
 
 ```bash
-# terminal 1 — start the server (binds 127.0.0.1:3000/mcp)
+# terminal 1 -- start the server (binds 127.0.0.1:3000/mcp)
 cargo run -p server
 
-# terminal 2 — run the client
+# terminal 2 -- run the client
 cargo run -p client
 ```
 
-The client prints `Order confirmed for Ada Lovelace shipping to 1 Analytical Way — total $12.99`.
+The client prints `Order confirmed for Ada Lovelace shipping to 1 Analytical Way -- total $12.99`.
 
 ## What to watch
 
@@ -25,9 +25,9 @@ On the **server** you'll see each of these logged **exactly once**, even though
 `place_order` re-executes fully across the elicitation round-trip:
 
 ```
-📦 fetching shipping quote…     # ctx.memo  — computed once, replayed after
-💳 charging card…               # ctx.once  — effect guarded across rounds
-✉️  receipt sent to Ada Lovelace # ctx.on_commit — runs once, on the final round
+📦 fetching shipping quote...     # ctx.memo  -- computed once, replayed after
+💳 charging card...               # ctx.once  -- effect guarded across rounds
+✉️  receipt sent to Ada Lovelace # ctx.on_commit -- runs once, on the final round
 ```
 
 That once-only behavior is the whole point of `memo` / `once` / `on_commit`:
@@ -38,12 +38,12 @@ without them, the re-run model would re-fetch, double-charge, and re-send.
 - **Stateless HTTP** transport (no session id on the wire).
 - **`server/discover`** instead of the `initialize`/`initialized` handshake
   (run automatically by `client.connect()`).
-- **`ctx.elicit(key, params)`** — the two-arg, replay-aware elicitation API.
-- **`requestState`** — an HMAC-signed blob the client echoes back, carrying the
+- **`ctx.elicit(key, params)`** -- the two-arg, replay-aware elicitation API.
+- **`requestState`** -- an HMAC-signed blob the client echoes back, carrying the
   replay log plus `memo`/`once` bookkeeping. Set a shared signing key in
   production via `App::with_request_state_secret`.
 - Proc macros: **`#[tool]`**, **`#[elicitation]`**, **`#[json_schema]`**.
 
 Legacy push-model features (URL elicitation, `complete_elicitation`,
-`on_elicitation_completed`) are intentionally not used — they don't apply to the
+`on_elicitation_completed`) are intentionally not used -- they don't apply to the
 stateless model.

--- a/examples/mrtr/client/src/main.rs
+++ b/examples/mrtr/client/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Connects over stateless HTTP, runs `server/discover` on `connect()`, and
 //! calls `place_order`. The `#[elicitation]` handler answers the server's form
-//! request transparently — the MRTR round-trips are driven inside the client.
+//! request transparently -- the MRTR round-trips are driven inside the client.
 
 use neva::prelude::*;
 use tracing_subscriber::prelude::*;

--- a/examples/mrtr/server/src/main.rs
+++ b/examples/mrtr/server/src/main.rs
@@ -22,7 +22,7 @@ async fn place_order(mut ctx: Context) -> Result<String, Error> {
     // instead of running the future again.
     let quote_cents: u32 = ctx
         .memo("quote", async {
-            tracing::info!("📦 fetching shipping quote…");
+            tracing::info!("📦 fetching shipping quote...");
             Ok(1299)
         })
         .await?;
@@ -43,7 +43,7 @@ async fn place_order(mut ctx: Context) -> Result<String, Error> {
 
     // once: the charge runs at most once across all rounds.
     ctx.once("charge", async {
-        tracing::info!("💳 charging card…");
+        tracing::info!("💳 charging card...");
         Ok(())
     })
     .await?;
@@ -56,7 +56,7 @@ async fn place_order(mut ctx: Context) -> Result<String, Error> {
     });
 
     Ok(format!(
-        "Order confirmed for {} shipping to {} — total ${:.2}",
+        "Order confirmed for {} shipping to {} -- total ${:.2}",
         ship.full_name,
         ship.address,
         quote_cents as f64 / 100.0

--- a/examples/oauth-client/src/main.rs
+++ b/examples/oauth-client/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), Error> {
                 .with_oauth(|oauth| oauth)
         })
         // The first request may wait for the user to finish in the
-        // browser — give it more than the default 10 seconds.
+        // browser -- give it more than the default 10 seconds.
         .with_timeout(Duration::from_secs(300))
     });
 

--- a/examples/oauth-hyper-engine/src/main.rs
+++ b/examples/oauth-hyper-engine/src/main.rs
@@ -156,8 +156,8 @@ async fn route(
             HyperEngine::adapt_response(handlers::handle_delete(neutral, &ctx).await)
         }
         http::Method::GET => match handlers::handle_get_sse::<HyperEngine>(neutral, &ctx).await {
-            SseResponse::Status(resp) => HyperEngine::adapt_response(resp),
-            SseResponse::Stream { headers, stream } => {
+            StreamResponse::Complete(resp) => HyperEngine::adapt_response(resp),
+            StreamResponse::Stream { headers, stream } => {
                 let body = StreamBody::new(stream.map(|event| Ok(Frame::data(event))));
                 let mut resp = http::Response::builder()
                     .status(http::StatusCode::OK)

--- a/examples/oauth-hyper-engine/src/main.rs
+++ b/examples/oauth-hyper-engine/src/main.rs
@@ -6,13 +6,13 @@
 //!   [`handlers::handle_oauth_metadata`];
 //! * requests failing token validation answer with
 //!   [`handlers::handle_unauthorized`], so the `401` carries the
-//!   `WWW-Authenticate: Bearer resource_metadata="…"` challenge;
+//!   `WWW-Authenticate: Bearer resource_metadata="..."` challenge;
 //! * decoded claims go into the neutral request's extensions as
 //!   `Arc<dyn Claims>`, which keeps `#[tool(roles = [...])]` gates
 //!   working exactly like under the default Volga engine.
 //!
 //! Token validation here is HS256 with a shared secret to keep the
-//! example self-contained — swap `decode_claims` for your JWKS-based
+//! example self-contained -- swap `decode_claims` for your JWKS-based
 //! validation against a real issuer.
 //!
 //! Run with:
@@ -108,7 +108,7 @@ impl HttpEngine for HyperEngine {
     }
 }
 
-/// The engine's router — the hyper counterpart of the three MCP routes
+/// The engine's router -- the hyper counterpart of the three MCP routes
 /// plus the well-known metadata document.
 async fn route(
     req: http::Request<Incoming>,
@@ -134,7 +134,7 @@ async fn route(
     };
 
     // The engine authorization contract: validate the credential, put
-    // the claims into the neutral request's extensions — or answer with
+    // the claims into the neutral request's extensions -- or answer with
     // the challenge so the client can start the OAuth flow.
     match decode_claims(neutral.headers(), &ctx, &secret) {
         Some(claims) => {
@@ -175,7 +175,7 @@ async fn route(
 }
 
 /// HS256 bearer validation with the audience bound to the canonical
-/// resource URI — the place to plug JWKS validation instead.
+/// resource URI -- the place to plug JWKS validation instead.
 fn decode_claims(
     headers: &http::HeaderMap,
     ctx: &HttpContext,

--- a/examples/oauth-with-keycloak/README.md
+++ b/examples/oauth-with-keycloak/README.md
@@ -2,7 +2,7 @@
 
 The full MCP authorization flow against a real OAuth 2.1/OIDC issuer:
 a neva server validating tokens against Keycloak's JWKS, and a neva
-client walking discovery → browser login → PKCE code exchange → tool
+client walking discovery -> browser login -> PKCE code exchange -> tool
 calls, including a role-gated tool.
 
 ## 1. Start Keycloak
@@ -23,7 +23,7 @@ The imported `neva` realm contains:
 |---|---|---|
 | public client | `neva-mcp-client`, redirect `http://127.0.0.1:8919/callback`, PKCE S256 | the MCP client |
 | audience mapper | adds `http://127.0.0.1:3000/mcp` to `aud` | RFC 8707 binding the server verifies |
-| role mapper | realm roles → flat `roles` claim | what neva's `DefaultClaims` / `#[tool(roles = [...])]` read |
+| role mapper | realm roles -> flat `roles` claim | what neva's `DefaultClaims` / `#[tool(roles = [...])]` read |
 | user | `demo` / `demo`, realm role `admin` | the person in the browser |
 
 ## 2. Start the MCP server
@@ -44,7 +44,7 @@ cargo run -p example-oauth-with-keycloak --bin keycloak-client
 ```
 
 The first request hits a `401`, the client discovers Keycloak through
-the challenge, and the system browser opens the login page — sign in as
+the challenge, and the system browser opens the login page -- sign in as
 `demo` / `demo`. After the redirect the client retries transparently and
 calls both tools; `admin_report` works because `demo` carries the
 `admin` realm role. Tokens are refreshed in the background afterwards.
@@ -63,12 +63,12 @@ In the authentication settings set **Client ID** to `neva-mcp-client`
 so the Inspector cannot register itself), then follow the prompts and
 sign in as `demo` / `demo`.
 
-The Inspector's **redirect URL field is read-only by design** — the
+The Inspector's **redirect URL field is read-only by design** -- the
 callback must land on the Inspector web app itself
-(`http://localhost:6274/oauth/callback`, plus `…/callback/debug` for the
+(`http://localhost:6274/oauth/callback`, plus `.../callback/debug` for the
 guided flow). Both are pre-registered on `neva-mcp-client` by the realm
 import; if you run the Inspector on a non-default port, add the matching
-URIs in the Keycloak admin console (Clients → `neva-mcp-client` → Valid
+URIs in the Keycloak admin console (Clients -> `neva-mcp-client` -> Valid
 redirect URIs).
 
 ## Notes

--- a/examples/oauth-with-keycloak/src/client.rs
+++ b/examples/oauth-with-keycloak/src/client.rs
@@ -1,10 +1,10 @@
-//! The client half of the Keycloak walkthrough — see README.md in this
+//! The client half of the Keycloak walkthrough -- see README.md in this
 //! directory for the full setup.
 //!
 //! Uses the client pre-registered by the realm import
 //! (`neva-mcp-client`, redirect `http://127.0.0.1:8919/callback`), so
 //! the loopback listener is pinned to that port. On the first request
-//! the browser opens Keycloak's login page — sign in as `demo` / `demo`.
+//! the browser opens Keycloak's login page -- sign in as `demo` / `demo`.
 //!
 //! ```no_rust
 //! cargo run -p example-oauth-with-keycloak --bin keycloak-client

--- a/examples/oauth-with-keycloak/src/server.rs
+++ b/examples/oauth-with-keycloak/src/server.rs
@@ -1,4 +1,4 @@
-//! The resource-server half of the Keycloak walkthrough — see README.md
+//! The resource-server half of the Keycloak walkthrough -- see README.md
 //! in this directory for the full setup.
 //!
 //! Minimal configuration on purpose: pointing bearer auth at the issuer

--- a/examples/protected-server/src/main.rs
+++ b/examples/protected-server/src/main.rs
@@ -6,7 +6,7 @@
 //! # Static decoding key (HS256):
 //! JWT_SECRET=a-string-secret-at-least-256-bits-long cargo run -p example-protected-server
 //!
-//! # OAuth 2.1/OIDC issuer mode — tokens are validated against the
+//! # OAuth 2.1/OIDC issuer mode -- tokens are validated against the
 //! # issuer's JWKS, and /.well-known/oauth-protected-resource/mcp is
 //! # served automatically:
 //! OAUTH_ISSUER=https://auth.example.com cargo run -p example-protected-server
@@ -67,7 +67,7 @@ async fn main() {
                         //   .with_config(|cfg| cfg
                         //       .with_client_config(|c| c.require_https(false)))
                         (Some(issuer), _) => auth.with_oauth(|oauth| oauth.with_issuer(issuer)),
-                        // Static decoding key (HS256) — the pre-OAuth setup.
+                        // Static decoding key (HS256) -- the pre-OAuth setup.
                         (None, Some(secret)) => auth
                             .validate_exp(false)
                             .with_aud(["some aud"])

--- a/examples/roots/README.md
+++ b/examples/roots/README.md
@@ -22,7 +22,7 @@ The RC removed the capability-driven push request. The *ability* was re-homed
 onto MRTR: the server asks with `ctx.list_roots(key)`, the reply is an
 `input_required` result carrying a `roots/list` envelope, and the client echoes
 its roots back in `inputResponses` alongside the opaque `requestState`. Roots
-arrive **deprecated** — they exist for migration.
+arrive **deprecated** -- they exist for migration.
 
 ### Run the server
 ```
@@ -33,14 +33,14 @@ cargo run --manifest-path examples/roots/rc/server/Cargo.toml
 cargo run --manifest-path examples/roots/rc/client/Cargo.toml
 ```
 
-The client prints `2 root(s): My Project (…), My Another Project (…)`.
+The client prints `2 root(s): My Project (...), My Another Project (...)`.
 
 ### What to watch
 
-`🔎 scan_workspace round starting…` is logged **twice** on the server: the
+`🔎 scan_workspace round starting...` is logged **twice** on the server: the
 handler re-runs from the top on the second round, with the roots replayed out
 of `requestState` instead of asked for again. Anything expensive above an input
-point belongs in `ctx.memo` / `ctx.once` for that reason — see
+point belongs in `ctx.memo` / `ctx.once` for that reason -- see
 [`examples/mrtr`](../mrtr) for the effect primitives.
 
 The client never registers a roots *handler*: roots are configured data, so

--- a/examples/roots/rc/client/src/main.rs
+++ b/examples/roots/rc/client/src/main.rs
@@ -3,7 +3,7 @@
 //! Roots are configured *data*, not a handler: the client answers the server's
 //! MRTR `roots/list` input request from the list it was built with. Because the
 //! list is non-empty, the client automatically declares
-//! `clientCapabilities.roots` on every request — a server may only ask for a
+//! `clientCapabilities.roots` on every request -- a server may only ask for a
 //! kind the client declared.
 //!
 //! The MRTR round-trips happen inside `call_tool`: the caller sees one call.
@@ -21,7 +21,7 @@ async fn main() -> Result<(), Error> {
         opt.with_http(|http| http.bind("127.0.0.1:3001").with_endpoint("/mcp"))
     });
 
-    // Deprecated on arrival, like the whole roots kind — the API stays for
+    // Deprecated on arrival, like the whole roots kind -- the API stays for
     // migration.
     #[allow(deprecated)]
     client
@@ -31,7 +31,7 @@ async fn main() -> Result<(), Error> {
             "My Another Project",
         );
 
-    // `connect()` runs `server/discover` — no `initialize` handshake under RC.
+    // `connect()` runs `server/discover` -- no `initialize` handshake under RC.
     client.connect().await?;
 
     let result = client.call_tool("scan_workspace", ()).await?;

--- a/examples/roots/rc/server/src/main.rs
+++ b/examples/roots/rc/server/src/main.rs
@@ -1,9 +1,9 @@
 //! New-spec (MCP 2026-07-28 RC) roots example server.
 //!
-//! Under the RC there is no `roots/list` server→client *request*: the
+//! Under the RC there is no `roots/list` server->client *request*: the
 //! capability-driven push channel is gone. The ability was re-homed onto MRTR
 //! as an input-request kind, so the server asks for roots the same way it asks
-//! for elicitation input — `ctx.list_roots(key)` — and the answer replays from
+//! for elicitation input -- `ctx.list_roots(key)` -- and the answer replays from
 //! the encrypted `requestState` on the next round.
 //!
 //! Roots are **deprecated on arrival**: they exist for migration, hence the
@@ -16,9 +16,9 @@ use tracing_subscriber::prelude::*;
 #[tool]
 async fn scan_workspace(mut ctx: Context) -> Result<String, Error> {
     // Everything above an input point re-runs on every round-trip, so guard
-    // side effects with `once` / `memo` — here the log line proves the handler
+    // side effects with `once` / `memo` -- here the log line proves the handler
     // really does execute twice.
-    tracing::info!("🔎 scan_workspace round starting…");
+    tracing::info!("🔎 scan_workspace round starting...");
 
     // Round 1: no answer for "dirs" yet, so this unwinds the handler and the
     // server replies `input_required` with a `roots/list` envelope.

--- a/examples/sampling/README.md
+++ b/examples/sampling/README.md
@@ -24,7 +24,7 @@ The RC removed the capability-driven push request. The *ability* was re-homed
 onto MRTR: the server borrows the client's model with `ctx.sample(key, params)`,
 the reply is an `input_required` result carrying a `sampling/createMessage`
 envelope, and the client echoes the completion back in `inputResponses`
-alongside the opaque `requestState`. Sampling arrives **deprecated** — it exists
+alongside the opaque `requestState`. Sampling arrives **deprecated** -- it exists
 for migration.
 
 ### Run the server
@@ -36,22 +36,22 @@ cargo run --manifest-path examples/sampling/rc/server/Cargo.toml
 cargo run --manifest-path examples/sampling/rc/client/Cargo.toml
 ```
 
-The client prints `[o3-mini] Revenue grew 12% with steady churn, …`.
+The client prints `[o3-mini] Revenue grew 12% with steady churn, ...`.
 
 ### What to watch
 
 The server logs show the whole point of the MRTR effect primitives:
 
 ```
-📝 summarize_report round starting…   # round 1
-📚 fetching source report…            # ctx.memo — computed once
-📝 summarize_report round starting…   # round 2: the handler re-runs…
-🗄️  summary archived                  # ctx.on_commit — fires once, at the end
+📝 summarize_report round starting...   # round 1
+📚 fetching source report...            # ctx.memo -- computed once
+📝 summarize_report round starting...   # round 2: the handler re-runs...
+🗄️  summary archived                  # ctx.on_commit -- fires once, at the end
 ```
 
-`📚 fetching source report…` appears **once** even though the handler ran
+`📚 fetching source report...` appears **once** even though the handler ran
 **twice**: the memo value is replayed out of `requestState` on the second round.
 
-The handler is wired with an explicit `client.map_sampling(…)` rather than the
-`#[sampling]` attribute — that macro belongs to the legacy push model and is not
+The handler is wired with an explicit `client.map_sampling(...)` rather than the
+`#[sampling]` attribute -- that macro belongs to the legacy push model and is not
 available under `proto-2026-07-28-rc`.

--- a/examples/sampling/rc/client/src/main.rs
+++ b/examples/sampling/rc/client/src/main.rs
@@ -1,6 +1,6 @@
 //! New-spec (MCP 2026-07-28 RC) sampling example client.
 //!
-//! The sampling handler is still a handler — but it is no longer a *push*
+//! The sampling handler is still a handler -- but it is no longer a *push*
 //! endpoint. Under the RC it fulfils MRTR `sampling/createMessage` input
 //! requests inside the client's round-trip loop, so the caller of `call_tool`
 //! sees a single call. Registering one makes the client declare
@@ -44,12 +44,12 @@ async fn main() -> Result<(), Error> {
         opt.with_http(|http| http.bind("127.0.0.1:3002").with_endpoint("/mcp"))
     });
 
-    // Deprecated on arrival, like the whole sampling kind — the API stays for
+    // Deprecated on arrival, like the whole sampling kind -- the API stays for
     // migration.
     #[allow(deprecated)]
     client.map_sampling(complete);
 
-    // `connect()` runs `server/discover` — no `initialize` handshake under RC.
+    // `connect()` runs `server/discover` -- no `initialize` handshake under RC.
     client.connect().await?;
 
     // One call from here; the MRTR round-trips happen inside.

--- a/examples/sampling/rc/server/src/main.rs
+++ b/examples/sampling/rc/server/src/main.rs
@@ -1,16 +1,16 @@
 //! New-spec (MCP 2026-07-28 RC) sampling example server.
 //!
-//! Under the RC there is no `sampling/createMessage` server→client *request*:
+//! Under the RC there is no `sampling/createMessage` server->client *request*:
 //! the capability-driven push channel is gone. The ability was re-homed onto
 //! MRTR as an input-request kind, so the server borrows the client's model the
-//! same way it asks for elicitation input — `ctx.sample(key, params)` — and the
+//! same way it asks for elicitation input -- `ctx.sample(key, params)` -- and the
 //! completion replays from the encrypted `requestState` on the next round.
 //!
 //! Sampling is **deprecated on arrival**: it exists for migration, hence the
 //! explicit `#[allow(deprecated)]` at the call site.
 //!
 //! Because the handler re-runs from the top on every round-trip, the expensive
-//! work around the sampling point is guarded with the MRTR effect primitives —
+//! work around the sampling point is guarded with the MRTR effect primitives --
 //! exactly as it would be around an elicitation point.
 
 use neva::prelude::*;
@@ -19,13 +19,13 @@ use tracing_subscriber::prelude::*;
 
 #[tool]
 async fn summarize_report(mut ctx: Context, topic: String) -> Result<String, Error> {
-    tracing::info!("📝 summarize_report round starting…");
+    tracing::info!("📝 summarize_report round starting...");
 
     // memo: the "fetch" happens once and is replayed on the second round,
     // even though everything above the sampling point re-executes.
     let report: String = ctx
         .memo("report", async {
-            tracing::info!("📚 fetching source report…");
+            tracing::info!("📚 fetching source report...");
             Ok(format!(
                 "Q3 numbers for {topic}: revenue up 12%, churn flat, two outages."
             ))

--- a/examples/tasks/client/src/main.rs
+++ b/examples/tasks/client/src/main.rs
@@ -10,7 +10,7 @@ async fn sampling_handler(params: CreateMessageRequestParams) -> CreateMessageRe
         .with_model("gpt-5")
         .with_content(
             r#"Winter night whispers,
-Warm lights breathe through frosted glass—
+Warm lights breathe through frosted glass--
 Time pauses, snow listens."#)
         .end_turn()
 }

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -35,11 +35,11 @@ uuid = { version = "1.24.0", features = ["v4", "serde"] }
 # optional
 chacha20poly1305 = { version = "0.11.0", optional = true }
 inventory = { version = "0.3.24", optional = true }
-jsonschema = { version = "0.48.2", optional = true }
+jsonschema = { version = "0.48.5", optional = true }
 once_cell = { version = "1.21.4", features = ["std"], optional = true }
 reqwest = { version = "0.13.4", features = ["stream", "json"], optional = true }
-sse-stream = { version = "0.2.4", optional = true }
-tokio-stream = { version = "0.1.18", optional = true }
+sse-stream = { version = "0.2.5", optional = true }
+tokio-stream = { version = "0.1.19", optional = true }
 tracing = { version = "0.1.44", optional = true }
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "json"], optional = true }
 volga = { version = "0.9.6", features = ["di", "jwt-auth-full"], optional = true }
@@ -58,7 +58,7 @@ nix = { version = "0.31.1", features = ["signal"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.53.1", features = ["rt", "rt-multi-thread", "macros"] }
-tokio-stream = { version = "0.1.18" }
+tokio-stream = { version = "0.1.19" }
 
 [features]
 default = []

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -129,7 +129,7 @@ impl App {
         // `notifications/resources/updated`, so the `resources.subscribe`
         // capability is masked off (see `McpOptions::resources_capability`).
         // Don't register subscribe/unsubscribe handlers under RC either, so the
-        // advertised surface and the accepted methods stay in sync — the server
+        // advertised surface and the accepted methods stay in sync -- the server
         // won't accept a subscription it never announces.
         #[cfg(not(feature = "proto-2026-07-28-rc"))]
         {
@@ -325,12 +325,12 @@ impl App {
     /// `requestState` (`proto-2026-07-28-rc`).
     ///
     /// The blob is sealed with ChaCha20-Poly1305 (AEAD) using a key derived from
-    /// this secret, so the payload — including any values a handler caches via
-    /// [`Context::memo`](crate::Context::memo) — is confidential as well as
+    /// this secret, so the payload -- including any values a handler caches via
+    /// [`Context::memo`](crate::Context::memo) -- is confidential as well as
     /// tamper-evident.
     ///
     /// **Multi-instance stateless deployments MUST set this to a shared
-    /// secret** — otherwise a retry that lands on a different instance fails to
+    /// secret** -- otherwise a retry that lands on a different instance fails to
     /// decrypt the `requestState`. If unset, an ephemeral per-process key is
     /// used (fine for single-instance / development).
     ///
@@ -338,7 +338,7 @@ impl App {
     /// [`with_request_state_keys`](Self::with_request_state_keys).
     ///
     /// Because the state is sealed rather than signed, this value protects the
-    /// *confidentiality* of memoized values, not just their integrity — treat
+    /// *confidentiality* of memoized values, not just their integrity -- treat
     /// it as a secret. See the [state codec docs](crate::types::mrtr) for why
     /// MRTR encrypts instead of signing.
     ///
@@ -361,9 +361,9 @@ impl App {
     /// enabling zero-downtime key rotation (`proto-2026-07-28-rc`).
     ///
     /// New blobs are sealed with the key `active_kid` names and carry the kid
-    /// on the wire (`v1.{kid}.…`); an inbound blob is decrypted with whichever
+    /// on the wire (`v1.{kid}....`); an inbound blob is decrypted with whichever
     /// accepted key its kid segment names. To rotate: ship the new key as
-    /// *accepted* on every instance first, then flip `active_kid` to it —
+    /// *accepted* on every instance first, then flip `active_kid` to it --
     /// states minted under the old kid keep verifying until their TTL lapses,
     /// after which the old key can be dropped.
     ///
@@ -435,7 +435,7 @@ impl App {
     /// [`InMemoryStateStore`](crate::app::mrtr_store::InMemoryStateStore).
     /// **Multi-instance stateless deployments should set a shared store** (e.g.
     /// Redis) so a retry routed to another instance still sees the committed
-    /// result — the same constraint as
+    /// result -- the same constraint as
     /// [`with_request_state_secret`](Self::with_request_state_secret).
     ///
     /// # Example
@@ -962,7 +962,7 @@ impl App {
         };
 
         // Capture before consuming the batch so we know whether to send an ack
-        // when all Response envelopes were consumed by pending.complete (§ below).
+        // when all Response envelopes were consumed by pending.complete (section below).
         let has_error_responses = batch
             .iter()
             .any(|e| matches!(e, MessageEnvelope::Response(Response::Err(_))));
@@ -1016,7 +1016,7 @@ impl App {
                         // complete it (the client is responding to a server request
                         // inside the batch). Otherwise, if the response carries an
                         // error, it is a synthetic InvalidRequest injected by the
-                        // deserializer for a malformed batch item — route it through
+                        // deserializer for a malformed batch item -- route it through
                         // the collector so it appears in the batch reply.
                         // Unmatched Ok responses are unsolicited or stale and are
                         // dropped silently, consistent with the single-message
@@ -1034,7 +1034,7 @@ impl App {
         join_all(futures).await;
 
         // Snapshot collected responses. Any response that a background task
-        // produces after this point is silently discarded — it arrived too
+        // produces after this point is silently discarded -- it arrived too
         // late to be included in the batch reply.
         let envelopes = responses
             .lock()
@@ -1131,7 +1131,7 @@ impl App {
             ),
             Message::Response(resp) => Some(Self::handle_response(resp, runtime).await),
             Message::Notification(notification) => {
-                // JSON-RPC 2.0 §4: notifications must never receive a response.
+                // JSON-RPC 2.0 section 4: notifications must never receive a response.
                 Self::handle_notification(notification, runtime).await;
                 None
             }
@@ -1225,16 +1225,16 @@ impl App {
 
         // MRTR idempotency: the final-round response cache is keyed by the
         // incoming state's sealed segment (the ciphertext+tag after the last
-        // `.` — `rsplit_once` keeps grabbing it regardless of the leading
-        // `v1.kid.` header segments — unique per minted state thanks to the
+        // `.` -- `rsplit_once` keeps grabbing it regardless of the leading
+        // `v1.kid.` header segments -- unique per minted state thanks to the
         // random AEAD nonce) *plus* a
         // digest of this round's `inputResponses`. The answers digest matters
         // because the *same* minted state can be echoed with *different*
-        // answers — a client (or attacker) replaying one round-1 blob with two
+        // answers -- a client (or attacker) replaying one round-1 blob with two
         // different `inputResponses` would otherwise hit the first answer's
         // cached result for the second. Folding in the answers' digest keeps
-        // those apart, while a genuine lost-response retry — same state *and*
-        // same answers — still hits. Only committed *final* rounds are ever
+        // those apart, while a genuine lost-response retry -- same state *and*
+        // same answers -- still hits. Only committed *final* rounds are ever
         // cached, so a hit here is by construction a replay of one.
         #[cfg(feature = "proto-2026-07-28-rc")]
         let state_tag: Option<String> = if mrtr_method {
@@ -1303,8 +1303,8 @@ impl App {
 
         // MRTR interception: if the handler requested input (recorded in the
         // shared `MrtrCtx`), convert to an `InputRequiredResult` regardless of
-        // what the handler returned. The pending flag — not the sentinel error
-        // — is the reliable signal, because tool/prompt/resource wrappers fold
+        // what the handler returned. The pending flag -- not the sentinel error
+        // -- is the reliable signal, because tool/prompt/resource wrappers fold
         // a handler `Err` into an in-band error result before we see it.
         #[cfg(feature = "proto-2026-07-28-rc")]
         let mut cache_final = false;
@@ -1380,7 +1380,7 @@ impl App {
 
         // RC task-elicit resume: an answer to a suspended task `ctx.elicit` is
         // correlated by the server-generated task id (the bare response id),
-        // *not* the session — the stateless transport mints a fresh session per
+        // *not* the session -- the stateless transport mints a fresh session per
         // POST, so the session-keyed request queue could never match the
         // suspend round. Try delivering to a parked task first; `provide_input`
         // hands the response back when no task elicit is waiting, so non-task
@@ -1526,7 +1526,7 @@ fn seed_mrtr_ctx(
         // `inputResponses` are answers to inputs the server requested in a
         // prior round; that request set lives in the encrypted `requestState`.
         // Without a verified state there is nothing to bind them to, so accept
-        // only solicited, non-duplicate keys — otherwise a client could
+        // only solicited, non-duplicate keys -- otherwise a client could
         // pre-seed answers for a later `ctx.elicit` key (skipping the intended
         // `InputRequiredResult`) or overwrite an already-resolved answer.
         let Some(requested) = requested.as_ref() else {
@@ -1628,7 +1628,7 @@ fn build_input_required(
 /// A protocol-level failure (`Err`, or an `Ok(Response::Err(..))`) is excluded
 /// by construction. Crucially, so is an *in-band* tool error: tool/prompt
 /// wrappers fold a handler `Err` into `Ok(CallToolResponse { isError: true })`,
-/// so a plain `resp.is_ok()` check would still run commits on a failed call —
+/// so a plain `resp.is_ok()` check would still run commits on a failed call --
 /// applying irreversible side effects (DB writes, charges) registered via
 /// `ctx.on_commit(..)` even though the tool ultimately reported failure.
 #[cfg(feature = "proto-2026-07-28-rc")]
@@ -1657,7 +1657,7 @@ mod tests {
         assert_eq!(app.options.max_state_bytes(), 4096);
     }
 
-    /// Deferred MRTR commits must run only for a genuine success — never for a
+    /// Deferred MRTR commits must run only for a genuine success -- never for a
     /// protocol-level error nor for an in-band tool error (`isError: true`),
     /// which tool wrappers fold a handler `Err` into.
     #[cfg(feature = "proto-2026-07-28-rc")]
@@ -1669,29 +1669,29 @@ mod tests {
 
         let id = RequestId::Number(1);
 
-        // Genuine success → commit.
+        // Genuine success -> commit.
         let ok = Ok(Response::success(
             id.clone(),
             json!({ "content": [], "isError": false }),
         ));
         assert!(super::mrtr_should_commit(&ok));
 
-        // Success with no `isError` field at all (e.g. a non-tool result) → commit.
+        // Success with no `isError` field at all (e.g. a non-tool result) -> commit.
         let plain = Ok(Response::success(id.clone(), json!({ "ok": true })));
         assert!(super::mrtr_should_commit(&plain));
 
-        // In-band tool error folded into Ok → do NOT commit.
+        // In-band tool error folded into Ok -> do NOT commit.
         let tool_err = Ok(Response::success(
             id.clone(),
             json!({ "content": [], "isError": true }),
         ));
         assert!(!super::mrtr_should_commit(&tool_err));
 
-        // Protocol-level error response → do NOT commit.
+        // Protocol-level error response -> do NOT commit.
         let proto_err = Ok(Response::error(id.clone(), Error::new(-32603, "boom")));
         assert!(!super::mrtr_should_commit(&proto_err));
 
-        // Handler `Err` → do NOT commit.
+        // Handler `Err` -> do NOT commit.
         let hard_err: Result<Response, Error> = Err(Error::new(-32603, "boom"));
         assert!(!super::mrtr_should_commit(&hard_err));
     }
@@ -1775,7 +1775,7 @@ mod tests {
         }
 
         /// Builds the `_meta` JSON with the given request state (if any) and
-        /// `inputResponses` map of key → accepted [`ElicitResult`].
+        /// `inputResponses` map of key -> accepted [`ElicitResult`].
         fn request_with_responses(state: Option<&str>, response_keys: &[&str]) -> Request {
             use crate::types::elicitation::ElicitResult;
             let responses: serde_json::Map<String, serde_json::Value> = response_keys
@@ -1899,7 +1899,7 @@ mod tests {
         .expect("non-empty batch must be constructable");
 
         // Replicate the filter logic from execute_batch:
-        // Request → Some(response slot), Notification/Response → None
+        // Request -> Some(response slot), Notification/Response -> None
         let response_slots: Vec<MessageEnvelope> = batch
             .into_iter()
             .filter_map(|envelope| match envelope {

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -920,7 +920,19 @@ impl App {
 
     #[cfg(feature = "tracing")]
     async fn tracing_middleware(ctx: MwContext, next: Next) -> Response {
+        #[cfg(not(feature = "proto-2026-07-28-rc"))]
         let span = create_tracing_span(ctx.session_id().cloned());
+        // RC: the request-scoped logging level rides on the originating
+        // request's `_meta`. Stamp it onto the span so the notification layer
+        // can decide which `notifications/message` to deliver for this request.
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        let span = {
+            let log_level = ctx
+                .request()
+                .and_then(|req| req.meta())
+                .and_then(|meta| meta.log_level);
+            create_tracing_span(ctx.session_id().cloned(), log_level)
+        };
         next(ctx).instrument(span).await
     }
 
@@ -1421,7 +1433,6 @@ impl App {
                     runtime.options().cancel_request(&params.request_id);
                 }
             }
-            #[cfg(not(feature = "proto-2026-07-28-rc"))]
             crate::types::notification::commands::MESSAGE => {
                 #[cfg(feature = "tracing")]
                 notification.write();
@@ -1436,12 +1447,35 @@ impl App {
     }
 }
 
-#[cfg(feature = "tracing")]
+#[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
 fn create_tracing_span(session_id: Option<uuid::Uuid>) -> tracing::Span {
     if let Some(mcp_session_id) = session_id {
         tracing::info_span!("request", mcp_session_id = mcp_session_id.to_string())
     } else {
         tracing::info_span!("request")
+    }
+}
+
+/// Builds the per-request tracing span, carrying the session id and (RC) the
+/// request-scoped logging level as span fields the notification layer reads.
+#[cfg(all(feature = "tracing", feature = "proto-2026-07-28-rc"))]
+fn create_tracing_span(
+    session_id: Option<uuid::Uuid>,
+    log_level: Option<crate::types::notification::LoggingLevel>,
+) -> tracing::Span {
+    match (session_id, log_level) {
+        (Some(sid), Some(level)) => tracing::info_span!(
+            "request",
+            mcp_session_id = sid.to_string(),
+            mcp_log_level = u64::from(level.severity())
+        ),
+        (Some(sid), None) => {
+            tracing::info_span!("request", mcp_session_id = sid.to_string())
+        }
+        (None, Some(level)) => {
+            tracing::info_span!("request", mcp_log_level = u64::from(level.severity()))
+        }
+        (None, None) => tracing::info_span!("request"),
     }
 }
 

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -1500,35 +1500,47 @@ impl Drop for RequestSinkGuard {
     }
 }
 
+/// Builds the per-request tracing span carrying the session id.
+///
+/// See the RC variant below for why the span is created at `ERROR`.
 #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
 fn create_tracing_span(session_id: Option<uuid::Uuid>) -> tracing::Span {
     if let Some(mcp_session_id) = session_id {
-        tracing::info_span!("request", mcp_session_id = mcp_session_id.to_string())
+        tracing::error_span!("request", mcp_session_id = mcp_session_id.to_string())
     } else {
-        tracing::info_span!("request")
+        tracing::error_span!("request")
     }
 }
 
 /// Builds the per-request tracing span, carrying the session id and (RC) the
 /// request-scoped logging level as span fields the notification layer reads.
+///
+/// The span is created at `ERROR` -- the highest level -- so it is not itself
+/// filtered out. It carries no message: it exists only to route and filter the
+/// events emitted inside it. At a lower level a common global threshold (say
+/// `LevelFilter::WARN`) would disable the span while still letting WARN/ERROR
+/// events through, leaving those events with no `mcp_session_id` to route by and
+/// no `mcp_log_level` to filter against -- request-scoped logging would silently
+/// stop working. `ERROR` keeps the context observable for every event that the
+/// application's own threshold admits.
 #[cfg(all(feature = "tracing", feature = "proto-2026-07-28-rc"))]
 fn create_tracing_span(
     session_id: Option<uuid::Uuid>,
     log_level: Option<crate::types::notification::LoggingLevel>,
 ) -> tracing::Span {
     match (session_id, log_level) {
-        (Some(sid), Some(level)) => tracing::info_span!(
+        (Some(sid), Some(level)) => tracing::error_span!(
             "request",
             mcp_session_id = sid.to_string(),
             mcp_log_level = u64::from(level.severity())
         ),
         (Some(sid), None) => {
-            tracing::info_span!("request", mcp_session_id = sid.to_string())
+            tracing::error_span!("request", mcp_session_id = sid.to_string())
         }
         (None, Some(level)) => {
-            tracing::info_span!("request", mcp_log_level = u64::from(level.severity()))
+            tracing::error_span!("request", mcp_log_level = u64::from(level.severity()))
         }
-        (None, None) => tracing::info_span!("request"),
+        (None, None) => tracing::error_span!("request"),
     }
 }
 
@@ -1742,6 +1754,32 @@ mod tests {
     fn with_max_state_bytes_sets_the_option() {
         let app = App::new().with_max_state_bytes(4096);
         assert_eq!(app.options.max_state_bytes(), 4096);
+    }
+
+    /// The request span carries the routing and filtering context for every
+    /// event emitted while handling a request, so a common global threshold
+    /// (`LevelFilter::WARN`) must not disable it: WARN/ERROR events stay enabled
+    /// and would otherwise lose their `mcp_session_id` and `mcp_log_level`.
+    #[cfg(all(feature = "tracing", feature = "proto-2026-07-28-rc"))]
+    #[test]
+    fn request_span_survives_a_warning_only_filter() {
+        use crate::types::notification::LoggingLevel;
+        use tracing_subscriber::prelude::*;
+
+        let subscriber =
+            tracing_subscriber::registry().with(tracing::level_filters::LevelFilter::WARN);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span =
+                super::create_tracing_span(Some(uuid::Uuid::new_v4()), Some(LoggingLevel::Warning));
+            assert!(
+                !span.is_disabled(),
+                "the request span must stay enabled under a warning-only filter"
+            );
+            // The contrast: an INFO span -- what this used to be -- is dropped,
+            // taking the request context with it.
+            assert!(tracing::info_span!("request").is_disabled());
+        });
     }
 
     /// Deferred MRTR commits must run only for a genuine success -- never for a

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -943,6 +943,16 @@ impl App {
 
     #[inline]
     async fn execute(msg: Message, runtime: ServerRuntime) {
+        // Closing the request notification sink here -- once the *whole*
+        // middleware pipeline has run -- is what lets a request-scoped SSE POST
+        // response know no more notifications are coming, so logs emitted by
+        // user middleware after `next(ctx)` still make it onto the stream.
+        #[cfg(all(
+            feature = "proto-2026-07-28-rc",
+            feature = "tracing",
+            feature = "http-server"
+        ))]
+        let _sink_guard = RequestSinkGuard(msg.session_id().copied());
         runtime.execute(msg).await;
     }
 
@@ -957,6 +967,16 @@ impl App {
         // role/permission guards, SSE routing) sees the original HTTP context.
         let batch_id = batch.id.clone();
         let batch_session_id = batch.session_id;
+        // One guard for the whole batch (inner requests run through
+        // `ServerRuntime::execute`, so they never close the shared sink early):
+        // the request-scoped SSE response stays open until every inner request
+        // and its middleware have finished. See `App::execute`.
+        #[cfg(all(
+            feature = "proto-2026-07-28-rc",
+            feature = "tracing",
+            feature = "http-server"
+        ))]
+        let _sink_guard = RequestSinkGuard(batch_session_id);
         #[cfg(feature = "http-server")]
         let batch_headers = batch.headers.clone();
         #[cfg(feature = "http-server")]
@@ -1449,6 +1469,34 @@ impl App {
     #[inline]
     fn wait_for_shutdown_signal(&mut self, token: CancellationToken) {
         shared::wait_for_shutdown_signal(token);
+    }
+}
+
+/// Closes the per-request notification sink for a stateless HTTP `POST` when the
+/// message's whole middleware pipeline is done (including on panic or task
+/// cancellation, hence a `Drop` guard rather than a plain call).
+///
+/// Dropping the sender is the completion signal a request-scoped SSE `POST`
+/// response waits for: only then does it know every notification -- including
+/// ones user middleware emitted after `next(ctx)` -- has been queued, so it can
+/// drain them and close with the final response.
+#[cfg(all(
+    feature = "proto-2026-07-28-rc",
+    feature = "tracing",
+    feature = "http-server"
+))]
+struct RequestSinkGuard(Option<uuid::Uuid>);
+
+#[cfg(all(
+    feature = "proto-2026-07-28-rc",
+    feature = "tracing",
+    feature = "http-server"
+))]
+impl Drop for RequestSinkGuard {
+    fn drop(&mut self) {
+        if let Some(id) = self.0 {
+            crate::types::notification::fmt::unregister_request_sink(&id);
+        }
     }
 }
 

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -278,9 +278,14 @@ impl App {
             );
         }
 
+        // The request tracing span must wrap the whole composed pipeline -- user
+        // `wrap` middleware included -- so log events they emit around
+        // `next(ctx)` stay inside the span and see the request-scoped level.
+        // Prepending makes it the outermost layer; the terminal dispatcher
+        // (`message_middleware`) stays innermost.
         #[cfg(feature = "tracing")]
         self.options
-            .add_middleware(make_mw(Self::tracing_middleware));
+            .add_middleware_front(make_mw(Self::tracing_middleware));
         self.options
             .add_middleware(make_mw(Self::message_middleware));
 

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -24,9 +24,9 @@ use crate::{
         resource::SubscribeRequestParams,
     },
 };
-// `RequestId` is only referenced by the server→client request paths (non-RC
+// `RequestId` is only referenced by the server->client request paths (non-RC
 // elicitation/sampling) and the task API; under the stateless RC build without
-// tasks it is unused — including in tests, whose `RequestId` uses live in
+// tasks it is unused -- including in tests, whose `RequestId` uses live in
 // modules carrying those very same gates.
 #[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "tasks"))]
 use crate::types::RequestId;
@@ -76,7 +76,7 @@ pub(crate) struct MrtrCtx {
     /// `requestState`, merged with this round's `inputResponses`).
     ///
     /// Raw [`serde_json::Value`]s: the result type depends on which kind of
-    /// input was requested, so each helper deserializes its own — the same
+    /// input was requested, so each helper deserializes its own -- the same
     /// arrangement [`Context::memo`] uses.
     pub(crate) answers: std::collections::HashMap<String, serde_json::Value>,
 
@@ -116,8 +116,8 @@ impl MrtrCtx {
     /// Returns the cached answer for `key`, or records the request and returns
     /// the MRTR "input required" sentinel error to unwind the handler.
     ///
-    /// The answer is stored raw, so it is deserialized into `T` — the result
-    /// type the requested kind implies — on the replay round. A stored answer
+    /// The answer is stored raw, so it is deserialized into `T` -- the result
+    /// type the requested kind implies -- on the replay round. A stored answer
     /// that does not fit `T` means the client answered the right key with the
     /// wrong kind of result, which is a protocol violation rather than a
     /// reason to re-ask (re-asking would loop).
@@ -196,7 +196,7 @@ pub(crate) enum ExecMode {
 
     /// Stateful task-augmented call: the tool runs in a background future that
     /// genuinely suspends on the task tracker. Carries no MRTR key /
-    /// `requestState` / replay log — the task tracker is the held state.
+    /// `requestState` / replay log -- the task tracker is the held state.
     #[cfg(feature = "tasks")]
     Task(Arc<TaskExec>),
 }
@@ -204,7 +204,7 @@ pub(crate) enum ExecMode {
 /// Per-dispatch state for a background, task-augmented tool call
 /// (`proto-2026-07-28-rc` + `tasks`): just the task id (also the
 /// session-independent resume key) and whether the tool's task support is
-/// `Required`. No MRTR key, `requestState`, or replay log — tasks run on the
+/// `Required`. No MRTR key, `requestState`, or replay log -- tasks run on the
 /// stateful substrate, not MRTR, so the MRTR effect helpers do not apply here.
 #[cfg(all(feature = "proto-2026-07-28-rc", feature = "tasks"))]
 #[derive(Default)]
@@ -230,7 +230,7 @@ impl TaskExec {
 ///
 /// Obtained via [`Context::task`]; mirrors the client's `Client::task()` builder.
 /// Its methods operate on the stateful task substrate (suspend/resume) and error
-/// when the current dispatch is not task-augmented — keeping the task and MRTR
+/// when the current dispatch is not task-augmented -- keeping the task and MRTR
 /// substrates explicitly separate.
 #[cfg(all(feature = "proto-2026-07-28-rc", feature = "tasks"))]
 #[derive(Debug)]
@@ -307,7 +307,7 @@ pub struct Context {
     /// Type-erased JWT/auth claims of the current request.
     ///
     /// Inserted by the HTTP engine. Any type implementing [`Claims`]
-    /// works — neva's `DefaultClaims`, or a custom claims struct from a
+    /// works -- neva's `DefaultClaims`, or a custom claims struct from a
     /// custom engine adapter.
     #[cfg(feature = "http-server")]
     pub(crate) claims: Option<Arc<dyn Claims>>,
@@ -317,7 +317,7 @@ pub struct Context {
 
     /// Represents a queue of pending requests
     ///
-    /// Only read by [`Context::send_request`] (server→client requests), which
+    /// Only read by [`Context::send_request`] (server->client requests), which
     /// the stateless RC build does not use.
     #[cfg_attr(feature = "proto-2026-07-28-rc", allow(dead_code))]
     pending: RequestQueue,
@@ -796,7 +796,7 @@ impl Context {
                     let task_id = task.id.clone();
 
                     // The tool runs in this spawned task on the *stateful* task
-                    // substrate — not MRTR. Under the RC it gets a `Task`
+                    // substrate -- not MRTR. Under the RC it gets a `Task`
                     // execution context (no MRTR key / `requestState`): elicitation
                     // goes through `ctx.task().elicit(...)`, which suspends on the
                     // task tracker (resumed by a client answer keyed by the task
@@ -1000,7 +1000,7 @@ impl Context {
     /// [`ElicitResult`].
     ///
     /// **Important:** code before an `elicit` point re-executes on every
-    /// round-trip — keep it side-effect-free.
+    /// round-trip -- keep it side-effect-free.
     ///
     /// # Example
     /// ```no_run
@@ -1025,7 +1025,7 @@ impl Context {
     ) -> Result<ElicitResult, Error> {
         // `ctx.elicit` is the *MRTR* (stateless re-run) entry point. A
         // task-augmented call runs on the stateful task substrate and must use
-        // the explicit `ctx.task().elicit(...)` builder instead — the two never
+        // the explicit `ctx.task().elicit(...)` builder instead -- the two never
         // mix (see [`ExecMode`]).
         match &self.exec {
             ExecMode::Mrtr(mrtr) => mrtr.resolve(
@@ -1051,14 +1051,14 @@ impl Context {
     /// handler unwinds; when the client retries with the result, the handler
     /// re-runs and this returns the cached [`CreateMessageResult`](crate::types::sampling::CreateMessageResult).
     ///
-    /// **Important:** code before this point re-executes on every round-trip —
+    /// **Important:** code before this point re-executes on every round-trip --
     /// keep it side-effect-free, or guard it with [`Self::once`] /
     /// [`Self::memo`] / [`Self::on_commit`], which work here exactly as they do
     /// for elicitation.
     ///
     /// # Deprecated on arrival
-    /// MCP 2026-07-28 removed sampling as a capability-driven server→client
-    /// request and re-homed the *ability* onto MRTR — already on its
+    /// MCP 2026-07-28 removed sampling as a capability-driven server->client
+    /// request and re-homed the *ability* onto MRTR -- already on its
     /// deprecation path (a 12-month lifecycle shared with roots and logging).
     /// It exists for migration; prefer tools that do not need the client's
     /// model.
@@ -1099,7 +1099,7 @@ impl Context {
     /// Asks the client which filesystem roots it exposes (MRTR,
     /// `proto-2026-07-28-rc`).
     ///
-    /// Same re-run/replay semantics as [`Self::elicit`] — see [`Self::sample`]
+    /// Same re-run/replay semantics as [`Self::elicit`] -- see [`Self::sample`]
     /// for the round-trip caveat.
     ///
     /// # Deprecated on arrival
@@ -1215,7 +1215,7 @@ impl Context {
 
     /// Suspends a task-augmented elicit until the client posts an answer.
     ///
-    /// Parks a resume slot keyed by the **task id** (not the session — the
+    /// Parks a resume slot keyed by the **task id** (not the session -- the
     /// stateless transport mints a fresh session per POST), exposes the prompt
     /// via `tasks/result`, and flips the task to `input_required`. The live
     /// background future then awaits the answer, which the dispatch layer routes
@@ -1265,7 +1265,7 @@ impl Context {
     ///
     /// # Durability
     /// The effect runs *before* the `requestState` recording it is durably
-    /// acknowledged by the client — it is at-most-once within a single
+    /// acknowledged by the client -- it is at-most-once within a single
     /// `requestState` chain, **not** globally exactly-once. For non-idempotent
     /// side effects, pass a stable idempotency key to the downstream system.
     ///
@@ -1294,7 +1294,7 @@ impl Context {
                 Ok(true)
             }
             // `once` is an MRTR helper (it dedups across re-runs). A required-task
-            // tool never re-runs, so using it there is a mistake — reject it.
+            // tool never re-runs, so using it there is a mistake -- reject it.
             #[cfg(feature = "tasks")]
             ExecMode::Task(task) if task.required => Err(Error::new(
                 ErrorCode::InvalidRequest,
@@ -1346,14 +1346,14 @@ impl Context {
                 Ok(value)
             }
             // `memo` is an MRTR helper (it caches across re-runs). A required-task
-            // tool never re-runs, so using it there is a mistake — reject it.
+            // tool never re-runs, so using it there is a mistake -- reject it.
             #[cfg(feature = "tasks")]
             ExecMode::Task(task) if task.required => Err(Error::new(
                 ErrorCode::InvalidRequest,
                 "ctx.memo is an MRTR helper and is not available in a required-task tool; compute the value inline",
             )),
             // Optional-task / None: no re-run, so there is nothing to cache
-            // against — just compute the value.
+            // against -- just compute the value.
             _ => {
                 let _ = key;
                 compute.await
@@ -1370,20 +1370,20 @@ impl Context {
     ///
     /// Commits run whenever the tool returns a success response.
     /// If your tool encodes failure in content rather than returning `Err` or
-    /// setting `isError: true`, commits will still run — return `Err`
+    /// setting `isError: true`, commits will still run -- return `Err`
     /// (folded into `isError: true` by the wrapper) or set the flag explicitly
     /// to suppress them.
     ///
     /// The future is stored in the shared dispatch state, so it must be
-    /// `Send + 'static` — capture by `move`. This is an **MRTR-only** helper:
+    /// `Send + 'static` -- capture by `move`. This is an **MRTR-only** helper:
     /// a task runs on the stateful substrate and never re-runs, so in a
     /// task-augmented call `on_commit` is ignored (run the effect inline
-    /// instead) — it warns for a `Required` tool and logs at `debug` for an
+    /// instead) -- it warns for a `Required` tool and logs at `debug` for an
     /// `Optional` one. Called outside an elicitable dispatch, it is a no-op.
     ///
     /// # Durability
     /// "Exactly once" means once per successfully-completed flow, not globally
-    /// idempotent — a client that abandons and restarts the flow runs it again.
+    /// idempotent -- a client that abandons and restarts the flow runs it again.
     ///
     /// # Example
     /// ```no_run
@@ -1617,8 +1617,8 @@ impl Context {
 
     /// Sends a [`Request`] to a client
     ///
-    /// Server→client requests (non-RC elicitation/sampling/roots and the task
-    /// API). The stateless RC transport has no out-of-band server→client
+    /// Server->client requests (non-RC elicitation/sampling/roots and the task
+    /// API). The stateless RC transport has no out-of-band server->client
     /// channel, so this is unused there.
     #[inline]
     #[cfg_attr(feature = "proto-2026-07-28-rc", allow(dead_code))]
@@ -1654,7 +1654,7 @@ impl Context {
     /// Sends a notification to a client.
     ///
     /// Under the stateless `proto-2026-07-28-rc` transport there is no
-    /// out-of-band server→client channel, so this is a no-op: progress,
+    /// out-of-band server->client channel, so this is a no-op: progress,
     /// list-changed, resource-updated, task-status and elicitation
     /// notifications are inert and clients poll instead.
     #[inline]
@@ -1667,10 +1667,10 @@ impl Context {
     ) -> Result<(), Error> {
         #[cfg(feature = "proto-2026-07-28-rc")]
         {
-            // No out-of-band server→client channel on the stateless transport,
+            // No out-of-band server->client channel on the stateless transport,
             // so this is an intentional no-op. Surface it once at debug so a
             // server author who calls e.g. `resource_updated`/`add_tool` and
-            // expects a push isn't silently misled — the masked capabilities
+            // expects a push isn't silently misled -- the masked capabilities
             // already tell clients to poll instead.
             #[cfg(feature = "tracing")]
             tracing::debug!(
@@ -1835,7 +1835,7 @@ mod mrtr_tests {
         assert!(mrtr.pending.lock().unwrap().is_some());
     }
 
-    /// Every kind replays through the same slot — only the result type differs.
+    /// Every kind replays through the same slot -- only the result type differs.
     #[test]
     fn resolve_replays_each_input_kind_as_its_own_result_type() {
         use crate::types::mrtr::InputRequest;

--- a/neva/src/app/mrtr_store.rs
+++ b/neva/src/app/mrtr_store.rs
@@ -8,9 +8,9 @@
 //! any server-side state. There is one gap that the signed state structurally
 //! cannot close: the **final** round mints no new state, so if its HTTP
 //! response is lost and the client retries the same `requestState` +
-//! `inputResponses`, the handler — and any
+//! `inputResponses`, the handler -- and any
 //! [`Context::on_commit`](crate::Context::on_commit) commits or post-elicit
-//! `once`/`memo` effects — would run a second time.
+//! `once`/`memo` effects -- would run a second time.
 //!
 //! This module's [`RequestStateStore`] closes that gap by caching the final
 //! response of a committed round, keyed by the incoming state's sealed segment
@@ -18,7 +18,7 @@
 //! echoes the same blob and answers (same key), so the cached response is
 //! returned verbatim and the handler never re-executes.
 //!
-//! The protocol does not mandate any of this — final-round deduplication is
+//! The protocol does not mandate any of this -- final-round deduplication is
 //! left to the implementation, and an SDK may reasonably leave it to the
 //! application author. neva ships it on by default, so a tool that charges a
 //! card or sends a receipt is safe to write in the obvious way. See the
@@ -27,7 +27,7 @@
 //!
 //! The default [`InMemoryStateStore`] is per-process. A multi-instance
 //! deployment should supply a shared implementation (e.g. Redis) via
-//! [`App::with_request_state_store`](crate::App::with_request_state_store) — for
+//! [`App::with_request_state_store`](crate::App::with_request_state_store) -- for
 //! the same reason such a deployment must share the MRTR secret (a retry routed
 //! to a different instance must see the same committed state).
 
@@ -65,7 +65,7 @@ pub trait RequestStateStore: Send + Sync {
     /// and re-sent while the first round is still executing) can both miss
     /// [`get`](Self::get) before either reaches [`put`](Self::put), so both
     /// re-run the handler and re-drain its
-    /// [`on_commit`](crate::Context::on_commit) effects — duplicating side
+    /// [`on_commit`](crate::Context::on_commit) effects -- duplicating side
     /// effects such as charges. Holding a per-`tag` reservation across the whole
     /// section serialises them: the loser blocks until the winner has committed,
     /// then sees the cached response on its own [`get`](Self::get) and never
@@ -88,11 +88,11 @@ pub trait RequestStateStore: Send + Sync {
 /// The default per-process [`RequestStateStore`], backed by a concurrent map
 /// with lazy TTL eviction (`proto-2026-07-28-rc`).
 ///
-/// Entries are bounded by their TTL (the state's `exp`, ≤ the configured
+/// Entries are bounded by their TTL (the state's `exp`, <= the configured
 /// `requestState` TTL, 300s by default) and evicted opportunistically on access,
 /// so the map's footprint tracks the number of in-flight MRTR flows. Each
 /// [`put`](Self::put) sweeps expired entries (and released reservation locks),
-/// which is `O(n)` in the live set — fine for single-instance and development,
+/// which is `O(n)` in the live set -- fine for single-instance and development,
 /// but high-QPS deployments should provide a shared store with background
 /// eviction instead (see the [module docs](self)).
 #[derive(Debug, Default)]
@@ -134,7 +134,7 @@ impl RequestStateStore for InMemoryStateStore {
             let now = now_secs();
             // Opportunistically drop expired entries so the map stays bounded.
             self.entries.retain(|_, (_, e)| *e > now);
-            // Drop reservation locks no task holds or awaits — only the map's
+            // Drop reservation locks no task holds or awaits -- only the map's
             // own reference remains (`strong_count == 1`). The tag committing
             // here is still held by the live guard (`>= 2`), so it survives.
             self.locks.retain(|_, m| Arc::strong_count(m) > 1);

--- a/neva/src/app/options.rs
+++ b/neva/src/app/options.rs
@@ -607,7 +607,7 @@ impl McpOptions {
         let mut cap = self.tools_capability.clone();
         // The stateless `proto-2026-07-28-rc` transport cannot push
         // `notifications/tools/list_changed`, so never advertise `listChanged`
-        // under RC — clients refresh on cache-TTL / the next `tools/list`
+        // under RC -- clients refresh on cache-TTL / the next `tools/list`
         // instead of relying on a push that will never arrive.
         #[cfg(feature = "proto-2026-07-28-rc")]
         if let Some(c) = cap.as_mut() {
@@ -643,7 +643,7 @@ impl McpOptions {
         let mut cap = self.prompts_capability.clone();
         // The stateless `proto-2026-07-28-rc` transport cannot push
         // `notifications/prompts/list_changed`, so never advertise `listChanged`
-        // under RC — see `tools_capability` for the rationale.
+        // under RC -- see `tools_capability` for the rationale.
         #[cfg(feature = "proto-2026-07-28-rc")]
         if let Some(c) = cap.as_mut() {
             c.list_changed = false;

--- a/neva/src/app/options.rs
+++ b/neva/src/app/options.rs
@@ -514,6 +514,15 @@ impl McpOptions {
             .add(middleware);
     }
 
+    /// Registers a middleware as the outermost layer of the pipeline.
+    #[inline]
+    #[cfg(feature = "tracing")]
+    pub(crate) fn add_middleware_front(&mut self, middleware: Middleware) {
+        self.middlewares
+            .get_or_insert_with(Middlewares::new)
+            .add_front(middleware);
+    }
+
     /// Returns a Model Context Protocol version that this server supports
     #[inline]
     pub(crate) fn protocol_ver(&self) -> &'static str {

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -118,7 +118,7 @@ impl Client {
     /// # }
     /// ```
     #[deprecated(
-        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR — see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
+        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR -- see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
     )]
     #[allow(deprecated)]
     pub fn add_root(&mut self, uri: impl Into<Uri>, name: impl Into<String>) -> &mut Self {
@@ -145,7 +145,7 @@ impl Client {
     /// # }
     /// ```
     #[deprecated(
-        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR — see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
+        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR -- see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
     )]
     #[allow(deprecated)]
     pub fn add_roots<T, I>(&mut self, roots: I) -> &mut Self
@@ -160,7 +160,7 @@ impl Client {
 
     /// Sends the "notifications/roots/list_changed" notification to the server
     #[deprecated(
-        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR — see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
+        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR -- see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
     )]
     pub fn publish_roots_changed(&mut self) {
         if let Some(handler) = self.handler.as_mut() {
@@ -171,7 +171,7 @@ impl Client {
 
     /// Registers a handler that will be running when a "sampling/createMessage" request is received
     #[deprecated(
-        note = "Sampling is deprecated in MCP 2026-07-28: the capability-driven `sampling/createMessage` request is gone and the ability is re-homed onto MRTR — see `Context::sample`. Under the RC this handler fulfils MRTR `sampling/createMessage` input requests."
+        note = "Sampling is deprecated in MCP 2026-07-28: the capability-driven `sampling/createMessage` request is gone and the ability is re-homed onto MRTR -- see `Context::sample`. Under the RC this handler fulfils MRTR `sampling/createMessage` input requests."
     )]
     pub fn map_sampling<F, R>(&mut self, handler: F) -> &mut Self
     where
@@ -263,7 +263,7 @@ impl Client {
     ///
     /// Under the RC flag the RC expectation is pinned to
     /// [`crate::RC_PROTOCOL_VERSION`]: a `with_mcp_version` override only
-    /// selects which legacy version the dual-mode fallback negotiates —
+    /// selects which legacy version the dual-mode fallback negotiates --
     /// it must never make `server/discover` reject a valid RC server.
     fn expected_protocol_ver(&self) -> &'static str {
         #[cfg(feature = "proto-2026-07-28-rc")]
@@ -314,7 +314,7 @@ impl Client {
     async fn legacy_init(&mut self) -> Result<(), Error> {
         #[cfg(not(feature = "proto-2026-07-28-rc"))]
         let protocol_ver = self.options.protocol_ver().to_string();
-        // The fallback negotiates the newest pre-RC version — offering
+        // The fallback negotiates the newest pre-RC version -- offering
         // the RC version to a server that just rejected `server/discover`
         // would only get refused again.
         #[cfg(feature = "proto-2026-07-28-rc")]
@@ -357,7 +357,7 @@ impl Client {
     /// Discovers server capabilities via `server/discover` (MCP 2026-07-28 RC).
     ///
     /// Replaces the `initialize`/`initialized` handshake. No `initialized`
-    /// notification is sent — the transport is stateless.
+    /// notification is sent -- the transport is stateless.
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub async fn discover(&mut self) -> Result<(), Error> {
         let resp = self.send_request(Self::discover_request()).await?;
@@ -388,13 +388,13 @@ impl Client {
     /// The dual-mode handshake (issue #84): tries `server/discover`
     /// first and, when the server clearly doesn't speak the RC protocol,
     /// falls back to the legacy `initialize` handshake and marks the
-    /// peer as legacy — subsequent traffic uses legacy semantics
+    /// peer as legacy -- subsequent traffic uses legacy semantics
     /// (session header, SSE stream, no MRTR, no RC routing headers).
     ///
     /// Only **wire-phase** failures classify for the fallback: transport
     /// errors and the server's JSON-RPC *error* reply. Once the server
     /// answers `server/discover` successfully, the peer has committed to
-    /// the RC protocol — later local failures (a malformed result, an
+    /// the RC protocol -- later local failures (a malformed result, an
     /// unsupported/mismatched `protocolVersion`) surface as real errors
     /// instead of a misleading fallback attempt on a transport that
     /// version validation may already have cancelled.
@@ -986,7 +986,7 @@ impl Client {
     /// An RC peer advertises tasks through
     /// `capabilities.extensions["io.modelcontextprotocol/tasks"]`; a
     /// legacy peer reached via the dual-mode fallback advertises the
-    /// top-level `tasks` field of its `initialize` result — both must
+    /// top-level `tasks` field of its `initialize` result -- both must
     /// resolve, or task-augmented calls report no support after a
     /// fallback.
     #[cfg(all(feature = "tasks", feature = "proto-2026-07-28-rc"))]
@@ -1059,7 +1059,7 @@ impl Client {
     async fn send_request(&mut self, req: Request) -> Result<Response, Error> {
         #[cfg(feature = "proto-2026-07-28-rc")]
         {
-            // A legacy peer (dual-mode fallback) never speaks MRTR — its
+            // A legacy peer (dual-mode fallback) never speaks MRTR -- its
             // requests take the plain path, elicitation rides the legacy
             // server-push channel instead.
             if self.is_legacy_peer() {
@@ -1162,8 +1162,8 @@ impl Client {
         let mut meta = req.meta().unwrap_or_default();
         meta.client_info = Some(self.options.implementation.clone());
         // Each flag reflects what this client can actually fulfil right now: a
-        // configured handler for elicitation/sampling, and — since roots are
-        // data rather than a handler — a declared roots capability. That is
+        // configured handler for elicitation/sampling, and -- since roots are
+        // data rather than a handler -- a declared roots capability. That is
         // either an explicit `with_roots(..)` or simply having roots, and it
         // deliberately stays true for an empty list: an empty
         // `ListRootsResult` is a valid answer, so a client that opted in must
@@ -1195,7 +1195,7 @@ impl Client {
     /// Applies the initial per-request RC client metadata (`clientInfo` /
     /// `clientCapabilities`, plus trace context) to every [`Request`] in a
     /// batch. The MRTR re-run fields (`inputResponses` / `requestState`) stay
-    /// `None` here — they are filled per request on each retry round by
+    /// `None` here -- they are filled per request on each retry round by
     /// [`Self::run_batch_with_mrtr`]. Notifications are left untouched.
     #[cfg(feature = "proto-2026-07-28-rc")]
     fn apply_client_meta_to_batch(&self, items: &mut [MessageEnvelope]) {
@@ -1209,7 +1209,7 @@ impl Client {
     /// Fulfils one server-requested input, whatever its kind, and returns the
     /// raw result to echo back under the request's key.
     ///
-    /// Sampling and roots are fulfilled here, on the MRTR loop — *not* as
+    /// Sampling and roots are fulfilled here, on the MRTR loop -- *not* as
     /// server-initiated pushes: under the RC there is no such channel. The
     /// client only ever gets asked for a kind it declared in
     /// [`ClientMrtrCapabilities`](crate::types::mrtr::ClientMrtrCapabilities),
@@ -1348,8 +1348,8 @@ impl Client {
 
     /// Drives the MRTR retry loop across an entire batch.
     ///
-    /// Each batched [`Request`] that elicits — the server replies with an
-    /// `input_required` result — is fulfilled via the configured elicitation
+    /// Each batched [`Request`] that elicits -- the server replies with an
+    /// `input_required` result -- is fulfilled via the configured elicitation
     /// handler and re-issued (carrying `inputResponses` + the echoed
     /// `requestState`) alongside any other still-eliciting requests, so the
     /// whole batch is driven to completion in lock-step rounds. One transport
@@ -1705,7 +1705,7 @@ async fn collect_batch_responses(
             tokio::select! {
                 biased;
                 // The transport died (or a shutdown signal cancelled it)
-                // — no response is coming for any receiver.
+                // -- no response is coming for any receiver.
                 _ = token.cancelled() => {
                     let _ = pending.pop(&id);
                     Err(Error::new(ErrorCode::InternalError, "Connection closed"))
@@ -1732,7 +1732,7 @@ async fn collect_batch_responses(
 }
 
 /// The error for an input kind the server asked for but this client has no
-/// fulfiller for — only reachable if the server ignored the declared
+/// fulfiller for -- only reachable if the server ignored the declared
 /// [`ClientMrtrCapabilities`](crate::types::mrtr::ClientMrtrCapabilities).
 #[cfg(feature = "proto-2026-07-28-rc")]
 fn no_fulfiller(kind: &str) -> Error {
@@ -1743,12 +1743,12 @@ fn no_fulfiller(kind: &str) -> Error {
 }
 
 /// Whether a `server/discover` failure means "this server doesn't speak
-/// the RC protocol" — the dual-mode fallback triggers only then.
+/// the RC protocol" -- the dual-mode fallback triggers only then.
 ///
-/// * `MethodNotFound` — a legacy server rejecting the unknown method
+/// * `MethodNotFound` -- a legacy server rejecting the unknown method
 ///   (neva's own legacy build answers exactly this);
-/// * `InvalidRequest` — strict servers rejecting the RC request shape;
-/// * `ParseError` — a non-JSON-RPC reply (an HTTP 4xx page) or an error
+/// * `InvalidRequest` -- strict servers rejecting the RC request shape;
+/// * `ParseError` -- a non-JSON-RPC reply (an HTTP 4xx page) or an error
 ///   code outside neva's `ErrorCode` set (e.g. the TS SDK's `-32000`
 ///   "server not initialized"), both of which surface as parse failures.
 ///
@@ -1836,7 +1836,7 @@ mod tests {
 
     /// A configured trace-context provider is invoked during RC metadata
     /// assembly, so `_meta.traceparent`/`tracestate` reach the wire alongside
-    /// `clientInfo` — for both single sends and (via the same path) batches.
+    /// `clientInfo` -- for both single sends and (via the same path) batches.
     #[cfg(feature = "proto-2026-07-28-rc")]
     #[test]
     fn apply_client_meta_injects_trace_context() {
@@ -1983,9 +1983,9 @@ mod dual_mode_tests {
     /// plain non-JSON-RPC 4xx page (framework routers, the TS SDK's
     /// "server not initialized" family); a future server answers
     /// *successfully* but with a `protocolVersion` this build does not
-    /// support — which must NOT trigger the fallback.
+    /// support -- which must NOT trigger the fallback.
     /// A protected endpoint answering `401` with a non-JSON body must not
-    /// trigger the fallback either — that is an authentication failure,
+    /// trigger the fallback either -- that is an authentication failure,
     /// not evidence of a legacy peer.
     #[derive(Clone, Copy)]
     enum DiscoverReply {
@@ -2231,7 +2231,7 @@ mod dual_mode_tests {
 
     /// A server that answers `server/discover` *successfully* but with a
     /// protocol version this build does not support has committed to the
-    /// RC path — the client must surface the real version error, not
+    /// RC path -- the client must surface the real version error, not
     /// mark the peer legacy and chase `initialize` on a cancelled
     /// transport.
     #[tokio::test(flavor = "multi_thread")]
@@ -2275,7 +2275,7 @@ mod dual_mode_tests {
 
     /// A protected RC endpoint replying `401` with a non-JSON body must
     /// surface the authentication failure, not be mistaken for a legacy
-    /// peer — otherwise the client silently drops the RC headers and
+    /// peer -- otherwise the client silently drops the RC headers and
     /// retries `initialize`, masking the real cause.
     #[tokio::test(flavor = "multi_thread")]
     async fn unauthorized_discover_does_not_fall_back() {
@@ -2388,7 +2388,7 @@ mod rc_roundtrip_tests {
         app.map_tool("echo", |name: String| async move { name });
         tokio::spawn(app.run());
 
-        // Wait until the server socket actually accepts connections —
+        // Wait until the server socket actually accepts connections --
         // a fixed sleep is not enough on loaded CI machines.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
         loop {
@@ -2416,7 +2416,7 @@ mod rc_roundtrip_tests {
 }
 
 /// After a dual-mode fallback, a legacy peer's top-level `tasks`
-/// capability must survive and resolve — an RC peer's extension form
+/// capability must survive and resolve -- an RC peer's extension form
 /// must keep working too.
 #[cfg(all(test, feature = "tasks", feature = "proto-2026-07-28-rc"))]
 mod fallback_tasks_capability_tests {

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1189,6 +1189,11 @@ impl Client {
             meta.tracestate = tc.tracestate;
         }
 
+        // Request-scoped logging level (replaces the removed `logging/setLevel`).
+        if self.options.log_level.is_some() {
+            meta.log_level = self.options.log_level;
+        }
+
         req.set_meta(meta);
     }
 

--- a/neva/src/client/batch.rs
+++ b/neva/src/client/batch.rs
@@ -12,8 +12,8 @@ use crate::{
 
 /// A fluent builder for constructing and sending a JSON-RPC 2.0 batch request.
 ///
-/// Obtain via [`Client::batch`]. Add requests with the provided methods —
-/// which mirror [`Client`]'s single-call API — then call [`BatchBuilder::send`].
+/// Obtain via [`Client::batch`]. Add requests with the provided methods --
+/// which mirror [`Client`]'s single-call API -- then call [`BatchBuilder::send`].
 ///
 /// # Example
 /// ```no_run

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -81,7 +81,7 @@ pub(super) struct RequestHandler {
     #[cfg(feature = "tasks")]
     tasks: Arc<TaskTracker>,
 
-    /// Which protocol generation the peer speaks (issue #84) — shared with
+    /// Which protocol generation the peer speaks (issue #84) -- shared with
     /// [`Client`](crate::client::Client), so the dual-mode fallback's flip
     /// is observed by the receive loop.
     #[cfg(feature = "proto-2026-07-28-rc")]
@@ -200,7 +200,7 @@ impl RequestHandler {
 
         tokio::select! {
             biased;
-            // The transport died (or a shutdown signal cancelled it) —
+            // The transport died (or a shutdown signal cancelled it) --
             // no response is coming; fail now rather than after the
             // full request timeout.
             _ = self.token.cancelled() => {
@@ -332,7 +332,7 @@ impl RequestHandler {
                         dispatch_notification(notification, &notification_handler).await;
                     }
                     Message::Batch(batch) => {
-                        // JSON-RPC 2.0 §6 allows either peer to send a batch
+                        // JSON-RPC 2.0 section 6 allows either peer to send a batch
                         // containing any mix of Requests, Notifications, and
                         // Responses.
                         //
@@ -348,8 +348,8 @@ impl RequestHandler {
                                 other => deferred.push(other),
                             }
                         }
-                        // JSON-RPC 2.0 §6: the response to a batch MUST be an
-                        // array — collect all per-request responses and send
+                        // JSON-RPC 2.0 section 6: the response to a batch MUST be an
+                        // array -- collect all per-request responses and send
                         // them back as one Message::Batch rather than as
                         // individual messages.
                         let responses = dispatch_batch_deferred(
@@ -366,7 +366,7 @@ impl RequestHandler {
                         .await;
                         // MessageBatch::new returns Err for an empty vec (all
                         // items were notifications), in which case no reply is
-                        // sent — correct per JSON-RPC 2.0 §6.
+                        // sent -- correct per JSON-RPC 2.0 section 6.
                         if let Ok(batch) = MessageBatch::new(responses)
                             && let Err(_err) = sender.send(Message::Batch(batch)).await
                         {
@@ -719,9 +719,9 @@ async fn get_task_result(req: Request, tasks: &Arc<TaskTracker>) -> Response {
 
 /// Validates that no two [`Request`] envelopes in a batch share the same ID.
 ///
-/// JSON-RPC 2.0 §6 does not explicitly forbid duplicate IDs in a batch, but
+/// JSON-RPC 2.0 section 6 does not explicitly forbid duplicate IDs in a batch, but
 /// duplicate IDs make response-to-request correlation ambiguous on the client
-/// side — [`crate::shared::RequestQueue::push`] would silently overwrite the
+/// side -- [`crate::shared::RequestQueue::push`] would silently overwrite the
 /// earlier waiter, causing it to time out even when a response arrives.
 ///
 /// This is a client-side defensive check, not a spec requirement.
@@ -759,7 +759,7 @@ mod tests {
             token.clone(),
         );
 
-        // The transport was never started — nothing will ever answer.
+        // The transport was never started -- nothing will ever answer.
         let req = Request::new(Some(RequestId::Number(1)), "ping", None::<()>);
         let pending = handler.send_request(req);
         tokio::pin!(pending);
@@ -796,7 +796,7 @@ mod tests {
         let rx2 = queue.push(&id2);
 
         let resp1 = Response::success(id1.clone(), json!({"result": "a"}));
-        // A Request envelope in the middle — must be skipped, not completed
+        // A Request envelope in the middle -- must be skipped, not completed
         let dummy_req = Request::new(Some(RequestId::Number(99)), "ping", None::<()>);
         let resp2 = Response::success(id2.clone(), json!({"result": "b"}));
 
@@ -962,10 +962,10 @@ mod tests {
             ))
         };
 
-        // Unique IDs — should pass
+        // Unique IDs -- should pass
         assert!(validate_batch_ids(&[req(1), req(2), req(3)]).is_ok());
 
-        // Duplicate ID — should fail
+        // Duplicate ID -- should fail
         let err = validate_batch_ids(&[req(1), req(2), req(1)]).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidRequest);
     }
@@ -977,7 +977,7 @@ mod tests {
         ));
         let req =
             MessageEnvelope::Request(Request::new(Some(RequestId::Number(1)), "ping", None::<()>));
-        // Two notifications with no ID fields — should not trigger duplicate check
+        // Two notifications with no ID fields -- should not trigger duplicate check
         assert!(validate_batch_ids(&[notif.clone(), req, notif]).is_ok());
     }
 

--- a/neva/src/client/options.rs
+++ b/neva/src/client/options.rs
@@ -97,6 +97,12 @@ pub struct McpOptions {
     /// behavior (headers) follows the handshake outcome.
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub(crate) peer_mode: crate::shared::PeerMode,
+
+    /// Request-scoped logging level attached to every outbound request's
+    /// `_meta["io.modelcontextprotocol/logLevel"]` (MCP 2026-07-28). Replaces
+    /// the removed global `logging/setLevel`.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    pub(crate) log_level: Option<crate::types::notification::LoggingLevel>,
 }
 
 impl Debug for McpOptions {
@@ -145,6 +151,8 @@ impl Default for McpOptions {
             max_mrtr_rounds: DEFAULT_MAX_MRTR_ROUNDS,
             #[cfg(feature = "proto-2026-07-28-rc")]
             peer_mode: Default::default(),
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            log_level: None,
         }
     }
 }
@@ -279,6 +287,34 @@ impl McpOptions {
     #[cfg(feature = "proto-2026-07-28-rc")]
     pub fn with_max_mrtr_rounds(mut self, rounds: usize) -> Self {
         self.max_mrtr_rounds = rounds;
+        self
+    }
+
+    /// Sets the request-scoped logging level (MCP 2026-07-28).
+    ///
+    /// The level is attached to every outbound request's
+    /// `_meta["io.modelcontextprotocol/logLevel"]`; the server delivers
+    /// `notifications/message` at or above this severity while handling the
+    /// request. This replaces the removed global `logging/setLevel` handshake.
+    ///
+    /// Deprecated on arrival: the 2026-07-28 draft marks the logging surface
+    /// deprecated, and it is expected to be removed in a future revision.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::client::Client;
+    /// use neva::types::notification::LoggingLevel;
+    ///
+    /// # #[allow(deprecated)]
+    /// let client = Client::new()
+    ///     .with_options(|o| o.with_log_level(LoggingLevel::Warning));
+    /// ```
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[deprecated(
+        note = "Request-scoped logging is deprecated in MCP 2026-07-28 and may be removed in a future revision."
+    )]
+    pub fn with_log_level(mut self, level: crate::types::notification::LoggingLevel) -> Self {
+        self.log_level = Some(level);
         self
     }
 

--- a/neva/src/client/options.rs
+++ b/neva/src/client/options.rs
@@ -197,7 +197,7 @@ impl McpOptions {
     ///
     /// Default: last available protocol version
     ///
-    /// Under `proto-2026-07-28-rc` the RC version itself is fixed — the
+    /// Under `proto-2026-07-28-rc` the RC version itself is fixed -- the
     /// value set here only selects which **legacy** version the
     /// dual-mode fallback negotiates when a server rejects
     /// `server/discover` (default: the newest pre-RC version).
@@ -208,7 +208,7 @@ impl McpOptions {
 
     /// Configures Roots capability
     #[deprecated(
-        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR — see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
+        note = "Roots are deprecated in MCP 2026-07-28: the capability-driven `roots/list` request is gone and the ability is re-homed onto MRTR -- see `Context::list_roots`. Under the RC this configures what the client answers MRTR `roots/list` input requests with."
     )]
     pub fn with_roots<T>(mut self, config: T) -> Self
     where
@@ -220,7 +220,7 @@ impl McpOptions {
 
     /// Configures Sampling capability
     #[deprecated(
-        note = "Sampling is deprecated in MCP 2026-07-28: the capability-driven `sampling/createMessage` request is gone and the ability is re-homed onto MRTR — see `Context::sample`."
+        note = "Sampling is deprecated in MCP 2026-07-28: the capability-driven `sampling/createMessage` request is gone and the ability is re-homed onto MRTR -- see `Context::sample`."
     )]
     pub fn with_sampling<T>(mut self, config: T) -> Self
     where
@@ -262,9 +262,9 @@ impl McpOptions {
     /// error. Guards against a server that keeps requesting input without ever
     /// converging.
     ///
-    /// This counts *re-issues* only — the initial send is always made on top of
-    /// this budget. So `1` permits a normal one-question flow (initial send →
-    /// `input_required` → one retry → final), and `0` sends the request once and
+    /// This counts *re-issues* only -- the initial send is always made on top of
+    /// this budget. So `1` permits a normal one-question flow (initial send ->
+    /// `input_required` -> one retry -> final), and `0` sends the request once and
     /// fails if it elicits at all.
     ///
     /// Default: 8.
@@ -313,7 +313,7 @@ impl McpOptions {
         // Hand the dual-mode switch to the HTTP transport so request
         // headers follow the negotiated protocol generation. Only the
         // HTTP transport carries them, so this is gated on `http-client`
-        // as well — stdio-only RC clients (no `TransportProto::HttpClient`
+        // as well -- stdio-only RC clients (no `TransportProto::HttpClient`
         // variant at all) pass the transport through untouched.
         #[cfg(all(feature = "proto-2026-07-28-rc", feature = "http-client"))]
         let transport = match transport {
@@ -325,7 +325,7 @@ impl McpOptions {
         transport
     }
 
-    /// The newest pre-RC protocol version — what the dual-mode fallback
+    /// The newest pre-RC protocol version -- what the dual-mode fallback
     /// negotiates with a legacy peer. Honors a legacy
     /// [`with_mcp_version`](Self::with_mcp_version) override.
     #[cfg(feature = "proto-2026-07-28-rc")]
@@ -418,7 +418,7 @@ mod tests {
 
     /// An explicit `with_roots(..)` must survive an empty roots list: the MRTR
     /// flag is derived from this, and an empty `ListRootsResult` is a perfectly
-    /// valid answer — a client that opted in must still be askable.
+    /// valid answer -- a client that opted in must still be askable.
     #[test]
     fn an_explicit_roots_capability_survives_an_empty_list() {
         #[allow(deprecated)]
@@ -429,7 +429,7 @@ mod tests {
             "an explicit opt-in must not be dropped just because the list is empty"
         );
 
-        // …and with neither an opt-in nor any roots there is nothing to declare.
+        // ...and with neither an opt-in nor any roots there is nothing to declare.
         let bare = McpOptions::default();
         assert!(bare.roots_capability().is_none());
     }
@@ -443,11 +443,11 @@ mod tests {
         let mut opts = McpOptions::default();
         assert!(
             opts.sampling_capability().is_none(),
-            "no sampling handler — nothing to advertise"
+            "no sampling handler -- nothing to advertise"
         );
         assert!(
             opts.elicitation_capability().is_none(),
-            "no elicitation handler — nothing to advertise"
+            "no elicitation handler -- nothing to advertise"
         );
 
         opts.add_sampling_handler(Arc::new(|_params| {

--- a/neva/src/error/error_code.rs
+++ b/neva/src/error/error_code.rs
@@ -37,7 +37,7 @@ pub enum ErrorCode {
     Timeout = -99998,
 
     /// [Internal code] A handler requested additional input via MRTR. Never
-    /// sent on the wire as an error — intercepted by the server dispatch layer
+    /// sent on the wire as an error -- intercepted by the server dispatch layer
     /// and converted into an `InputRequiredResult`.
     #[cfg(feature = "proto-2026-07-28-rc")]
     InputRequired = -99997,
@@ -157,7 +157,7 @@ impl ErrorCode {
         }
     }
 
-    /// Code to use for "resource not found" — spec-version dependent.
+    /// Code to use for "resource not found" -- spec-version dependent.
     ///
     /// - Default build (pre-2026 spec): [`Self::ResourceNotFound`] (`-32002`).
     /// - `proto-2026-07-28-rc`: [`Self::InvalidParams`] (`-32602`), per the RC.

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -246,11 +246,14 @@ pub mod prelude {
     #[cfg(feature = "http-server")]
     pub use crate::auth::{Claims, DefaultClaims};
 
+    #[cfg(feature = "http-server")]
+    #[allow(deprecated)]
+    pub use crate::transport::SseResponse;
     #[cfg(all(feature = "http-server", feature = "server-tls"))]
     pub use crate::transport::http::{DevCertMode, TlsConfig};
     #[cfg(feature = "http-server")]
     pub use crate::transport::{
-        HttpContext, HttpEngine, HttpRequest, HttpResponse, HttpServer, SseResponse, handlers,
+        HttpContext, HttpEngine, HttpRequest, HttpResponse, HttpServer, StreamResponse, handlers,
     };
 
     #[cfg(all(feature = "server", feature = "proto-2026-07-28-rc"))]

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -152,7 +152,7 @@ pub mod auth {
     pub use crate::transport::http::core::types::Claims;
 
     /// `DefaultClaims` is a pre-built [`Claims`] impl matching the JWT
-    /// standard claim names. Engine-agnostic — under the Volga adapter
+    /// standard claim names. Engine-agnostic -- under the Volga adapter
     /// it additionally implements `volga::auth::AuthClaims` so it can
     /// be fed straight into Volga's bearer-auth pipeline.
     #[cfg(feature = "http-server")]
@@ -171,7 +171,7 @@ pub mod auth {
 
     /// Volga's claims trait, re-exported for users who need to plug a
     /// custom claims type into Volga's `Authorizer<C>`. For neva's own
-    /// per-tool checks, implement [`Claims`] instead — that one is
+    /// per-tool checks, implement [`Claims`] instead -- that one is
     /// engine-neutral.
     #[cfg(feature = "http-server-volga")]
     pub use volga::auth::AuthClaims;
@@ -190,14 +190,14 @@ pub mod auth {
         //! configures the RFC 9728 Protected Resource Metadata document
         //! through `HttpServer::with_oauth_metadata`; the protocol-level
         //! types are re-exported from
-        //! [`volga-oauth-core`](https://docs.rs/volga-oauth-core) —
+        //! [`volga-oauth-core`](https://docs.rs/volga-oauth-core) --
         //! a crate with no HTTP I/O and no dependency on the Volga
         //! framework, so they are available to every `HttpEngine`.
         //!
         //! Client side (`client-oauth`): the pluggable
         //! `AuthorizationHandler` contract with the default
         //! `LoopbackHandler`, plus the `TokenStore` persistence
-        //! abstraction — configured through `HttpClient::with_oauth`.
+        //! abstraction -- configured through `HttpClient::with_oauth`.
 
         #[cfg(feature = "server-oauth")]
         pub use crate::transport::http::core::oauth::{
@@ -297,7 +297,7 @@ mod proto_versions_tests {
     fn stable_versions_always_listed() {
         // Stable versions are PROTOCOL_VERSIONS minus the RC entry (when enabled).
         // Future stable additions land in PROTOCOL_VERSIONS and are automatically
-        // covered by this test — no need to update the test when new versions
+        // covered by this test -- no need to update the test when new versions
         // are advertised.
         let stable: Vec<_> = PROTOCOL_VERSIONS
             .iter()
@@ -308,7 +308,7 @@ mod proto_versions_tests {
             !stable.is_empty(),
             "PROTOCOL_VERSIONS must always advertise at least one stable version"
         );
-        // The set must include 2024-11-05 (the inaugural MCP version) — this is
+        // The set must include 2024-11-05 (the inaugural MCP version) -- this is
         // a stronger invariant: even if we ever retire intermediate versions,
         // the original SHOULD remain for backwards compatibility.
         assert!(

--- a/neva/src/middleware.rs
+++ b/neva/src/middleware.rs
@@ -172,6 +172,14 @@ impl Middlewares {
         self.pipeline.push(middleware);
     }
 
+    /// Adds a middleware at the front of the pipeline, making it the outermost
+    /// layer so its wrapping (e.g. the request tracing span) covers every
+    /// already-registered user middleware.
+    #[inline]
+    pub(super) fn add_front(&mut self, middleware: Middleware) {
+        self.pipeline.insert(0, middleware);
+    }
+
     /// Composes middlewares into a "Linked List" and returns head
     pub(super) fn compose(&self) -> Option<Next> {
         if self.pipeline.is_empty() {

--- a/neva/src/middleware.rs
+++ b/neva/src/middleware.rs
@@ -176,6 +176,7 @@ impl Middlewares {
     /// layer so its wrapping (e.g. the request tracing span) covers every
     /// already-registered user middleware.
     #[inline]
+    #[cfg(feature = "tracing")]
     pub(super) fn add_front(&mut self, middleware: Middleware) {
         self.pipeline.insert(0, middleware);
     }

--- a/neva/src/shared.rs
+++ b/neva/src/shared.rs
@@ -45,18 +45,18 @@ mod task_api;
 #[cfg(feature = "tasks")]
 mod task_tracker;
 
-/// The future returned by neva's object-safe async traits — a boxed,
+/// The future returned by neva's object-safe async traits -- a boxed,
 /// `Send` future borrowing for `'a`.
 ///
 /// Traits like `AuthorizationHandler` (client OAuth) and `RequestStateStore`
 /// (MRTR idempotency) are stored behind
-/// `Arc<dyn …>`, which rules out `async fn` in the trait (not dyn-compatible),
+/// `Arc<dyn ...>`, which rules out `async fn` in the trait (not dyn-compatible),
 /// so their methods return this instead. Owning the alias here means
-/// implementing such a trait needs no `futures` dependency of your own — and
+/// implementing such a trait needs no `futures` dependency of your own -- and
 /// no version of it kept in lockstep with neva's.
 ///
 /// It is a plain alias for `Pin<Box<dyn Future<Output = T> + Send + 'a>>`
-/// (identical to `futures_util::future::BoxFuture`), so `Box::pin(async { … })`
+/// (identical to `futures_util::future::BoxFuture`), so `Box::pin(async { ... })`
 /// is all an implementation has to write.
 ///
 /// # Example
@@ -82,11 +82,11 @@ pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T
 pub(crate) fn wait_for_shutdown_signal(token: CancellationToken) {
     tokio::spawn(async move {
         match wait_for_shutdown_signal_impl().await {
-            // A shutdown signal actually arrived — cancel the transport.
+            // A shutdown signal actually arrived -- cancel the transport.
             Ok(_) => token.cancel(),
             // Failing to *register* the handler (e.g. a sandboxed
             // environment restricting signal APIs) must not tear the
-            // transport down — the watcher simply exits and process
+            // transport down -- the watcher simply exits and process
             // lifecycle stays with whatever launched it.
             #[cfg(feature = "tracing")]
             Err(err) => tracing::error!(
@@ -140,12 +140,12 @@ async fn wait_for_shutdown_signal_impl() -> std::io::Result<()> {
     }
 }
 
-/// Which protocol generation the connected peer speaks — the runtime
+/// Which protocol generation the connected peer speaks -- the runtime
 /// switch behind the dual-mode client (issue #84).
 ///
 /// An RC-flagged client starts in RC mode (`server/discover`, stateless,
 /// MRTR) and flips to legacy exactly once, in `Client::connect`'s
-/// fallback, before any other traffic — so nothing races the switch.
+/// fallback, before any other traffic -- so nothing races the switch.
 /// The legacy build has no switch: it is legacy by construction.
 ///
 /// Cheap to clone; all clones observe the same flip.

--- a/neva/src/shared.rs
+++ b/neva/src/shared.rs
@@ -3,7 +3,7 @@
 #[cfg(any(feature = "server", feature = "client"))]
 use tokio_util::sync::CancellationToken;
 
-#[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "tracing")]
 pub(crate) use message_registry::MessageRegistry;
 #[cfg(any(feature = "server", feature = "client"))]
 pub(crate) use requests_queue::PendingResponse;
@@ -31,7 +31,7 @@ mod arc_str;
 mod either;
 mod into_args;
 mod memchr;
-#[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "tracing")]
 mod message_registry;
 #[cfg(feature = "http-client")]
 pub mod mt;

--- a/neva/src/shared/sse_session_registry.rs
+++ b/neva/src/shared/sse_session_registry.rs
@@ -160,7 +160,6 @@ impl SseSessionRegistry {
                 session.sender = Self::disconnected_sender();
                 #[cfg(feature = "tracing")]
                 {
-                    #[cfg(not(feature = "proto-2026-07-28-rc"))]
                     crate::types::notification::fmt::LOG_REGISTRY.unregister(&session_id);
                     tracing::warn!(
                         logger = "neva",
@@ -174,7 +173,6 @@ impl SseSessionRegistry {
                 session.sender = Self::disconnected_sender();
                 #[cfg(feature = "tracing")]
                 {
-                    #[cfg(not(feature = "proto-2026-07-28-rc"))]
                     crate::types::notification::fmt::LOG_REGISTRY.unregister(&session_id);
                     tracing::warn!(
                         logger = "neva",
@@ -274,7 +272,7 @@ impl SseSessionRegistry {
                     .unwrap_or_else(|e| e.into_inner());
                 session.sender.is_closed() && now.saturating_duration_since(last_activity) >= ttl
             });
-            #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+            #[cfg(feature = "tracing")]
             if _removed.is_some() {
                 crate::types::notification::fmt::LOG_REGISTRY.unregister(&id);
             }

--- a/neva/src/shared/sse_session_registry.rs
+++ b/neva/src/shared/sse_session_registry.rs
@@ -32,7 +32,7 @@ struct SseSession {
     /// happens-before for all readers.
     next_seq: AtomicU64,
     capacity: usize,
-    /// Updated on each reconnect via register(). Plain u64 — mutated only through
+    /// Updated on each reconnect via register(). Plain u64 -- mutated only through
     /// a DashMap write-shard lock.
     generation: u64,
 }
@@ -114,7 +114,7 @@ impl SseSessionRegistry {
     /// Unconditionally removes a session.
     ///
     /// Use for explicit session termination (e.g. DELETE /mcp). Unlike [`unregister`],
-    /// this does not check the generation — the session is always removed.
+    /// this does not check the generation -- the session is always removed.
     pub(crate) fn terminate(&self, id: &Uuid) {
         self.sessions.remove(id);
     }
@@ -122,7 +122,7 @@ impl SseSessionRegistry {
     /// Buffers `message` and sends it to the session's live channel.
     ///
     /// Buffer-first: the message is stored before the channel send, so a dead
-    /// channel does not lose the event — it remains available for the next reconnect.
+    /// channel does not lose the event -- it remains available for the next reconnect.
     /// If the session is not found, the event is dropped (no buffer to write to).
     pub(crate) fn send(&self, message: Message) -> Result<(), Error> {
         let Some(&session_id) = message.session_id() else {
@@ -133,7 +133,7 @@ impl SseSessionRegistry {
             #[cfg(feature = "tracing")]
             tracing::warn!(
                 logger = "neva",
-                "Session {} not found for SSE send — event dropped",
+                "Session {} not found for SSE send -- event dropped",
                 session_id
             );
             return Ok(());
@@ -204,7 +204,7 @@ impl SseSessionRegistry {
             return Vec::new();
         }
 
-        // Eviction path: oldest seq was evicted → best-effort, return full buffer
+        // Eviction path: oldest seq was evicted -> best-effort, return full buffer
         if buf.front().is_some_and(|(s, _)| *s > last_seq) {
             return buf.iter().cloned().collect();
         }
@@ -215,7 +215,7 @@ impl SseSessionRegistry {
     /// Returns all buffered events in sequence order.
     ///
     /// Used on an initial SSE connection (no `Last-Event-ID`) to recover any events
-    /// buffered during the POST → GET handshake window. Returns empty if the session
+    /// buffered during the POST -> GET handshake window. Returns empty if the session
     /// is unknown or the buffer is empty.
     pub(crate) fn replay_all(&self, id: &Uuid) -> Vec<(u64, Arc<Message>)> {
         let Some(session) = self.sessions.get(id) else {
@@ -230,7 +230,7 @@ impl SseSessionRegistry {
     /// Call when a session ID is first minted (on POST /mcp) so that any server-initiated
     /// events emitted before the client's SSE GET arrive are buffered and available for
     /// replay. If an entry already exists (live connection or prior pre-registration),
-    /// this is a no-op — the existing buffer and sequence counter are preserved.
+    /// this is a no-op -- the existing buffer and sequence counter are preserved.
     ///
     /// Has no effect when `capacity == 0` (buffering disabled).
     // Stateless RC transport skips pre-registration (no SSE GET); the method
@@ -329,7 +329,7 @@ mod tests {
         let registry = SseSessionRegistry::new(16);
         let id = Uuid::new_v4();
 
-        // First connection: send 3 events → seqs 0, 1, 2
+        // First connection: send 3 events -> seqs 0, 1, 2
         let (tx1, _rx1) = mpsc::channel(16);
         registry.register(id, tx1);
         for _ in 0..3 {
@@ -437,7 +437,7 @@ mod tests {
         let (seq, _) = rx.try_recv().expect("event must be delivered live");
         assert_eq!(seq, 0);
 
-        // Send second event: seq=1. replay_since(&id, 0) returns seq > 0 → [seq=1]
+        // Send second event: seq=1. replay_since(&id, 0) returns seq > 0 -> [seq=1]
         registry.send(make_msg(id)).unwrap();
         let replayed = registry.replay_since(&id, 0);
         assert_eq!(replayed.len(), 1);
@@ -474,7 +474,7 @@ mod tests {
         }
 
         // Buffer should hold seqs 1, 2, 3 (seq 0 evicted)
-        // Eviction path: oldest_seq(1) > last_seq(0) → return full buffer
+        // Eviction path: oldest_seq(1) > last_seq(0) -> return full buffer
         let replayed = registry.replay_since(&id, 0);
         assert_eq!(replayed.len(), 3);
         assert_eq!(replayed[0].0, 1);
@@ -524,7 +524,7 @@ mod tests {
             registry.send(make_msg(id)).unwrap();
         }
         // Buffer holds seqs 2, 3, 4 (seqs 0 and 1 were evicted).
-        // Client sends last_seq=0 (evicted) → oldest(2) > 0 → full buffer returned.
+        // Client sends last_seq=0 (evicted) -> oldest(2) > 0 -> full buffer returned.
         let replayed = registry.replay_since(&id, 0);
         assert_eq!(replayed.len(), 3);
         assert_eq!(replayed[0].0, 2);
@@ -540,7 +540,7 @@ mod tests {
         for _ in 0..3 {
             registry.send(make_msg(id)).unwrap();
         }
-        // Newest seq = 2; replay_since(2) → strictly > 2 → empty
+        // Newest seq = 2; replay_since(2) -> strictly > 2 -> empty
         let replayed = registry.replay_since(&id, 2);
         assert!(replayed.is_empty());
     }
@@ -559,7 +559,7 @@ mod tests {
         registry.register(id, tx);
         drop(rx); // kill the channel
 
-        // send() must not return an error — event is buffered for next reconnect
+        // send() must not return an error -- event is buffered for next reconnect
         registry.send(make_msg(id)).unwrap();
 
         // Buffer holds the event
@@ -608,7 +608,7 @@ mod tests {
         registry.send(make_msg(id)).unwrap(); // seq=0
         registry.send(make_msg(id)).unwrap(); // seq=1
 
-        // Simulate GET /mcp: register live channel — in-place, preserving buffer
+        // Simulate GET /mcp: register live channel -- in-place, preserving buffer
         let (tx, mut rx) = mpsc::channel(8);
         registry.register(id, tx);
 

--- a/neva/src/shared/task_tracker.rs
+++ b/neva/src/shared/task_tracker.rs
@@ -756,11 +756,11 @@ mod tests {
         let task_id = task.id.clone();
         let _handle = tracker.track(task);
 
-        // Tracked but no parked elicit → the response is handed back (boxed).
+        // Tracked but no parked elicit -> the response is handed back (boxed).
         let answer = Response::success(RequestId::Number(1), serde_json::json!("x"));
         assert!(tracker.provide_input(&task_id, answer).is_err());
 
-        // Unknown task → also handed back.
+        // Unknown task -> also handed back.
         let answer = Response::success(RequestId::Number(2), serde_json::json!("x"));
         assert!(tracker.provide_input("nonexistent", answer).is_err());
     }

--- a/neva/src/transport.rs
+++ b/neva/src/transport.rs
@@ -7,8 +7,12 @@ use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "http-server")]
 pub use http::{
-    HttpContext, HttpEngine, HttpRequest, HttpResponse, HttpServer, SseResponse, handlers,
+    HttpContext, HttpEngine, HttpRequest, HttpResponse, HttpServer, StreamResponse, handlers,
 };
+
+#[cfg(feature = "http-server")]
+#[allow(deprecated)]
+pub use http::SseResponse;
 
 #[cfg(feature = "server")]
 pub(crate) use stdio::StdIoServer;

--- a/neva/src/transport.rs
+++ b/neva/src/transport.rs
@@ -81,7 +81,7 @@ pub(crate) enum TransportProtoSender {
         /// Accumulated response envelopes to be bundled into the batch reply.
         ///
         /// `std::sync::Mutex` is intentional: the lock is never held across an
-        /// `.await` (lock → push → unlock, then `Ok(())`), so the lighter
+        /// `.await` (lock -> push -> unlock, then `Ok(())`), so the lighter
         /// synchronous mutex is the right tool here.
         responses: std::sync::Arc<std::sync::Mutex<Vec<crate::types::MessageEnvelope>>>,
     },

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -34,8 +34,12 @@ pub use core::{
     context::HttpContext,
     engine::HttpEngine,
     handlers,
-    types::{HttpRequest, HttpResponse, SseResponse},
+    types::{HttpRequest, HttpResponse, StreamResponse},
 };
+
+#[cfg(feature = "http-server")]
+#[allow(deprecated)]
+pub use core::types::SseResponse;
 
 #[cfg(feature = "http-client")]
 pub(crate) mod client;

--- a/neva/src/transport/http.rs
+++ b/neva/src/transport/http.rs
@@ -254,7 +254,7 @@ impl std::fmt::Debug for HttpClient {
 impl ServiceUrl {
     /// Builds the full request URL (`proto://addr/endpoint`).
     ///
-    /// Note: this **allocates** a fresh `String` — it is not a cheap borrow
+    /// Note: this **allocates** a fresh `String` -- it is not a cheap borrow
     /// despite reading stored fields. Assemble it once and cache the result
     /// (as `McpSession` does) rather than calling it per request.
     #[inline]
@@ -336,7 +336,7 @@ where
     E: HttpEngine,
 {
     /// Creates a new [`HttpServer`] bound to `addr`, running the supplied
-    /// engine. This is the engine-agnostic constructor — use it when
+    /// engine. This is the engine-agnostic constructor -- use it when
     /// plugging in a non-default engine.
     ///
     /// Returns `HttpServer<DefaultClaims, E>`. For a custom claims type,
@@ -389,7 +389,7 @@ where
     }
 
     /// Swap the HTTP engine. Engine-specific config (auth, TLS) does not
-    /// carry over — the new engine starts with its own defaults.
+    /// carry over -- the new engine starts with its own defaults.
     pub fn with_engine<E2>(self, engine: E2) -> HttpServer<C, E2>
     where
         E2: HttpEngine,
@@ -607,7 +607,7 @@ impl HttpServer<server::DefaultClaims, VolgaEngine> {
         let auth = config(server::AuthConfig::default());
         // Default-flow glue: when OAuth issuer mode is on and no
         // Protected Resource Metadata was configured explicitly, derive
-        // the document from that issuer — the well-known route and the
+        // the document from that issuer -- the well-known route and the
         // 401 challenge then work out of the box. An explicit
         // `with_oauth_metadata` (before or after this call) wins.
         #[cfg(feature = "server-oauth")]
@@ -715,7 +715,7 @@ impl HttpClient {
     }
 
     fn runtime(&mut self) -> Result<ClientRuntimeContext, Error> {
-        // Build the OAuth session before consuming transport state —
+        // Build the OAuth session before consuming transport state --
         // same rationale as the server-side OAuth resolve.
         #[cfg(feature = "client-oauth")]
         let oauth = self
@@ -796,7 +796,7 @@ where
 
         // Take the engine out of the Option so we can move it into the
         // spawned task. start() must only be called once per HttpServer
-        // — the App's run loop owns the HttpServer instance and calls
+        // -- the App's run loop owns the HttpServer instance and calls
         // start() exactly once.
         let engine = self
             .engine
@@ -983,7 +983,7 @@ mod engine_smoke_tests {
             .with_oauth_metadata(|oauth| oauth.with_resource("not a uri"));
 
         assert!(server.build_context_and_engine().is_err());
-        // The config failure must not consume the HTTP writer — it fires
+        // The config failure must not consume the HTTP writer -- it fires
         // before any transport state is taken.
         assert!(server.sender.rx.is_some());
     }

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -323,13 +323,7 @@ async fn send_request(
     // `notifications/progress` followed by the response. Forward every parsed
     // message to the receive loop, which routes notifications to handlers and
     // resolves the pending request on the response.
-    let is_event_stream = resp
-        .headers()
-        .get(CONTENT_TYPE)
-        .and_then(|v| v.to_str().ok())
-        .is_some_and(|ct| ct.contains("text/event-stream"));
-
-    if is_event_stream {
+    if is_event_stream(resp.headers()) {
         let mut answered = false;
         let mut stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
         while let Some(event) = stream.next().await {
@@ -436,6 +430,15 @@ fn parse_failure(status: reqwest::StatusCode, err: &impl std::fmt::Display) -> (
         ErrorCode::InternalError
     };
     (code, format!("HTTP {status}: {err}"))
+}
+
+/// Whether a reply is SSE-framed rather than a single JSON document.
+fn is_event_stream(headers: &reqwest::header::HeaderMap) -> bool {
+    headers
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|ct| ct.split(';').next())
+        .is_some_and(|essence| essence.trim().eq_ignore_ascii_case("text/event-stream"))
 }
 
 /// The ids of the requests `msg` carries (empty for notifications and
@@ -878,6 +881,36 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "a malformed frame must not reach the receive loop"
+        );
+    }
+
+    /// Media types are case-insensitive and may carry parameters: mistaking such
+    /// a reply for JSON would fail the request on an SSE-framed body.
+    #[test]
+    fn event_stream_media_type_is_matched_case_insensitively() {
+        let cases = [
+            ("text/event-stream", true),
+            ("Text/Event-Stream", true),
+            ("TEXT/EVENT-STREAM; charset=utf-8", true),
+            ("text/event-stream ;charset=utf-8", true),
+            ("application/json", false),
+            ("text/event-streaming", false),
+            ("application/json, text/event-stream", false),
+        ];
+
+        for (value, expected) in cases {
+            let mut headers = reqwest::header::HeaderMap::new();
+            headers.insert(CONTENT_TYPE, value.parse().unwrap());
+            assert_eq!(
+                is_event_stream(&headers),
+                expected,
+                "wrong verdict for content-type {value:?}"
+            );
+        }
+
+        assert!(
+            !is_event_stream(&reqwest::header::HeaderMap::new()),
+            "a reply without content-type is not an SSE stream"
         );
     }
 }

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -36,7 +36,7 @@ enum ClientAuth {
     None,
     /// Static bearer token from `HttpClient::with_auth`.
     Static(Arc<str>),
-    /// Managed OAuth session — the token changes as flows complete.
+    /// Managed OAuth session -- the token changes as flows complete.
     #[cfg(feature = "client-oauth")]
     OAuth(Arc<oauth::OAuthSession>),
 }
@@ -62,7 +62,7 @@ impl ClientAuth {
     }
 }
 
-// SSE constants — the standalone GET stream serves legacy peers only;
+// SSE constants -- the standalone GET stream serves legacy peers only;
 // its machinery compiles under both flags for the dual-mode client and
 // activates at runtime when a legacy `initialize` handshake happens.
 const LAST_EVENT_ID: HeaderName = HeaderName::from_static("last-event-id");
@@ -103,7 +103,7 @@ pub(super) async fn connect(rt: ClientRuntimeContext, token: CancellationToken) 
 
     // The SSE task arms itself only when a legacy `initialize` handshake
     // completes (`session.initialized()` fires exclusively for the
-    // `initialize` method) — against an RC peer it stays parked until
+    // `initialize` method) -- against an RC peer it stays parked until
     // cancellation, so the stateless RC transport still issues only POSTs.
     tokio::join!(
         handle_connection(
@@ -323,7 +323,7 @@ async fn send_request(
                 tracing::error!(logger = "neva", "Failed to send response: {}", _err);
             }
         }
-        // A reply that is not JSON-RPC — an HTML error page, or an error
+        // A reply that is not JSON-RPC -- an HTML error page, or an error
         // code outside neva's `ErrorCode` set (e.g. the TS SDK's -32000).
         // Complete every originating request with an id-bound error
         // response: a bare `Err` pushed into the channel would terminate
@@ -356,19 +356,19 @@ async fn send_request(
 /// The code matters beyond diagnostics: `ParseError` is one of the
 /// dual-mode fallback triggers (issue #84), so it must be produced *only*
 /// for replies that genuinely suggest "this peer doesn't know the RC
-/// method/route" — an allowlist, not a catch-all:
+/// method/route" -- an allowlist, not a catch-all:
 ///
-/// * any `2xx` — a legacy peer answering `server/discover` on the wire but
+/// * any `2xx` -- a legacy peer answering `server/discover` on the wire but
 ///   with a body neva can't read as JSON-RPC, most notably an error code
 ///   outside its `ErrorCode` set (the TS SDK's `-32000` "server not
 ///   initialized" family);
-/// * `400` / `404` / `405` / `406` — routers and legacy servers rejecting
+/// * `400` / `404` / `405` / `406` -- routers and legacy servers rejecting
 ///   the unknown method or endpoint outright.
 ///
 /// Everything else is an upstream failure that says nothing about the
 /// peer's protocol generation and must surface as-is
 /// (`InternalError`, like "Connection closed"):
-/// `401`/`403`/`407` (authentication — otherwise a failed login against a
+/// `401`/`403`/`407` (authentication -- otherwise a failed login against a
 /// valid RC server reads as "legacy"), `429` (rate limit) and every `5xx`
 /// (reverse-proxy outage, gateway timeout). Treating those as legacy
 /// evidence would silently drop the RC headers, retry `initialize` into
@@ -450,7 +450,7 @@ async fn handle_sse_connection(
 
     let token = session.cancellation_token();
     // At most one interactive re-authorization per (re)connection attempt
-    // sequence — a second consecutive 401 means the fresh token is not
+    // sequence -- a second consecutive 401 means the fresh token is not
     // accepted and the session must fail rather than loop.
     #[cfg(feature = "client-oauth")]
     let mut reauthorized = false;
@@ -550,7 +550,7 @@ async fn handle_sse_connection(
             }
         }
 
-        // Stream ended — wait before reconnecting to avoid hammering the server
+        // Stream ended -- wait before reconnecting to avoid hammering the server
         tokio::select! {
             biased;
             _ = token.cancelled() => return,
@@ -594,7 +594,7 @@ async fn handle_msg(
         return false;
     };
     // A malformed SSE frame must not reach the receive loop as a bare
-    // `Err` (that would terminate it) — log and skip; the last event id
+    // `Err` (that would terminate it) -- log and skip; the last event id
     // does not advance, so a reconnect replays the event.
     let msg = match serde_json::from_str::<Message>(&data) {
         Ok(msg) => msg,
@@ -642,7 +642,7 @@ impl From<reqwest::Error> for Error {
 }
 
 // These tests exercise the SSE GET stream path, which serves legacy
-// peers — compiled under both flags for the dual-mode client.
+// peers -- compiled under both flags for the dual-mode client.
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -661,7 +661,7 @@ mod tests {
     const VALID_MSG: &str = r#"{"jsonrpc":"2.0","method":"ping"}"#;
 
     /// Only statuses that actually suggest an unknown method/route may
-    /// yield `ParseError` — the dual-mode fallback trigger. Upstream
+    /// yield `ParseError` -- the dual-mode fallback trigger. Upstream
     /// failures (auth, rate limit, 5xx) must stay `InternalError` so a
     /// valid RC peer is never mistaken for a legacy one.
     #[test]
@@ -738,7 +738,7 @@ mod tests {
         let session = make_session();
         let (tx, _rx) = mpsc::channel(1);
 
-        // Non-message SSE event (has event: field) — no data sent to channel, but
+        // Non-message SSE event (has event: field) -- no data sent to channel, but
         // ID should still advance so the server does not replay it on reconnect.
         let event = sse_stream::Sse::default()
             .id("evt-keepalive")

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -324,23 +324,8 @@ async fn send_request(
     // message to the receive loop, which routes notifications to handlers and
     // resolves the pending request on the response.
     if is_event_stream(resp.headers()) {
-        let mut answered = false;
-        let mut stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
-        while let Some(event) = stream.next().await {
-            match event {
-                Ok(sse) if sse.is_message() => {
-                    if forward_sse_message(sse, &resp_tx).await {
-                        answered = true;
-                    }
-                }
-                Ok(_) => {}
-                Err(_err) => {
-                    #[cfg(feature = "tracing")]
-                    tracing::error!(logger = "neva", "SSE POST stream error: {}", _err);
-                    break;
-                }
-            }
-        }
+        let stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
+        let answered = drain_post_sse(stream, &resp_tx).await;
 
         // A truncated stream, an unparseable frame, or EOF before the final
         // response would otherwise leave the originating request sitting in the
@@ -616,13 +601,55 @@ async fn handle_sse_connection(
     }
 }
 
+/// Drains a request-scoped SSE `POST` reply, forwarding every JSON-RPC message
+/// it carries to the receive loop.
+///
+/// Returns whether the terminal reply arrived, so the caller can fail the
+/// originating request when the stream ends without one.
+async fn drain_post_sse<S>(mut stream: S, resp_tx: &mpsc::Sender<Result<Message, Error>>) -> bool
+where
+    S: futures_util::Stream<Item = Result<sse_stream::Sse, sse_stream::Error>> + Unpin,
+{
+    let mut answered = false;
+    while let Some(event) = stream.next().await {
+        match event {
+            Ok(sse) if is_message_event(&sse) => {
+                if forward_sse_message(sse, resp_tx).await {
+                    answered = true;
+                }
+            }
+            Ok(_) => {}
+            Err(_err) => {
+                #[cfg(feature = "tracing")]
+                tracing::error!(logger = "neva", "SSE POST stream error: {}", _err);
+                break;
+            }
+        }
+    }
+    answered
+}
+
+/// Whether an SSE frame carries a JSON-RPC message.
+///
+/// `message` is the *default* SSE event type, so a frame that omits `event:` and
+/// one that names it explicitly mean the same thing. `Sse::is_message` only
+/// covers the former (it is `event.is_none()`), so a peer that spells the type
+/// out would otherwise have every frame -- notifications and the terminal
+/// response alike -- discarded.
+fn is_message_event(event: &sse_stream::Sse) -> bool {
+    match &event.event {
+        None => true,
+        Some(kind) => kind.trim() == "message",
+    }
+}
+
 async fn handle_event(
     event: sse_stream::Sse,
     session: &Arc<McpSession>,
     resp_tx: &mpsc::Sender<Result<Message, Error>>,
 ) {
     let id = event.id.clone();
-    let delivered = if event.is_message() {
+    let delivered = if is_message_event(&event) {
         handle_msg(event, resp_tx).await
     } else {
         #[cfg(feature = "tracing")]
@@ -839,11 +866,87 @@ mod tests {
         let session = make_session();
         let (tx, _rx) = mpsc::channel(1);
 
-        // is_message() returns true (no event: field) but data is None
+        // A message frame (no event: field) but data is None
         let event = sse_stream::Sse::default().id("evt-empty");
         handle_event(event, &session, &tx).await;
 
         assert!(session.last_event_id().is_none());
+    }
+
+    /// `message` is the default SSE event type, so naming it explicitly must be
+    /// treated exactly like omitting it.
+    #[test]
+    fn explicitly_named_message_events_count_as_messages() {
+        let cases = [
+            (None, true),
+            (Some("message"), true),
+            (Some(" message "), true),
+            (Some("Message"), false),
+            (Some("keepalive"), false),
+            (Some("endpoint"), false),
+        ];
+
+        for (kind, expected) in cases {
+            let event = match kind {
+                Some(kind) => sse_stream::Sse::default().event(kind),
+                None => sse_stream::Sse::default(),
+            };
+            assert_eq!(
+                is_message_event(&event),
+                expected,
+                "wrong verdict for event type {kind:?}"
+            );
+        }
+    }
+
+    /// A peer that frames its stream with `event: message` must have its payload
+    /// delivered on both SSE paths -- the standalone `GET` and the POST reply.
+    #[tokio::test]
+    async fn named_message_events_are_delivered_on_both_sse_paths() {
+        let response = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+
+        // Standalone GET stream: delivered, and the last event id advances.
+        let session = make_session();
+        let (tx, mut rx) = mpsc::channel(1);
+        let event = sse_stream::Sse::default()
+            .id("evt-named")
+            .event("message")
+            .data(response);
+        handle_event(event, &session, &tx).await;
+        assert!(rx.try_recv().is_ok(), "GET frame must be delivered");
+        assert_eq!(session.last_event_id(), Some("evt-named".to_string()));
+
+        // Request-scoped POST reply, driven through the real drain loop: the
+        // notification and the response are both delivered, and the stream counts
+        // as answered so the request is not failed as truncated.
+        let (tx, mut rx) = mpsc::channel(4);
+        let frames = vec![
+            Ok(sse_stream::Sse::default()
+                .event("message")
+                .data(r#"{"jsonrpc":"2.0","method":"notifications/message"}"#)),
+            Ok(sse_stream::Sse::default().event("message").data(response)),
+        ];
+        assert!(
+            drain_post_sse(futures_util::stream::iter(frames), &tx).await,
+            "the POST stream must count as answered"
+        );
+        assert!(matches!(rx.try_recv(), Ok(Ok(Message::Notification(_)))));
+        assert!(matches!(rx.try_recv(), Ok(Ok(Message::Response(_)))));
+    }
+
+    /// Frames of some other event type are skipped without answering the
+    /// request, and a stream that carries only those ends unanswered.
+    #[tokio::test]
+    async fn drain_post_sse_skips_other_event_types() {
+        let (tx, mut rx) = mpsc::channel(2);
+        let frames = vec![
+            Ok(sse_stream::Sse::default().event("keepalive").data("{}")),
+            Ok(sse_stream::Sse::default()
+                .event("endpoint")
+                .data(r#"{"jsonrpc":"2.0","id":1,"result":{}}"#)),
+        ];
+        assert!(!drain_post_sse(futures_util::stream::iter(frames), &tx).await);
+        assert!(rx.try_recv().is_err(), "no frame should be delivered");
     }
 
     /// A request-scoped SSE `POST` reply must be recognized as *answered* only

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -67,6 +67,7 @@ impl ClientAuth {
 // activates at runtime when a legacy `initialize` handshake happens.
 const LAST_EVENT_ID: HeaderName = HeaderName::from_static("last-event-id");
 const SSE_RECONNECT_DELAY: Duration = Duration::from_secs(3);
+const STREAM_ENDED_BEFORE_RESPONSE: &str = "POST SSE stream ended before the response arrived";
 
 #[cfg(feature = "proto-2026-07-28-rc")]
 fn routing_hints(msg: &Message) -> Option<(&str, Option<&str>)> {
@@ -329,16 +330,39 @@ async fn send_request(
         .is_some_and(|ct| ct.contains("text/event-stream"));
 
     if is_event_stream {
+        let mut answered = false;
         let mut stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
         while let Some(event) = stream.next().await {
             match event {
                 Ok(sse) if sse.is_message() => {
-                    handle_msg(sse, &resp_tx).await;
+                    if forward_sse_message(sse, &resp_tx).await {
+                        answered = true;
+                    }
                 }
                 Ok(_) => {}
                 Err(_err) => {
                     #[cfg(feature = "tracing")]
                     tracing::error!(logger = "neva", "SSE POST stream error: {}", _err);
+                    break;
+                }
+            }
+        }
+
+        // A truncated stream, an unparseable frame, or EOF before the final
+        // response would otherwise leave the originating request sitting in the
+        // pending queue until it times out. Fail it now, id-bound, exactly like
+        // the non-JSON-RPC reply path below. `InternalError` (not `ParseError`)
+        // on purpose: the peer clearly speaks RC, so this must not be mistaken
+        // for dual-mode fallback evidence.
+        if !answered {
+            #[cfg(feature = "tracing")]
+            tracing::error!(logger = "neva", STREAM_ENDED_BEFORE_RESPONSE);
+            for id in request_ids(&req) {
+                let resp = crate::types::Response::error(
+                    id,
+                    Error::new(ErrorCode::InternalError, STREAM_ENDED_BEFORE_RESPONSE),
+                );
+                if resp_tx.send(Ok(Message::Response(resp))).await.is_err() {
                     break;
                 }
             }
@@ -642,6 +666,35 @@ async fn handle_msg(
     true
 }
 
+/// Forwards one frame of a request-scoped SSE `POST` reply to the receive loop.
+///
+/// Returns `true` only for the *terminal* reply -- a response or a batch
+/// response -- so the caller can tell an orderly stream end from a truncated one
+/// (notifications, and frames that fail to parse, return `false`).
+async fn forward_sse_message(
+    event: sse_stream::Sse,
+    resp_tx: &mpsc::Sender<Result<Message, Error>>,
+) -> bool {
+    let Some(data) = event.data else {
+        return false;
+    };
+    let msg = match serde_json::from_str::<Message>(&data) {
+        Ok(msg) => msg,
+        Err(_err) => {
+            #[cfg(feature = "tracing")]
+            tracing::error!(logger = "neva", "Failed to parse SSE POST event: {}", _err);
+            return false;
+        }
+    };
+    let terminal = matches!(msg, Message::Response(_) | Message::Batch(_));
+    if let Err(_err) = resp_tx.send(Ok(msg)).await {
+        #[cfg(feature = "tracing")]
+        tracing::error!(logger = "neva", "Failed to send response: {}", _err);
+        return false;
+    }
+    terminal
+}
+
 #[inline]
 #[cfg(not(feature = "client-tls"))]
 fn create_client() -> Result<reqwest::Client, Error> {
@@ -788,6 +841,44 @@ mod tests {
         handle_event(event, &session, &tx).await;
 
         assert!(session.last_event_id().is_none());
+    }
+
+    /// A request-scoped SSE `POST` reply must be recognized as *answered* only
+    /// once its terminal reply arrives -- that flag is what tells a truncated
+    /// stream (which has to fail the pending request) from an orderly one.
+    #[tokio::test]
+    async fn forward_sse_message_flags_only_terminal_replies() {
+        let cases = [
+            // (frame, is_terminal)
+            (
+                r#"{"jsonrpc":"2.0","method":"notifications/message"}"#,
+                false,
+            ),
+            (r#"{"jsonrpc":"2.0","id":1,"result":{}}"#, true),
+            (r#"[{"jsonrpc":"2.0","id":1,"result":{}}]"#, true),
+        ];
+
+        for (frame, terminal) in cases {
+            let (tx, mut rx) = mpsc::channel(1);
+            let event = sse_stream::Sse::default().data(frame);
+            assert_eq!(
+                forward_sse_message(event, &tx).await,
+                terminal,
+                "wrong terminal flag for {frame}"
+            );
+            assert!(rx.try_recv().is_ok(), "{frame} should still be delivered");
+        }
+    }
+
+    #[tokio::test]
+    async fn forward_sse_message_reports_unparseable_frame_as_unanswered() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let event = sse_stream::Sse::default().data("not json");
+        assert!(!forward_sse_message(event, &tx).await);
+        assert!(
+            rx.try_recv().is_err(),
+            "a malformed frame must not reach the receive loop"
+        );
     }
 }
 

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -316,6 +316,36 @@ async fn send_request(
     }
 
     let status = resp.status();
+
+    // Streamable HTTP allows a POST reply to be a request-scoped SSE stream
+    // (MCP 2026-07-28): it carries this request's `notifications/message` /
+    // `notifications/progress` followed by the response. Forward every parsed
+    // message to the receive loop, which routes notifications to handlers and
+    // resolves the pending request on the response.
+    let is_event_stream = resp
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.contains("text/event-stream"));
+
+    if is_event_stream {
+        let mut stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
+        while let Some(event) = stream.next().await {
+            match event {
+                Ok(sse) if sse.is_message() => {
+                    handle_msg(sse, &resp_tx).await;
+                }
+                Ok(_) => {}
+                Err(_err) => {
+                    #[cfg(feature = "tracing")]
+                    tracing::error!(logger = "neva", "SSE POST stream error: {}", _err);
+                    break;
+                }
+            }
+        }
+        return;
+    }
+
     match resp.json::<Message>().await {
         Ok(msg) => {
             if let Err(_err) = resp_tx.send(Ok(msg)).await {

--- a/neva/src/transport/http/client/mcp_session.rs
+++ b/neva/src/transport/http/client/mcp_session.rs
@@ -9,7 +9,7 @@ use tokio_util::sync::CancellationToken;
 
 /// Represents current MCP Session
 pub(super) struct McpSession {
-    /// Dual-mode protocol switch — legacy peers get legacy headers.
+    /// Dual-mode protocol switch -- legacy peers get legacy headers.
     #[cfg(feature = "proto-2026-07-28-rc")]
     peer_mode: crate::shared::PeerMode,
     initialized: Notify,

--- a/neva/src/transport/http/client/oauth.rs
+++ b/neva/src/transport/http/client/oauth.rs
@@ -2,8 +2,8 @@
 //!
 //! Implements the MCP authorization sequence on top of
 //! [`volga-oauth-client`](https://docs.rs/volga-oauth-client) (framework
-//! independent — plain hyper): a `401` challenge is parsed for its
-//! `resource_metadata` pointer (RFC 9728 §5.1), the Protected Resource
+//! independent -- plain hyper): a `401` challenge is parsed for its
+//! `resource_metadata` pointer (RFC 9728 section 5.1), the Protected Resource
 //! Metadata and the authorization server metadata are discovered
 //! (RFC 8414, OIDC fallback), the client registers dynamically when no
 //! `client_id` is configured (RFC 7591, `application_type: "native"` for
@@ -61,7 +61,7 @@ impl CallbackParams {
     /// (e.g. `"code=abc&state=xyz&iss=https%3A%2F%2Fauth"`).
     ///
     /// Returns an error when the response carries an OAuth `error`
-    /// (RFC 6749 §4.1.2.1) or is missing `code`/`state`.
+    /// (RFC 6749 section 4.1.2.1) or is missing `code`/`state`.
     ///
     /// # Example
     /// ```no_run
@@ -107,7 +107,7 @@ impl CallbackParams {
     }
 }
 
-/// Minimal `application/x-www-form-urlencoded` pair iterator — enough
+/// Minimal `application/x-www-form-urlencoded` pair iterator -- enough
 /// for authorization-response queries (no `+`-space legacy handling
 /// beyond the standard).
 fn form_urlencoded_parse(query: &str) -> impl Iterator<Item = (String, String)> + '_ {
@@ -153,8 +153,8 @@ fn percent_decode(s: &str) -> Option<String> {
 ///
 /// Both methods return a [`BoxFuture`] rather than being `async fn`: the
 /// handler is stored behind `Arc<dyn AuthorizationHandler>`, and `async fn`
-/// in a trait is not dyn-compatible. `Box::pin(async move { … })` is all an
-/// implementation needs — and the alias is neva's own, so implementing this
+/// in a trait is not dyn-compatible. `Box::pin(async move { ... })` is all an
+/// implementation needs -- and the alias is neva's own, so implementing this
 /// trait pulls in no `futures` dependency.
 ///
 /// # Example
@@ -171,7 +171,7 @@ fn percent_decode(s: &str) -> Option<String> {
 ///     }
 ///     fn authorize(&self, url: String) -> BoxFuture<'_, Result<CallbackParams, Error>> {
 ///         Box::pin(async move {
-///             // show `url` to the user, await the callback…
+///             // show `url` to the user, await the callback...
 ///             # let _ = url;
 ///             todo!()
 ///         })
@@ -181,7 +181,7 @@ fn percent_decode(s: &str) -> Option<String> {
 pub trait AuthorizationHandler: Send + Sync + 'static {
     /// The redirect URI the authorization response will be delivered to.
     ///
-    /// Called once per flow, before dynamic client registration — the
+    /// Called once per flow, before dynamic client registration -- the
     /// URI is registered and sent with the authorization request.
     fn redirect_uri(&self) -> BoxFuture<'_, Result<String, Error>>;
 
@@ -194,7 +194,7 @@ pub trait AuthorizationHandler: Send + Sync + 'static {
 /// loopback listener, opens the system browser at the authorization URL
 /// and captures the single redirect request.
 ///
-/// The redirect URI is `http://127.0.0.1:{port}/callback` — loopback
+/// The redirect URI is `http://127.0.0.1:{port}/callback` -- loopback
 /// redirects are the standard exception to the HTTPS rule for native
 /// clients, and dynamic registration declares such a client as
 /// `application_type: "native"` accordingly.
@@ -246,7 +246,7 @@ impl LoopbackHandler {
         Self::default()
     }
 
-    /// Pins the callback listener to a fixed port — required when the
+    /// Pins the callback listener to a fixed port -- required when the
     /// authorization server does not allow arbitrary loopback ports on
     /// the registered redirect URI.
     pub fn with_port(mut self, port: u16) -> Self {
@@ -315,7 +315,7 @@ impl LoopbackHandler {
 }
 
 /// Extracts the query string out of the callback's request line
-/// (`GET /callback?code=…&state=… HTTP/1.1`) and parses it.
+/// (`GET /callback?code=...&state=... HTTP/1.1`) and parses it.
 fn parse_callback_request(raw: &[u8]) -> Result<CallbackParams, Error> {
     let line = raw
         .split(|&b| b == b'\r' || b == b'\n')
@@ -359,7 +359,7 @@ impl AuthorizationHandler for LoopbackHandler {
     }
 }
 
-/// Launches the system browser at `url`, best-effort — on failure the
+/// Launches the system browser at `url`, best-effort -- on failure the
 /// URL is still available from the log/handler.
 fn open_in_browser(url: &str) {
     #[cfg(target_os = "macos")]
@@ -469,7 +469,7 @@ impl OAuthClientConfig {
     }
 
     /// Replaces the in-process token store with a custom
-    /// [`TokenStore`] (encrypted file, OS keychain, …).
+    /// [`TokenStore`] (encrypted file, OS keychain, ...).
     pub fn with_token_store(mut self, store: impl TokenStore + 'static) -> Self {
         self.store = Arc::new(store);
         self
@@ -488,7 +488,7 @@ impl OAuthClientConfig {
 }
 
 /// The OAuth client and authorization-server metadata retained from the
-/// last successful flow — everything a non-interactive token refresh
+/// last successful flow -- everything a non-interactive token refresh
 /// needs.
 struct FlowState {
     client: OAuthClient,
@@ -504,7 +504,7 @@ const REFRESH_LEEWAY: std::time::Duration = std::time::Duration::from_secs(30);
 /// single-flight authorization flow.
 pub(crate) struct OAuthSession {
     config: OAuthClientConfig,
-    /// Canonicalized server URL — the RFC 8707 resource indicator and
+    /// Canonicalized server URL -- the RFC 8707 resource indicator and
     /// the token-store key.
     resource: String,
     /// Current bearer token, read on every outgoing request.
@@ -557,7 +557,7 @@ impl OAuthSession {
 
     /// The bearer token to attach to the next request, proactively
     /// refreshed when the stored set is about to expire and a refresh
-    /// token is available — the session then renews without user
+    /// token is available -- the session then renews without user
     /// interaction. Falls back to the current token when refresh is not
     /// possible; the `401` path handles the rest.
     pub(crate) async fn refreshed_bearer(&self) -> Option<Arc<str>> {
@@ -589,7 +589,7 @@ impl OAuthSession {
                 self.set_token(token.clone());
                 Some(token)
             }
-            // Nothing renewable — interactive authorization it is.
+            // Nothing renewable -- interactive authorization it is.
             Ok(None) => None,
             // Transient failure (issuer unreachable): keep the current
             // token and let the request outcome decide.
@@ -604,7 +604,7 @@ impl OAuthSession {
     /// Runs the authorization flow triggered by a `401` and returns the
     /// fresh bearer token.
     ///
-    /// `www_authenticate` is the challenge header value, when present —
+    /// `www_authenticate` is the challenge header value, when present --
     /// its `resource_metadata` pointer takes precedence over well-known
     /// derivation. `used` is the token the failed request carried:
     /// concurrent callers that lost the race simply pick up the token
@@ -625,7 +625,7 @@ impl OAuthSession {
 
         // Refresh before interrupting the user: a stored refresh token
         // renews the session silently. A token identical to the rejected
-        // one is no help though (revoked server-side) — interactive then.
+        // one is no help though (revoked server-side) -- interactive then.
         if let Some(token) = self.maintain(&mut flight).await
             && used != Some(&*token)
         {
@@ -694,7 +694,7 @@ impl OAuthSession {
         Ok(token)
     }
 
-    /// Builds the [`OAuthClient`] — from the configured `client_id` or
+    /// Builds the [`OAuthClient`] -- from the configured `client_id` or
     /// through dynamic registration (RFC 7591).
     async fn build_client(
         &self,
@@ -730,7 +730,7 @@ impl OAuthSession {
 /// authorization-code client.
 ///
 /// A loopback redirect URI makes this a **native** client
-/// (`application_type: "native"`) — authorization servers reject `web`
+/// (`application_type: "native"`) -- authorization servers reject `web`
 /// clients with plain-http loopback redirects, which is exactly the
 /// desktop/CLI case.
 fn registration_metadata(redirect_uri: &str) -> ClientMetadata {
@@ -758,7 +758,7 @@ fn is_loopback_redirect(uri: &str) -> bool {
         return false;
     };
     let authority = rest.split(['/', '?']).next().unwrap_or_default();
-    // Bracketed IPv6 hosts carry colons of their own — split on the
+    // Bracketed IPv6 hosts carry colons of their own -- split on the
     // closing bracket first, then strip a `:port` for everything else.
     let host = match authority.split_once(']') {
         Some((bracketed, _)) => &authority[..bracketed.len() + 1],
@@ -775,8 +775,8 @@ fn is_loopback_redirect(uri: &str) -> bool {
 /// `authorization_response_iss_parameter_supported`, the parameter is
 /// required and must match the issuer; when it is merely present, it
 /// must still match. A mismatch means the response may come from a
-/// different (potentially malicious) authorization server — mix-up
-/// attack — and aborts the flow.
+/// different (potentially malicious) authorization server -- mix-up
+/// attack -- and aborts the flow.
 fn validate_issuer(
     params: &CallbackParams,
     metadata: &AuthorizationServerMetadata,
@@ -876,7 +876,7 @@ mod tests {
         let metadata = registration_metadata("http://127.0.0.1:8919/callback");
         assert_eq!(metadata.application_type.as_deref(), Some("native"));
         assert_eq!(metadata.token_endpoint_auth_method.as_deref(), Some("none"));
-        // The wire shape is what the AS actually reads — it must stay a
+        // The wire shape is what the AS actually reads -- it must stay a
         // top-level member, not an extension field.
         let json = serde_json::to_value(&metadata).unwrap();
         assert_eq!(json["application_type"], serde_json::json!("native"));
@@ -1040,7 +1040,7 @@ mod tests {
         assert_eq!(token.as_deref(), Some("fresh-token"));
         let stored = store.get("http://127.0.0.1:3000/mcp").unwrap();
         assert_eq!(stored.access_token, "fresh-token");
-        // No rotation in the response — the old refresh token carries over.
+        // No rotation in the response -- the old refresh token carries over.
         assert_eq!(stored.refresh_token.as_deref(), Some("refresh-1"));
         // The flow state survives for the next refresh.
         assert!(session.flow.lock().await.is_some());
@@ -1054,7 +1054,7 @@ mod tests {
             Some(std::time::SystemTime::now() + std::time::Duration::from_secs(3600));
         store.put("http://127.0.0.1:3000/mcp", &tokens);
 
-        // No flow state — a refresh attempt would return None; a fresh
+        // No flow state -- a refresh attempt would return None; a fresh
         // token must never get that far.
         let session = session_with(store, None);
 
@@ -1071,7 +1071,7 @@ mod tests {
 
         let session = session_with(store, None);
 
-        // Nothing to refresh with — the current token is returned and
+        // Nothing to refresh with -- the current token is returned and
         // the 401 path decides what happens next.
         assert_eq!(
             session.refreshed_bearer().await.as_deref(),

--- a/neva/src/transport/http/core.rs
+++ b/neva/src/transport/http/core.rs
@@ -1,7 +1,7 @@
 //! Engine-agnostic Streamable HTTP transport primitives.
 //!
 //! This module owns the protocol-level logic of the MCP Streamable HTTP
-//! transport — JSON-RPC framing, SSE replay/dispatch, and the request/response
+//! transport -- JSON-RPC framing, SSE replay/dispatch, and the request/response
 //! types that flow through engine adapters. Engines (Volga, Axum, custom)
 //! implement [`engine::HttpEngine`] and call the free helpers in [`handlers`].
 

--- a/neva/src/transport/http/core/auth.rs
+++ b/neva/src/transport/http/core/auth.rs
@@ -2,8 +2,8 @@
 //!
 //! These helpers enforce the `with_roles` / `with_permissions` rules
 //! attached to tools, prompts, and resources. They operate on neva's
-//! own [`Claims`] trait so any HTTP engine — Volga, axum, hyper, a
-//! custom adapter — can opt in by implementing the trait for its claims
+//! own [`Claims`] trait so any HTTP engine -- Volga, axum, hyper, a
+//! custom adapter -- can opt in by implementing the trait for its claims
 //! type. The Volga adapter re-uses these same validators so behavior is
 //! identical across engines.
 
@@ -21,7 +21,7 @@ const ERR_UNAUTHORIZED: &str = "Subject is not authorized to invoke this";
 /// `claims` is `None`.
 ///
 /// Accepts `Option<&dyn Claims>` so the same validator runs against any
-/// engine-supplied claims type — Volga's `DefaultClaims` or a custom
+/// engine-supplied claims type -- Volga's `DefaultClaims` or a custom
 /// claims struct from an axum / hyper adapter.
 #[inline]
 pub(crate) fn validate_permissions(
@@ -163,7 +163,7 @@ mod tests {
     }
 
     /// Verify that two different `Claims`-implementing types both flow
-    /// through the same dyn-Claims validator — this is the engine
+    /// through the same dyn-Claims validator -- this is the engine
     /// neutrality contract.
     #[test]
     fn validator_accepts_heterogeneous_claims_types() {

--- a/neva/src/transport/http/core/context.rs
+++ b/neva/src/transport/http/core/context.rs
@@ -16,7 +16,7 @@ pub(crate) type RequestMap = Arc<DashMap<crate::types::RequestId, oneshot::Sende
 /// the SSE session registry, and per-session queue capacities.
 ///
 /// All fields are cheaply cloneable (Arc / Copy), so engines can move
-/// the whole context into route handlers — wrap it in `Arc` only if
+/// the whole context into route handlers -- wrap it in `Arc` only if
 /// the framework's state pattern requires that (Volga `add_singleton`,
 /// axum `with_state`).
 ///
@@ -76,7 +76,7 @@ impl HttpContext {
     /// deployed as (e.g. `"https://api.example.com/mcp"`), when OAuth is
     /// configured.
     ///
-    /// This is the audience value access tokens must be bound to — the
+    /// This is the audience value access tokens must be bound to -- the
     /// default Volga adapter feeds it into bearer validation as a
     /// required `aud`; a custom engine should enforce the same check.
     #[cfg(feature = "server-oauth")]

--- a/neva/src/transport/http/core/context.rs
+++ b/neva/src/transport/http/core/context.rs
@@ -16,9 +16,9 @@ pub(crate) type RequestMap = Arc<DashMap<crate::types::RequestId, oneshot::Sende
 /// the SSE session registry, and per-session queue capacities.
 ///
 /// All fields are cheaply cloneable (Arc / Copy), so engines can move
-/// the whole context into route handlers -- wrap it in `Arc` only if
-/// the framework's state pattern requires that (Volga `add_singleton`,
-/// axum `with_state`).
+/// the whole context into route handlers or register it in the
+/// framework's state/DI as-is -- an extra `Arc` wrap is never needed
+/// (Volga's `Dc<T>` and actix's `Data<T>` already add their own).
 ///
 /// Fields are `pub(crate)`; engines interact through the public
 /// accessors and the helpers in [`super::handlers`].

--- a/neva/src/transport/http/core/engine.rs
+++ b/neva/src/transport/http/core/engine.rs
@@ -1,4 +1,4 @@
-//! The [`HttpEngine`] contract — what an HTTP-stack adapter must implement.
+//! The [`HttpEngine`] contract -- what an HTTP-stack adapter must implement.
 
 use crate::{error::Error, types::Message};
 use std::future::Future;
@@ -15,7 +15,7 @@ use super::{
 /// HTTP conversion bridges and two SSE event constructors, and runs an
 /// HTTP server until `token` fires. All JSON-RPC framing, SSE
 /// replay/dedup, batch fast-path, and oneshot pending logic stays in
-/// neva — an engine adapter is the thinnest possible shim from neva's
+/// neva -- an engine adapter is the thinnest possible shim from neva's
 /// neutral types onto a framework's native types.
 ///
 /// Route handlers typically just call the `dispatch_*` helpers in
@@ -27,12 +27,12 @@ use super::{
 /// To enable neva's per-tool / per-prompt / per-resource role and
 /// permission gates, the engine is responsible for decoding the
 /// inbound request's auth credential (bearer token, session cookie,
-/// custom header — whatever the engine supports) into a value
+/// custom header -- whatever the engine supports) into a value
 /// implementing [`crate::auth::Claims`], wrapping it in
 /// `Arc<dyn neva::auth::Claims>`, and inserting it into
 /// `request.extensions_mut()` **before** calling [`dispatch_post`].
 ///
-/// neva itself does not parse credentials — that is the engine's job.
+/// neva itself does not parse credentials -- that is the engine's job.
 /// If no claims are inserted, neva treats the request as unauthenticated
 /// and any tool/prompt/resource that declares required roles or
 /// permissions will reject it.
@@ -49,14 +49,14 @@ use super::{
 /// responsible for two things:
 ///
 /// 1. Mount a GET route on `HttpContext::oauth_metadata_path` and serve it
-///    with `handlers::handle_oauth_metadata` — this is the RFC 9728 Protected
+///    with `handlers::handle_oauth_metadata` -- this is the RFC 9728 Protected
 ///    Resource Metadata document, reachable without authentication.
 /// 2. Answer requests that fail token validation with
 ///    `handlers::handle_unauthorized`, so the 401 carries the
 ///    `WWW-Authenticate` challenge pointing at that document and clients can
 ///    start the OAuth discovery flow.
 ///
-/// Both helpers return neva's neutral [`HttpResponse`] — pass it through
+/// Both helpers return neva's neutral [`HttpResponse`] -- pass it through
 /// `adapt_response` like any other reply.
 ///
 /// [`dispatch_post`]: super::handlers::dispatch_post
@@ -86,7 +86,7 @@ pub trait HttpEngine: Send + Sync + 'static {
     ///
     /// `Send` is intentionally not required here, so engines whose native
     /// request type holds a non-`Send` state (actix-web's `HttpRequest`
-    /// holds `Rc<…>` internally) can still implement this trait. For
+    /// holds `Rc<...>` internally) can still implement this trait. For
     /// engines whose request type is `Send`, [`dispatch_post`] /
     /// [`dispatch_delete`] / [`dispatch_get_sse`] produce `Send` futures
     /// automatically; for `!Send` engines, the futures are `!Send` and
@@ -146,7 +146,7 @@ pub trait HttpEngine: Send + Sync + 'static {
 
 /// `pub(crate)` dyn-compatible bridge: lets `TransportProto::HttpServer`
 /// store any `HttpServer<C, E>` behind a single trait object without
-/// becoming generic itself. Engines never see this trait — it lives at
+/// becoming generic itself. Engines never see this trait -- it lives at
 /// the `HttpServer` ⇄ `TransportProto` seam.
 pub(crate) trait HttpTransport: Send + Sync + 'static {
     /// Starts the engine and returns a token that, when cancelled, shuts

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -471,7 +471,19 @@ fn parse_message(body: &Bytes) -> Result<Message, ErrorCode> {
     })
 }
 
-fn get_or_create_mcp_session(headers: &HeaderMap) -> uuid::Uuid {
+fn get_or_create_mcp_session(
+    #[cfg_attr(feature = "proto-2026-07-28-rc", allow(unused_variables))] headers: &HeaderMap,
+) -> uuid::Uuid {
+    // RC removed protocol-level sessions and the `Mcp-Session-Id` header, and
+    // this id doubles as the per-POST correlation key for the pending-response
+    // slot and the request notification sink. Mint a fresh one per POST so a
+    // client-supplied (or proxied) header can never collide two concurrent
+    // stateless requests onto the same sink/slot.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    {
+        uuid::Uuid::new_v4()
+    }
+    #[cfg(not(feature = "proto-2026-07-28-rc"))]
     headers
         .get(MCP_SESSION_ID)
         .and_then(|v| v.to_str().ok())

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -302,7 +302,7 @@ async fn handle_post_streaming<E: HttpEngine>(
             let full_id = msg.full_id();
             ctx.pending.insert(full_id.clone(), resp_tx);
 
-            if !request_opts_into_notifications(&msg) {
+            if !opts_into_notifications(&msg) {
                 if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
                     ctx.pending.remove(&full_id);
                     return StreamResponse::Complete(status_response(
@@ -352,21 +352,36 @@ async fn handle_post_streaming<E: HttpEngine>(
     }
 }
 
-/// Whether a request opted into request-scoped notifications, i.e. carries a
-/// `logLevel` or `progressToken` in `_meta`.
+/// Whether a message opts into request-scoped notifications: a request -- or,
+/// for a batch, *any* contained request -- carrying `logLevel` or
+/// `progressToken` in `_meta`.
+///
+/// Batches count because a client (e.g. via `Client::apply_client_meta_to_batch`)
+/// stamps the configured level onto every batched request; the inner requests
+/// share this POST's session id (copied in `execute_batch`), so their
+/// notifications route to the one sink and stream on this single response.
 #[cfg(all(feature = "proto-2026-07-28-rc", feature = "tracing"))]
-fn request_opts_into_notifications(msg: &Message) -> bool {
-    if let Message::Request(r) = msg
-        && let Some(meta) = r
-            .params
-            .as_ref()
-            .and_then(|p| p.get("_meta"))
-            .and_then(|m| m.as_object())
-    {
-        meta.contains_key("io.modelcontextprotocol/logLevel") || meta.contains_key("progressToken")
-    } else {
-        false
+fn opts_into_notifications(msg: &Message) -> bool {
+    match msg {
+        Message::Request(r) => request_opts_in(r),
+        Message::Batch(batch) => batch.iter().any(
+            |env| matches!(env, crate::types::MessageEnvelope::Request(r) if request_opts_in(r)),
+        ),
+        _ => false,
     }
+}
+
+/// Whether a single request carries `logLevel` or `progressToken` in `_meta`.
+#[cfg(all(feature = "proto-2026-07-28-rc", feature = "tracing"))]
+fn request_opts_in(req: &crate::types::Request) -> bool {
+    req.params
+        .as_ref()
+        .and_then(|p| p.get("_meta"))
+        .and_then(|m| m.as_object())
+        .is_some_and(|meta| {
+            meta.contains_key("io.modelcontextprotocol/logLevel")
+                || meta.contains_key("progressToken")
+        })
 }
 
 /// Builds the request-scoped SSE body: it yields notifications from `notif_rx`

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -81,7 +81,7 @@ pub async fn dispatch_delete<E: HttpEngine>(
 /// native SSE response type) vs `Status(resp)` (passing `resp` through
 /// [`HttpEngine::adapt_response`]).
 ///
-/// Returns [`Err`] when [`HttpEngine::adapt_request`] fails — same
+/// Returns [`Err`] when [`HttpEngine::adapt_request`] fails -- same
 /// rationale as [`dispatch_post`].
 pub async fn dispatch_get_sse<E: HttpEngine>(
     req: E::Request,
@@ -91,7 +91,7 @@ pub async fn dispatch_get_sse<E: HttpEngine>(
     Ok(handle_get_sse::<E>(neutral, ctx).await)
 }
 
-/// Handle a POST `/{endpoint}` request — the JSON-RPC message ingress.
+/// Handle a POST `/{endpoint}` request -- the JSON-RPC message ingress.
 ///
 /// All MCP protocol logic lives here: parse body, classify as
 /// request/notification/batch, run the init pre-register, attach claims
@@ -113,7 +113,7 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
     // `MCP-Protocol-Version` header; reject before body dispatch otherwise.
     // `PROTOCOL_VERSIONS` still lists legacy versions (e.g. 2025-06-18) for
     // the non-RC build, but this build has removed the legacy initialize/SSE
-    // behavior and only speaks RC stateless semantics — so a client/proxy
+    // behavior and only speaks RC stateless semantics -- so a client/proxy
     // advertising a legacy version must be rejected, not silently served
     // under RC. Compare against the fixed RC version (the last/only RC entry)
     // rather than the whole compatibility list.
@@ -212,9 +212,9 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
 
     let (resp_tx, resp_rx) = tokio::sync::oneshot::channel::<Message>();
     // full_id() takes &self, so we can compute the key before moving msg
-    // into the send. RequestId is not Clone — the original handler used
+    // into the send. RequestId is not Clone -- the original handler used
     // the same insert-then-send order. The pending entry is reaped by
-    // the SSE registry's cleanup loop if the inbound send fails (rare —
+    // the SSE registry's cleanup loop if the inbound send fails (rare --
     // the channel is sized for hundreds of in-flight requests).
     ctx.pending.insert(msg.full_id(), resp_tx);
     if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
@@ -229,8 +229,8 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
 /// Parse the body into a [`Message`].
 ///
 /// Single-step decode: `serde_json::Error::classify()` distinguishes
-/// JSON-RPC 2.0 §5.1 ParseError (`Category::Syntax` / `Category::Eof` —
-/// the body is not valid JSON) from InvalidRequest (`Category::Data` —
+/// JSON-RPC 2.0 section 5.1 ParseError (`Category::Syntax` / `Category::Eof` --
+/// the body is not valid JSON) from InvalidRequest (`Category::Data` --
 /// the body is valid JSON but does not match any [`Message`] variant).
 fn parse_message(body: &Bytes) -> Result<Message, ErrorCode> {
     serde_json::from_slice::<Message>(body).map_err(|e| match e.classify() {
@@ -286,7 +286,7 @@ fn status_response(
     resp
 }
 
-/// Handle a DELETE `/{endpoint}` request — explicit session termination.
+/// Handle a DELETE `/{endpoint}` request -- explicit session termination.
 ///
 /// Returns 400 if `Mcp-Session-Id` is missing; otherwise terminates the
 /// SSE session in the registry (and unregisters its log channel, when
@@ -313,7 +313,7 @@ fn parse_session_id(headers: &HeaderMap) -> Option<uuid::Uuid> {
         .and_then(|s| uuid::Uuid::parse_str(s).ok())
 }
 
-/// Handle a GET on the well-known path — serves the RFC 9728 Protected
+/// Handle a GET on the well-known path -- serves the RFC 9728 Protected
 /// Resource Metadata document pre-built at server start.
 ///
 /// The engine mounts this on [`HttpContext::oauth_metadata_path`]; if the
@@ -347,7 +347,7 @@ pub fn handle_oauth_metadata(ctx: &HttpContext) -> HttpResponse {
 /// when OAuth is not configured.
 ///
 /// The default Volga adapter emits its own challenge through Volga's
-/// bearer pipeline — this helper is for custom engines that validate
+/// bearer pipeline -- this helper is for custom engines that validate
 /// tokens themselves.
 ///
 /// # Example
@@ -369,7 +369,7 @@ pub fn handle_unauthorized(ctx: &HttpContext) -> HttpResponse {
         .unwrap_or_default()
 }
 
-/// Internal item type used inside the GET handler — the engine's
+/// Internal item type used inside the GET handler -- the engine's
 /// `tracked_event` / `ephemeral_event` is invoked exactly once per emitted
 /// event to produce the engine-native representation.
 enum SseItem {
@@ -392,7 +392,7 @@ impl Drop for SseConnectionCleanup {
     }
 }
 
-/// Handle a GET `/{endpoint}` request — SSE stream subscribe.
+/// Handle a GET `/{endpoint}` request -- SSE stream subscribe.
 ///
 /// Returns `SseResponse::Status(400)` if the session id is missing,
 /// otherwise opens (or reconnects to) the session in the SSE registry

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -299,7 +299,7 @@ pub async fn handle_delete(req: HttpRequest, ctx: &HttpContext) -> HttpResponse 
             .unwrap_or_default();
     };
 
-    #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+    #[cfg(feature = "tracing")]
     crate::types::notification::fmt::LOG_REGISTRY.unregister(&id);
     ctx.sse_registry.terminate(&id);
 
@@ -385,7 +385,7 @@ struct SseConnectionCleanup {
 
 impl Drop for SseConnectionCleanup {
     fn drop(&mut self) {
-        #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+        #[cfg(feature = "tracing")]
         crate::types::notification::fmt::LOG_REGISTRY
             .unregister_if_generation(&self.id, self.generation);
         self.registry.unregister(&self.id, self.generation);
@@ -422,7 +422,7 @@ pub async fn handle_get_sse<E: HttpEngine>(
     let (_log_tx, log_rx) = tokio::sync::mpsc::channel::<Message>(ctx.sse_log_queue_capacity);
 
     let generation = ctx.sse_registry.register(id, msg_tx);
-    #[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+    #[cfg(feature = "tracing")]
     crate::types::notification::fmt::LOG_REGISTRY.register(id, generation, _log_tx);
 
     let last_seq: Option<u64> = req

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -384,11 +384,18 @@ fn request_opts_in(req: &crate::types::Request) -> bool {
         })
 }
 
-/// Builds the request-scoped SSE body: it yields notifications from `notif_rx`
-/// as they arrive (biased ahead of the response so buffered notifications lead),
-/// then the final response from `resp_rx`, then ends. Dropping the stream (end
-/// of body or client disconnect) unregisters the per-request sink and clears the
-/// pending entry.
+/// Builds the request-scoped SSE body: notifications flow as they arrive
+/// (biased ahead of the response), then the final response closes the stream.
+///
+/// The response is *buffered* rather than emitted on arrival: the terminal
+/// `message_middleware` completes it while user middleware wrapped around
+/// `next(ctx)` may still be running and logging. The stream therefore stays open
+/// until the notification channel closes -- which happens when the whole
+/// pipeline is done and `App`'s sink guard drops the sender (see
+/// `RequestSinkGuard`) -- drains what is queued, and emits the response last.
+///
+/// Dropping the stream (end of body or client disconnect) unregisters the
+/// per-request sink and clears the pending entry.
 #[cfg(all(feature = "proto-2026-07-28-rc", feature = "tracing"))]
 fn post_notification_stream(
     id: uuid::Uuid,
@@ -409,51 +416,86 @@ fn post_notification_stream(
         }
     }
 
-    enum State {
-        Active {
-            notif_rx: tokio::sync::mpsc::Receiver<Message>,
-            resp_rx: tokio::sync::oneshot::Receiver<Message>,
-            cleanup: Cleanup,
-        },
-        // Holds the cleanup guard until the stream is fully consumed.
-        Done(Cleanup),
+    struct State {
+        notif_rx: tokio::sync::mpsc::Receiver<Message>,
+        /// Taken once the response arrives (or the channel is known dead).
+        resp_rx: Option<tokio::sync::oneshot::Receiver<Message>>,
+        /// The buffered final response, emitted after the last notification.
+        response: Option<Message>,
+        /// Whether more notifications may still arrive.
+        notifs_open: bool,
+        /// Holds the cleanup guard until the stream is fully consumed.
+        _cleanup: Cleanup,
     }
 
-    let cleanup = Cleanup {
-        id,
-        full_id,
-        pending,
+    /// What one poll of the two channels produced.
+    enum Step {
+        Notification(Message),
+        NotificationsClosed,
+        Response(Option<Message>),
+    }
+
+    let state = State {
+        notif_rx,
+        resp_rx: Some(resp_rx),
+        response: None,
+        notifs_open: true,
+        _cleanup: Cleanup {
+            id,
+            full_id,
+            pending,
+        },
     };
 
-    stream::unfold(
-        State::Active {
-            notif_rx,
-            resp_rx,
-            cleanup,
-        },
-        |state| async move {
-            match state {
-                State::Done(_cleanup) => None,
-                State::Active {
-                    mut notif_rx,
-                    mut resp_rx,
-                    cleanup,
-                } => {
-                    tokio::select! {
+    stream::unfold(state, |mut state| async move {
+        while state.notifs_open {
+            // Split the borrows so both channels can be polled in one `select!`.
+            let step = {
+                let State {
+                    notif_rx, resp_rx, ..
+                } = &mut state;
+                match resp_rx.as_mut() {
+                    Some(rx) => tokio::select! {
                         biased;
-                        Some(n) = notif_rx.recv() => Some((
-                            n,
-                            State::Active { notif_rx, resp_rx, cleanup },
-                        )),
-                        r = &mut resp_rx => match r {
-                            Ok(resp) => Some((resp, State::Done(cleanup))),
-                            Err(_) => None,
+                        n = notif_rx.recv() => match n {
+                            Some(n) => Step::Notification(n),
+                            None => Step::NotificationsClosed,
                         },
-                    }
+                        r = rx => Step::Response(r.ok()),
+                    },
+                    // Response already in hand: keep draining notifications.
+                    None => match notif_rx.recv().await {
+                        Some(n) => Step::Notification(n),
+                        None => Step::NotificationsClosed,
+                    },
+                }
+            };
+
+            match step {
+                Step::Notification(n) => return Some((n, state)),
+                Step::NotificationsClosed => state.notifs_open = false,
+                Step::Response(Some(resp)) => {
+                    // Buffer it and keep draining until the pipeline is done.
+                    state.response = Some(resp);
+                    state.resp_rx = None;
+                }
+                // The response channel was dropped: the runtime will never
+                // answer, so stop waiting on notifications and end the body
+                // rather than holding the connection open.
+                Step::Response(None) => {
+                    state.resp_rx = None;
+                    state.notifs_open = false;
                 }
             }
-        },
-    )
+        }
+
+        // Pipeline finished and every notification is drained; close with the
+        // response. A dropped response channel (runtime gone) just ends the body.
+        if let Some(rx) = state.resp_rx.take() {
+            state.response = rx.await.ok();
+        }
+        state.response.take().map(|resp| (resp, state))
+    })
 }
 
 /// Parse the body into a [`Message`].

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -3,7 +3,7 @@
 //! These free functions contain all the JSON-RPC and MCP transport logic
 //! that used to live inside Volga-shaped route handlers. They take a
 //! neutral [`HttpRequest`] and an [`HttpContext`], and return a neutral
-//! [`HttpResponse`] (or an [`SseResponse`] for the GET handler).
+//! [`StreamResponse`] (POST and GET) or [`HttpResponse`] (DELETE, metadata).
 
 use crate::{
     auth::Claims,
@@ -20,31 +20,45 @@ use tokio_stream::wrappers::ReceiverStream;
 use super::{
     context::HttpContext,
     engine::HttpEngine,
-    types::{HttpRequest, HttpResponse, SseResponse},
+    types::{HttpRequest, HttpResponse, StreamResponse},
 };
 
 pub(crate) const MCP_SESSION_ID: &str = "Mcp-Session-Id";
 
 /// One-call POST pipeline for engine adapters: convert the engine-native
-/// request into neva's neutral form via [`HttpEngine::adapt_request`],
-/// run the JSON-RPC dispatch via [`handle_post`], then convert the
-/// neutral response back via [`HttpEngine::adapt_response`].
+/// request into neva's neutral form via [`HttpEngine::adapt_request`] and
+/// run the JSON-RPC dispatch.
+///
+/// The result is a [`StreamResponse`] -- the two reply shapes Streamable
+/// HTTP allows on POST (both since spec revision 2025-03-26):
+///
+/// * `Complete(resp)` -- a single-body reply (JSON object, batch array, or a
+///   bare status such as `202`); pass it through
+///   [`HttpEngine::adapt_response`].
+/// * `Stream { stream, .. }` -- a request-scoped SSE stream carrying the
+///   request's `notifications/message` / `notifications/progress` followed by
+///   its final response; frame it exactly like the GET stream. Produced under
+///   `proto-2026-07-28-rc` + `tracing` when the request opts in (carries
+///   `io.modelcontextprotocol/logLevel` or a `progressToken` in `_meta`);
+///   other builds always return `Complete`.
 ///
 /// Returns [`Err`] when [`HttpEngine::adapt_request`] fails. Engines whose
 /// native response type is itself a `Result` can integrate with `?`;
 /// engines whose response type is infallible can map the error onto an
 /// HTTP 500 of their choosing.
 ///
-/// Lets a route handler collapse to a single line, e.g. (axum):
+/// A route handler is the same two-arm match the GET route already has,
+/// e.g. (axum):
 ///
 /// ```rust,ignore
 /// async fn post_handler(
 ///     State(ctx): State<HttpContext>,
 ///     req: axum::Request<Body>,
 /// ) -> Result<axum::Response, MyError> {
-///     handlers::dispatch_post::<MyEngine>(req, &ctx)
-///         .await
-///         .map_err(MyError::from)
+///     match handlers::dispatch_post::<MyEngine>(req, &ctx).await? {
+///         StreamResponse::Stream { stream, .. } => sse_response(stream),
+///         StreamResponse::Complete(resp) => Ok(MyEngine::adapt_response(resp)),
+///     }
 /// }
 /// ```
 ///
@@ -57,10 +71,19 @@ pub(crate) const MCP_SESSION_ID: &str = "Mcp-Session-Id";
 pub async fn dispatch_post<E: HttpEngine>(
     req: E::Request,
     ctx: &HttpContext,
-) -> Result<E::Response, Error> {
+) -> Result<StreamResponse<impl Stream<Item = E::SseEvent> + Send + 'static>, Error> {
     let neutral = E::adapt_request(req).await?;
-    let resp = handle_post(neutral, ctx).await;
-    Ok(E::adapt_response(resp))
+    #[cfg(all(feature = "proto-2026-07-28-rc", feature = "tracing"))]
+    {
+        Ok(handle_post_streaming::<E>(neutral, ctx).await)
+    }
+    // Without the RC flag (or without tracing to source the notifications)
+    // every POST reply is a single body; the Stream arm is never produced.
+    #[cfg(not(all(feature = "proto-2026-07-28-rc", feature = "tracing")))]
+    {
+        let resp = handle_post(neutral, ctx).await;
+        Ok(StreamResponse::<stream::Empty<E::SseEvent>>::Complete(resp))
+    }
 }
 
 /// One-call DELETE pipeline for engine adapters. See [`dispatch_post`].
@@ -76,9 +99,9 @@ pub async fn dispatch_delete<E: HttpEngine>(
 /// One-call GET-SSE pipeline for engine adapters: converts the
 /// engine-native request to neutral and runs the GET-SSE handshake.
 ///
-/// The returned [`SseResponse`] is engine-agnostic; the engine still
+/// The returned [`StreamResponse`] is engine-agnostic; the engine still
 /// matches `Stream { headers, stream }` (wrapping the stream in its
-/// native SSE response type) vs `Status(resp)` (passing `resp` through
+/// native SSE response type) vs `Complete(resp)` (passing `resp` through
 /// [`HttpEngine::adapt_response`]).
 ///
 /// Returns [`Err`] when [`HttpEngine::adapt_request`] fails -- same
@@ -86,18 +109,23 @@ pub async fn dispatch_delete<E: HttpEngine>(
 pub async fn dispatch_get_sse<E: HttpEngine>(
     req: E::Request,
     ctx: &HttpContext,
-) -> Result<SseResponse<impl Stream<Item = E::SseEvent> + Send + 'static>, Error> {
+) -> Result<StreamResponse<impl Stream<Item = E::SseEvent> + Send + 'static>, Error> {
     let neutral = E::adapt_request(req).await?;
     Ok(handle_get_sse::<E>(neutral, ctx).await)
 }
 
-/// Handle a POST `/{endpoint}` request -- the JSON-RPC message ingress.
+/// Handle a POST `/{endpoint}` request -- the JSON-RPC message ingress,
+/// always replying with a single body (JSON object, batch array, or status).
 ///
-/// All MCP protocol logic lives here: parse body, classify as
+/// This is the JSON-only building block: parse body, classify as
 /// request/notification/batch, run the init pre-register, attach claims
 /// from `req.extensions()`, push the message onto the inbound channel,
 /// and await the response on a oneshot (for requests) or return 202
 /// immediately (for notifications and notification-only batches).
+///
+/// Prefer [`dispatch_post`], which also covers the request-scoped SSE reply
+/// (`StreamResponse::Stream`) the RC transport produces for requests that opt
+/// into notifications; use this directly only when the engine cannot stream.
 ///
 /// # Example
 ///
@@ -106,6 +134,37 @@ pub async fn dispatch_get_sse<E: HttpEngine>(
 /// // engine translates `resp` into its native response type
 /// ```
 pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
+    match prepare_post(req, ctx).await {
+        PostPrep::Reply(resp) => resp,
+        PostPrep::Dispatch { id, msg } => {
+            let (resp_tx, resp_rx) = tokio::sync::oneshot::channel::<Message>();
+            ctx.pending.insert(msg.full_id(), resp_tx);
+            if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
+                return status_response(http::StatusCode::INTERNAL_SERVER_ERROR, id);
+            }
+            match resp_rx.await {
+                Ok(resp) => build_json_response(http::StatusCode::OK, id, &resp),
+                Err(_) => status_response(http::StatusCode::INTERNAL_SERVER_ERROR, id),
+            }
+        }
+    }
+}
+
+/// Outcome of the shared POST preamble: either an early reply (protocol error,
+/// parse error, or a `202` for a notification/notification-only batch, all with
+/// side effects already applied), or a request ready to dispatch.
+enum PostPrep {
+    /// A fully-formed reply -- return it as-is.
+    Reply(HttpResponse),
+    /// A request to dispatch: `msg` already carries its session id, headers, and
+    /// claims; `id` is the per-`POST` session id used for response framing.
+    Dispatch { id: uuid::Uuid, msg: Message },
+}
+
+/// Runs the transport preamble shared by the JSON and streaming POST paths:
+/// protocol-version validation, body parse, trace-context recording, and the
+/// notification fast-paths (which forward to the runtime and reply `202`).
+async fn prepare_post(req: HttpRequest, ctx: &HttpContext) -> PostPrep {
     let mut headers = req.headers().clone();
     let id = get_or_create_mcp_session(&headers);
 
@@ -124,6 +183,7 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
             .get(crate::transport::http::MCP_PROTOCOL_VERSION)
             .and_then(|v| v.to_str().ok())
             .is_some_and(|v| Some(v) == rc_version);
+
         if !ok {
             let resp = Response::error(
                 RequestId::Null,
@@ -132,7 +192,11 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
                     "Missing or unsupported MCP-Protocol-Version header",
                 ),
             );
-            return build_json_response(http::StatusCode::OK, id, &Message::Response(resp));
+            return PostPrep::Reply(build_json_response(
+                http::StatusCode::OK,
+                id,
+                &Message::Response(resp),
+            ));
         }
     }
     // Engine-neutral claims pickup: any engine that decoded auth claims
@@ -148,7 +212,11 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
         Ok(msg) => msg,
         Err(code) => {
             let resp = Response::error(RequestId::Null, Error::from(code));
-            return build_json_response(http::StatusCode::OK, id, &Message::Response(resp));
+            return PostPrep::Reply(build_json_response(
+                http::StatusCode::OK,
+                id,
+                &Message::Response(resp),
+            ));
         }
     };
 
@@ -187,7 +255,7 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
     if matches!(msg, Message::Notification(_)) {
         let msg = msg.set_session_id(id);
         let _ = ctx.inbound_tx.send(Ok(msg)).await;
-        return status_response(http::StatusCode::ACCEPTED, id);
+        return PostPrep::Reply(status_response(http::StatusCode::ACCEPTED, id));
     }
 
     // Batch-of-notifications fast-path.
@@ -197,9 +265,9 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
     {
         let msg = msg.set_session_id(id);
         if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
-            return status_response(http::StatusCode::INTERNAL_SERVER_ERROR, id);
+            return PostPrep::Reply(status_response(http::StatusCode::INTERNAL_SERVER_ERROR, id));
         }
-        return status_response(http::StatusCode::ACCEPTED, id);
+        return PostPrep::Reply(status_response(http::StatusCode::ACCEPTED, id));
     }
 
     // Strip Authorization before forwarding (claims are already extracted).
@@ -210,20 +278,167 @@ pub async fn handle_post(req: HttpRequest, ctx: &HttpContext) -> HttpResponse {
         msg = msg.set_claims(c);
     }
 
-    let (resp_tx, resp_rx) = tokio::sync::oneshot::channel::<Message>();
-    // full_id() takes &self, so we can compute the key before moving msg
-    // into the send. RequestId is not Clone -- the original handler used
-    // the same insert-then-send order. The pending entry is reaped by
-    // the SSE registry's cleanup loop if the inbound send fails (rare --
-    // the channel is sized for hundreds of in-flight requests).
-    ctx.pending.insert(msg.full_id(), resp_tx);
-    if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
-        return status_response(http::StatusCode::INTERNAL_SERVER_ERROR, id);
+    PostPrep::Dispatch { id, msg }
+}
+
+/// The RC arm of [`dispatch_post`]: a POST pipeline that can return a
+/// request-scoped SSE response, mirroring [`handle_get_sse`].
+///
+/// When the request opts into request-scoped notifications (carries
+/// `io.modelcontextprotocol/logLevel` or a `progressToken` in `_meta`), the
+/// reply is an SSE stream: notifications produced while handling the request
+/// flow first (routed via the per-request sink), then the final response closes
+/// the stream. Otherwise the reply is a single JSON object (`Complete`),
+/// exactly as [`handle_post`].
+#[cfg(all(feature = "proto-2026-07-28-rc", feature = "tracing"))]
+async fn handle_post_streaming<E: HttpEngine>(
+    req: HttpRequest,
+    ctx: &HttpContext,
+) -> StreamResponse<impl Stream<Item = E::SseEvent> + Send + 'static> {
+    match prepare_post(req, ctx).await {
+        PostPrep::Reply(resp) => StreamResponse::Complete(resp),
+        PostPrep::Dispatch { id, msg } => {
+            let (resp_tx, resp_rx) = tokio::sync::oneshot::channel::<Message>();
+            let full_id = msg.full_id();
+            ctx.pending.insert(full_id.clone(), resp_tx);
+
+            if !request_opts_into_notifications(&msg) {
+                if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
+                    ctx.pending.remove(&full_id);
+                    return StreamResponse::Complete(status_response(
+                        http::StatusCode::INTERNAL_SERVER_ERROR,
+                        id,
+                    ));
+                }
+                return match resp_rx.await {
+                    Ok(resp) => StreamResponse::Complete(build_json_response(
+                        http::StatusCode::OK,
+                        id,
+                        &resp,
+                    )),
+                    Err(_) => StreamResponse::Complete(status_response(
+                        http::StatusCode::INTERNAL_SERVER_ERROR,
+                        id,
+                    )),
+                };
+            }
+
+            // Opted in: register the per-request notification sink (keyed by the
+            // per-POST session id, which the tracing span carries) before the
+            // runtime starts handling, then stream notifications + response.
+            let notif_rx = crate::types::notification::fmt::register_request_sink(
+                id,
+                ctx.sse_log_queue_capacity,
+            );
+
+            if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
+                crate::types::notification::fmt::unregister_request_sink(&id);
+                ctx.pending.remove(&full_id);
+                return StreamResponse::Complete(status_response(
+                    http::StatusCode::INTERNAL_SERVER_ERROR,
+                    id,
+                ));
+            }
+
+            let stream =
+                post_notification_stream(id, full_id, ctx.pending.clone(), notif_rx, resp_rx)
+                    .map(|msg| E::ephemeral_event(&msg));
+
+            StreamResponse::Stream {
+                headers: HeaderMap::new(),
+                stream,
+            }
+        }
     }
-    match resp_rx.await {
-        Ok(resp) => build_json_response(http::StatusCode::OK, id, &resp),
-        Err(_) => status_response(http::StatusCode::INTERNAL_SERVER_ERROR, id),
+}
+
+/// Whether a request opted into request-scoped notifications, i.e. carries a
+/// `logLevel` or `progressToken` in `_meta`.
+#[cfg(all(feature = "proto-2026-07-28-rc", feature = "tracing"))]
+fn request_opts_into_notifications(msg: &Message) -> bool {
+    if let Message::Request(r) = msg
+        && let Some(meta) = r
+            .params
+            .as_ref()
+            .and_then(|p| p.get("_meta"))
+            .and_then(|m| m.as_object())
+    {
+        meta.contains_key("io.modelcontextprotocol/logLevel") || meta.contains_key("progressToken")
+    } else {
+        false
     }
+}
+
+/// Builds the request-scoped SSE body: it yields notifications from `notif_rx`
+/// as they arrive (biased ahead of the response so buffered notifications lead),
+/// then the final response from `resp_rx`, then ends. Dropping the stream (end
+/// of body or client disconnect) unregisters the per-request sink and clears the
+/// pending entry.
+#[cfg(all(feature = "proto-2026-07-28-rc", feature = "tracing"))]
+fn post_notification_stream(
+    id: uuid::Uuid,
+    full_id: RequestId,
+    pending: super::context::RequestMap,
+    notif_rx: tokio::sync::mpsc::Receiver<Message>,
+    resp_rx: tokio::sync::oneshot::Receiver<Message>,
+) -> impl Stream<Item = Message> + Send {
+    struct Cleanup {
+        id: uuid::Uuid,
+        full_id: RequestId,
+        pending: super::context::RequestMap,
+    }
+    impl Drop for Cleanup {
+        fn drop(&mut self) {
+            crate::types::notification::fmt::unregister_request_sink(&self.id);
+            self.pending.remove(&self.full_id);
+        }
+    }
+
+    enum State {
+        Active {
+            notif_rx: tokio::sync::mpsc::Receiver<Message>,
+            resp_rx: tokio::sync::oneshot::Receiver<Message>,
+            cleanup: Cleanup,
+        },
+        // Holds the cleanup guard until the stream is fully consumed.
+        Done(Cleanup),
+    }
+
+    let cleanup = Cleanup {
+        id,
+        full_id,
+        pending,
+    };
+
+    stream::unfold(
+        State::Active {
+            notif_rx,
+            resp_rx,
+            cleanup,
+        },
+        |state| async move {
+            match state {
+                State::Done(_cleanup) => None,
+                State::Active {
+                    mut notif_rx,
+                    mut resp_rx,
+                    cleanup,
+                } => {
+                    tokio::select! {
+                        biased;
+                        Some(n) = notif_rx.recv() => Some((
+                            n,
+                            State::Active { notif_rx, resp_rx, cleanup },
+                        )),
+                        r = &mut resp_rx => match r {
+                            Ok(resp) => Some((resp, State::Done(cleanup))),
+                            Err(_) => None,
+                        },
+                    }
+                }
+            }
+        },
+    )
 }
 
 /// Parse the body into a [`Message`].
@@ -394,9 +609,9 @@ impl Drop for SseConnectionCleanup {
 
 /// Handle a GET `/{endpoint}` request -- SSE stream subscribe.
 ///
-/// Returns `SseResponse::Status(400)` if the session id is missing,
+/// Returns `StreamResponse::Complete(400)` if the session id is missing,
 /// otherwise opens (or reconnects to) the session in the SSE registry
-/// and returns `SseResponse::Stream { headers, stream }` where `stream`
+/// and returns `StreamResponse::Stream { headers, stream }` where `stream`
 /// is an `impl Stream<Item = E::SseEvent>` produced by calling the
 /// engine's [`HttpEngine::tracked_event`] / [`HttpEngine::ephemeral_event`]
 /// for each underlying `SseItem`.
@@ -407,9 +622,9 @@ impl Drop for SseConnectionCleanup {
 pub async fn handle_get_sse<E: HttpEngine>(
     req: HttpRequest,
     ctx: &HttpContext,
-) -> SseResponse<impl Stream<Item = E::SseEvent> + Send + 'static> {
+) -> StreamResponse<impl Stream<Item = E::SseEvent> + Send + 'static> {
     let Some(id) = parse_session_id(req.headers()) else {
-        return SseResponse::Status(
+        return StreamResponse::Complete(
             http::Response::builder()
                 .status(http::StatusCode::BAD_REQUEST)
                 .body(Bytes::new())
@@ -473,7 +688,7 @@ pub async fn handle_get_sse<E: HttpEngine>(
         headers.insert(MCP_SESSION_ID, v);
     }
 
-    SseResponse::Stream {
+    StreamResponse::Stream {
         headers,
         stream: guarded,
     }
@@ -715,8 +930,8 @@ mod tests {
             .unwrap();
         let resp = handle_get_sse::<TestEngine>(req, &ctx).await;
         match resp {
-            SseResponse::Status(r) => assert_eq!(r.status(), http::StatusCode::BAD_REQUEST),
-            SseResponse::Stream { .. } => panic!("expected Status, got Stream"),
+            StreamResponse::Complete(r) => assert_eq!(r.status(), http::StatusCode::BAD_REQUEST),
+            StreamResponse::Stream { .. } => panic!("expected Status, got Stream"),
         }
     }
 
@@ -733,13 +948,13 @@ mod tests {
             .unwrap();
         let resp = handle_get_sse::<TestEngine>(req, &ctx).await;
         match resp {
-            SseResponse::Stream { headers, stream: _ } => {
+            StreamResponse::Stream { headers, stream: _ } => {
                 assert_eq!(
                     headers.get(MCP_SESSION_ID).and_then(|v| v.to_str().ok()),
                     Some(id.to_string().as_str())
                 );
             }
-            SseResponse::Status(_) => panic!("expected Stream, got Status"),
+            StreamResponse::Complete(_) => panic!("expected Stream, got Status"),
         }
     }
 

--- a/neva/src/transport/http/core/oauth.rs
+++ b/neva/src/transport/http/core/oauth.rs
@@ -5,8 +5,8 @@
 //! ([RFC 9728](https://www.rfc-editor.org/rfc/rfc9728)) and answer
 //! unauthorized requests with a `WWW-Authenticate` bearer challenge that
 //! points at it. This module owns the engine-neutral half of that
-//! contract — options, one-time resolution into a ready-to-serve document,
-//! and the challenge — so any [`HttpEngine`](super::engine::HttpEngine)
+//! contract -- options, one-time resolution into a ready-to-serve document,
+//! and the challenge -- so any [`HttpEngine`](super::engine::HttpEngine)
 //! (Volga, axum, hyper, a custom adapter) serves byte-identical metadata.
 //!
 //! Protocol-level types come from
@@ -16,7 +16,7 @@
 //!
 //! Token *validation* deliberately stays the engine's job (the default
 //! Volga adapter uses Volga's bearer/JWKS pipeline; a custom engine brings
-//! its own middleware) — see the authorization contract on
+//! its own middleware) -- see the authorization contract on
 //! [`HttpEngine`](super::engine::HttpEngine).
 
 use bytes::Bytes;
@@ -37,7 +37,7 @@ pub use volga_oauth_core::{
 /// The `resource` identifier defaults to the server's own URL
 /// (`proto://addr/endpoint`) and only needs
 /// [`with_resource`](Self::with_resource) when the public URL differs
-/// from the bind address — e.g. behind a reverse proxy.
+/// from the bind address -- e.g. behind a reverse proxy.
 ///
 /// # Example
 /// ```no_run
@@ -62,7 +62,7 @@ impl OAuthResourceOptions {
     ///
     /// Defaults to the server's own URL. Set it when clients reach the
     /// server through a different public URL than the bind address
-    /// (reverse proxy, TLS termination). The value is canonicalized —
+    /// (reverse proxy, TLS termination). The value is canonicalized --
     /// scheme/host lowercased, default ports dropped.
     ///
     /// # Example
@@ -156,7 +156,7 @@ impl OAuthResourceOptions {
     /// Resolves the options against the server's base URL into the
     /// ready-to-serve [`OAuthResource`]: canonicalizes the resource
     /// identifier (defaulting it to `base_url`), derives the metadata
-    /// URL/path per RFC 9728 §3.1, pre-serializes the document, and
+    /// URL/path per RFC 9728 section 3.1, pre-serializes the document, and
     /// pre-renders the `WWW-Authenticate` challenge.
     pub(crate) fn resolve(self, base_url: &str) -> Result<OAuthResource, Error> {
         let mut metadata = self.metadata;
@@ -191,7 +191,7 @@ impl OAuthResourceOptions {
 pub(crate) struct OAuthResource {
     /// Pre-serialized RFC 9728 metadata document.
     pub(crate) body: Bytes,
-    /// Absolute URL of the metadata document — the `resource_metadata`
+    /// Absolute URL of the metadata document -- the `resource_metadata`
     /// value of the bearer challenge.
     pub(crate) metadata_url: Arc<str>,
     /// Path the engine mounts the metadata route on
@@ -199,15 +199,15 @@ pub(crate) struct OAuthResource {
     pub(crate) metadata_path: Arc<str>,
     /// Pre-rendered `WWW-Authenticate` header value.
     pub(crate) challenge: Arc<str>,
-    /// Canonicalized resource identifier (RFC 8707) — the audience value
+    /// Canonicalized resource identifier (RFC 8707) -- the audience value
     /// access tokens must be bound to.
     pub(crate) resource: Arc<str>,
 }
 
 /// Strips the scheme and authority off an absolute URL, leaving the path.
 ///
-/// `metadata_url` always carries a path (RFC 9728 §3.1 inserts the
-/// well-known segment), so the fallback is unreachable — it only exists
+/// `metadata_url` always carries a path (RFC 9728 section 3.1 inserts the
+/// well-known segment), so the fallback is unreachable -- it only exists
 /// to keep the function total without panicking.
 fn well_known_path(url: &str) -> &str {
     url.find("://")

--- a/neva/src/transport/http/core/types.rs
+++ b/neva/src/transport/http/core/types.rs
@@ -10,7 +10,7 @@ use http::HeaderMap;
 
 /// Engine-neutral inbound HTTP request.
 ///
-/// The body is fully buffered to [`Bytes`] before this type is constructed —
+/// The body is fully buffered to [`Bytes`] before this type is constructed --
 /// MCP messages are bounded JSON-RPC frames and the protocol handlers always
 /// buffer the whole body before parsing.
 ///
@@ -39,7 +39,7 @@ pub type HttpResponse = http::Response<Bytes>;
 
 /// Outcome of the GET handler: either an SSE stream or a non-SSE status reply.
 ///
-/// `Stream` is the happy path — 200 OK + the event stream.
+/// `Stream` is the happy path -- 200 OK + the event stream.
 /// `Status` is returned when the request couldn't establish a session
 /// (typically 400 with no `Mcp-Session-Id` header).
 #[derive(Debug)]
@@ -65,7 +65,7 @@ pub enum SseResponse<S> {
 ///
 /// Under the default Volga adapter, `volga::auth::AuthClaims` is also
 /// re-exported as [`crate::auth::Claims`], and the Volga-flavored
-/// `DefaultClaims` implements this trait too — so the same validator
+/// `DefaultClaims` implements this trait too -- so the same validator
 /// runs for every engine.
 ///
 /// # Example
@@ -104,30 +104,30 @@ pub trait Claims: std::fmt::Debug + Send + Sync + 'static {
 }
 
 /// Engine-agnostic pre-built [`Claims`] type matching the JWT standard
-/// claim names. Available for every HTTP engine — under the Volga
+/// claim names. Available for every HTTP engine -- under the Volga
 /// adapter it also implements `volga::auth::AuthClaims` so it can be
 /// fed straight into Volga's bearer-auth pipeline.
 #[derive(Default, Clone, Debug, serde::Deserialize)]
 pub struct DefaultClaims {
-    /// JWT `sub` claim — subject.
+    /// JWT `sub` claim -- subject.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sub: Option<String>,
-    /// JWT `iss` claim — issuer.
+    /// JWT `iss` claim -- issuer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iss: Option<String>,
-    /// JWT `aud` claim — audience.
+    /// JWT `aud` claim -- audience.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aud: Option<String>,
-    /// JWT `exp` claim — expiration time (seconds since epoch).
+    /// JWT `exp` claim -- expiration time (seconds since epoch).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exp: Option<i64>,
-    /// JWT `nbf` claim — not-before time.
+    /// JWT `nbf` claim -- not-before time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nbf: Option<i64>,
-    /// JWT `iat` claim — issued-at time.
+    /// JWT `iat` claim -- issued-at time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub iat: Option<i64>,
-    /// JWT `jti` claim — token id.
+    /// JWT `jti` claim -- token id.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub jti: Option<String>,
     /// Subject role.

--- a/neva/src/transport/http/core/types.rs
+++ b/neva/src/transport/http/core/types.rs
@@ -37,13 +37,20 @@ pub type HttpRequest = http::Request<Bytes>;
 /// ```
 pub type HttpResponse = http::Response<Bytes>;
 
-/// Outcome of the GET handler: either an SSE stream or a non-SSE status reply.
+/// Outcome of a streaming-capable handler: an SSE stream or a complete
+/// (single-body) reply.
 ///
-/// `Stream` is the happy path -- 200 OK + the event stream.
-/// `Status` is returned when the request couldn't establish a session
-/// (typically 400 with no `Mcp-Session-Id` header).
+/// This is the neutral shape of every MCP HTTP reply. Streamable HTTP has
+/// allowed both forms on `POST` since 2025-03-26: a single JSON body (one
+/// object, or an array for a batch) or a `text/event-stream` carrying
+/// request-scoped messages. The GET handler uses the same shape for the
+/// session SSE stream on the legacy transport.
+///
+/// `Stream` is the streaming path -- 200 OK + the event stream.
+/// `Complete` is a finished single-body reply: a JSON object or batch array,
+/// a `202 Accepted`, or an error status.
 #[derive(Debug)]
-pub enum SseResponse<S> {
+pub enum StreamResponse<S> {
     /// 200 OK with an SSE event stream.
     Stream {
         /// Response headers (typically just `Mcp-Session-Id`).
@@ -51,9 +58,15 @@ pub enum SseResponse<S> {
         /// Stream of engine-native SSE event values.
         stream: S,
     },
-    /// Non-streaming status response (e.g. 400 when no session id is provided).
-    Status(HttpResponse),
+    /// A complete non-streaming reply (JSON body or bare status).
+    Complete(HttpResponse),
 }
+
+/// Former name of [`StreamResponse`], kept for one release.
+///
+/// Note the `Status` variant is now [`StreamResponse::Complete`].
+#[deprecated(note = "renamed to StreamResponse; the Status variant is now Complete")]
+pub type SseResponse<S> = StreamResponse<S>;
 
 /// Typed claims contract used by neva's per-tool authorization checks.
 ///

--- a/neva/src/transport/http/server.rs
+++ b/neva/src/transport/http/server.rs
@@ -1,4 +1,4 @@
-//! HTTP server module — under the `http-server-volga` default feature
+//! HTTP server module -- under the `http-server-volga` default feature
 //! this re-exports the Volga adapter; under bare `http-server` alone
 //! it is essentially empty.
 

--- a/neva/src/transport/http/server/volga/auth_config.rs
+++ b/neva/src/transport/http/server/volga/auth_config.rs
@@ -36,12 +36,12 @@ pub struct AuthConfig<C: AuthClaims = DefaultClaims> {
 
     /// Whether the user configured an audience themselves (via
     /// [`with_aud`](Self::with_aud) / [`with_resource`](Self::with_resource) /
-    /// [`with_resources`](Self::with_resources)) — suppresses the
+    /// [`with_resources`](Self::with_resources)) -- suppresses the
     /// OAuth-mode default of binding tokens to the canonical resource URI.
     #[cfg(feature = "server-oauth")]
     aud_configured: bool,
 
-    /// Whether the user configured acceptable issuers themselves —
+    /// Whether the user configured acceptable issuers themselves --
     /// suppresses the OAuth-mode default of requiring the configured
     /// issuer.
     #[cfg(feature = "server-oauth")]
@@ -140,7 +140,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     /// tokens.
     ///
     /// In OAuth issuer mode this is set automatically to the server's
-    /// canonical resource URI — call it only to accept a different
+    /// canonical resource URI -- call it only to accept a different
     /// audience (e.g. a public URL behind a reverse proxy).
     ///
     /// # Example
@@ -284,7 +284,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     /// Switches token validation to OAuth 2.1/OIDC issuer mode: instead
     /// of a static decoding key, the issuer's JSON Web Key Set is
     /// discovered (RFC 8414, with an OIDC fallback) and used to validate
-    /// incoming JWTs, keyed by each token's `kid` — with rotation,
+    /// incoming JWTs, keyed by each token's `kid` -- with rotation,
     /// refresh cooldown and key-age limits handled by Volga.
     ///
     /// MCP defaults applied automatically unless overridden: the token's
@@ -317,7 +317,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     }
 
     /// The issuer configured through [`with_oauth`](Self::with_oauth),
-    /// if any — used by the transport to seed the Protected Resource
+    /// if any -- used by the transport to seed the Protected Resource
     /// Metadata document when it was not configured explicitly.
     #[cfg(feature = "server-oauth")]
     pub(crate) fn oauth_issuer(&self) -> Option<&str> {
@@ -347,7 +347,7 @@ impl<C: AuthClaims> AuthConfig<C> {
     }
 
     /// Takes the Volga-facing OAuth issuer configuration out, validating
-    /// that an issuer was actually provided — `with_oauth` without
+    /// that an issuer was actually provided -- `with_oauth` without
     /// `with_issuer` is a configuration error that must fail startup.
     #[cfg(feature = "server-oauth")]
     pub(crate) fn take_oauth(&mut self) -> Result<Option<VolgaOAuthConfig>, crate::error::Error> {
@@ -395,7 +395,7 @@ impl Debug for OAuthConfig {
 #[cfg(feature = "server-oauth")]
 impl OAuthConfig {
     /// Sets the issuer identifier URL whose keys validate bearer tokens.
-    /// Mandatory — OAuth mode without an issuer fails server start.
+    /// Mandatory -- OAuth mode without an issuer fails server start.
     ///
     /// # Example
     /// ```no_run
@@ -526,7 +526,7 @@ mod tests {
     }
 
     // `BearerAuthConfig` keeps its audience set private; its `Debug` impl
-    // exposes the RFC 8707 `resources` list, which `with_resource` feeds —
+    // exposes the RFC 8707 `resources` list, which `with_resource` feeds --
     // assert through that.
     fn resources_of(auth: &AuthConfig) -> String {
         format!("{:?}", auth.inner)

--- a/neva/src/transport/http/server/volga/engine.rs
+++ b/neva/src/transport/http/server/volga/engine.rs
@@ -1,4 +1,4 @@
-//! [`VolgaEngine`] — the default [`HttpEngine`] implementation.
+//! [`VolgaEngine`] -- the default [`HttpEngine`] implementation.
 //!
 //! This engine is bound by `HttpServer` when the `http-server-volga`
 //! feature is enabled. It owns the Volga adapter logic exclusively: any
@@ -35,7 +35,7 @@ use super::routes;
 /// use neva::transport::http::server::volga::VolgaEngine;
 ///
 /// let engine = VolgaEngine::default();
-/// // wired into `HttpServer` by Task 13 — engines never run standalone.
+/// // wired into `HttpServer` by Task 13 -- engines never run standalone.
 /// ```
 #[derive(Default)]
 pub struct VolgaEngine {
@@ -122,14 +122,14 @@ impl HttpEngine for VolgaEngine {
                 // URI (RFC 8707) and `iss` must match the issuer.
                 #[cfg(feature = "server-oauth")]
                 auth.apply_mcp_defaults(ctx.oauth_resource());
-                // `with_oauth` without an issuer is a config error —
+                // `with_oauth` without an issuer is a config error --
                 // surface it as a failed start, not a Volga panic.
                 #[cfg(feature = "server-oauth")]
                 let volga_oauth = auth.take_oauth()?;
 
                 let (bearer, rules) = auth.into_parts();
                 // Advertise the RFC 9728 document on Volga's own 401
-                // challenges: `WWW-Authenticate: Bearer resource_metadata="…"`.
+                // challenges: `WWW-Authenticate: Bearer resource_metadata="..."`.
                 #[cfg(feature = "server-oauth")]
                 let bearer = match &oauth_metadata_url {
                     Some(url) => bearer.with_resource_metadata_url(url.as_str()),
@@ -166,7 +166,7 @@ impl HttpEngine for VolgaEngine {
                 }
                 mcp.map_post("/", routes::post);
                 // Stateless RC transport has no SSE GET stream and no
-                // session-termination DELETE — only POST is routed.
+                // session-termination DELETE -- only POST is routed.
                 #[cfg(not(feature = "proto-2026-07-28-rc"))]
                 {
                     mcp.map_get("/", routes::get);
@@ -174,7 +174,7 @@ impl HttpEngine for VolgaEngine {
                 }
             });
 
-        // RFC 9728 §3: the Protected Resource Metadata document must be
+        // RFC 9728 section 3: the Protected Resource Metadata document must be
         // reachable without credentials.
         #[cfg(feature = "server-oauth")]
         if let Some(path) = &oauth_metadata_path {

--- a/neva/src/transport/http/server/volga/engine.rs
+++ b/neva/src/transport/http/server/volga/engine.rs
@@ -117,9 +117,6 @@ impl HttpEngine for VolgaEngine {
     }
 
     async fn run(self, ctx: HttpContext, token: CancellationToken) -> Result<(), Error> {
-        // Volga wires shared state through DI as `Arc<HttpContext>`, so
-        // wrap once here for the duration of the engine's lifetime.
-        let ctx = Arc::new(ctx);
         let addr = ctx.addr().to_owned();
         let endpoint = ctx.endpoint().to_owned();
         #[cfg(feature = "server-oauth")]

--- a/neva/src/transport/http/server/volga/engine.rs
+++ b/neva/src/transport/http/server/volga/engine.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, ErrorCode};
 use crate::transport::http::core::{
     context::HttpContext,
     engine::HttpEngine,
-    types::{HttpRequest as NeutralRequest, HttpResponse as NeutralResponse},
+    types::{DefaultClaims, HttpRequest as NeutralRequest, HttpResponse as NeutralResponse},
 };
 use crate::types::Message;
 #[cfg(feature = "server-tls")]
@@ -58,6 +58,16 @@ impl HttpEngine for VolgaEngine {
     type SseEvent = SseMessage;
 
     async fn adapt_request(req: Self::Request) -> Result<NeutralRequest, Error> {
+        // Claims decoded and validated by Volga's `authorize` middleware --
+        // the single decode path for both static-key and OAuth/JWKS modes.
+        // Reading them from the request (rather than re-decoding the
+        // `Authorization` header) also survives Volga's default
+        // `strip_token_from_request`, which removes the header before the
+        // route runs. Inserting them here (per the `HttpEngine` contract)
+        // keeps the Volga routes on the same `dispatch_*` seam as every
+        // other engine.
+        let claims: Option<::volga::auth::Authenticated<DefaultClaims>> = req.extract().ok();
+
         let mut builder = http::Request::builder()
             .method(req.method().clone())
             .uri(req.uri().clone())
@@ -72,9 +82,17 @@ impl HttpEngine for VolgaEngine {
         let body = read_body(req.into_body())
             .await
             .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))?;
-        builder
+
+        let mut neutral = builder
             .body(body)
-            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))
+            .map_err(|e| Error::new(ErrorCode::InternalError, e.to_string()))?;
+
+        if let Some(claims) = claims {
+            let claims: Arc<dyn crate::auth::Claims> = Arc::new(claims.into_inner());
+            neutral.extensions_mut().insert(claims);
+        }
+
+        Ok(neutral)
     }
 
     fn adapt_response(resp: NeutralResponse) -> Self::Response {
@@ -86,6 +104,7 @@ impl HttpEngine for VolgaEngine {
         for (name, value) in parts.headers.iter() {
             builder = builder.header_raw(name.as_str(), value.as_bytes());
         }
+
         builder.body(http_body)
     }
 

--- a/neva/src/transport/http/server/volga/routes.rs
+++ b/neva/src/transport/http/server/volga/routes.rs
@@ -8,47 +8,36 @@
 //! routes call those methods so the seam matches every other engine.
 
 use crate::transport::http::core::{
-    context::HttpContext, engine::HttpEngine, handlers, types::SseResponse,
+    context::HttpContext, engine::HttpEngine, handlers, types::StreamResponse,
 };
 use ::volga::{
-    HttpRequest, HttpResult, auth::Authenticated, di::Dc, error::Error as VolgaError,
-    http::sse::Message as SseMessage, sse,
+    HttpRequest, HttpResult, di::Dc, error::Error as VolgaError, http::sse::Message as SseMessage,
+    sse,
 };
 use std::sync::Arc;
 
 use super::engine::VolgaEngine;
-use crate::auth::Claims;
-use crate::transport::http::core::types::DefaultClaims;
 
 /// `POST /<endpoint>` -- JSON-RPC ingress.
-pub(crate) async fn post(req: HttpRequest) -> HttpResult {
-    let manager: Dc<Arc<HttpContext>> = req.extract()?;
-
-    // Claims decoded and validated by Volga's `authorize` middleware --
-    // the single decode path for both static-key and OAuth/JWKS modes.
-    // Reading them from the request (rather than re-decoding the
-    // `Authorization` header) also survives Volga's default
-    // `strip_token_from_request`, which removes the header before the
-    // route runs.
-    let claims: Option<Authenticated<DefaultClaims>> = req.extract().ok();
-
-    let mut neutral = VolgaEngine::adapt_request(req)
+///
+/// The same two-arm shape as [`get`]: `dispatch_post` yields a
+/// [`StreamResponse`], where `Stream` is a request-scoped SSE reply (RC:
+/// the request's `notifications/message` / `notifications/progress`
+/// followed by its response) and `Complete` is a single-body reply.
+/// Claims are attached inside [`VolgaEngine::adapt_request`], per the
+/// `HttpEngine` contract.
+pub(crate) async fn post(req: HttpRequest, manager: Dc<Arc<HttpContext>>) -> HttpResult {
+    //let manager: Dc<Arc<HttpContext>> = req.extract()?;
+    let outcome = handlers::dispatch_post::<VolgaEngine>(req, &manager)
         .await
         .map_err(to_volga_err)?;
-
-    // Stash claims (if any) in the neutral request's extensions so the
-    // engine-agnostic handler can attach them to the outgoing message.
-    // The wire shape here is `Arc<dyn Claims>`, matching the contract
-    // documented on `HttpEngine` -- every engine inserts its own
-    // `Claims`-implementing type wrapped in `Arc<dyn Claims>` so neva's
-    // per-tool/prompt/resource gates run identically across engines.
-    if let Some(claims) = claims {
-        let claims: Arc<dyn Claims> = Arc::new(claims.into_inner());
-        neutral.extensions_mut().insert(claims);
+    match outcome {
+        StreamResponse::Stream { stream, .. } => {
+            let stream = futures_util::StreamExt::map(stream, Ok::<SseMessage, VolgaError>);
+            sse!(stream)
+        }
+        StreamResponse::Complete(resp) => VolgaEngine::adapt_response(resp),
     }
-
-    let resp = handlers::handle_post(neutral, &manager).await;
-    VolgaEngine::adapt_response(resp)
 }
 
 /// `DELETE /<endpoint>` -- explicit session termination.
@@ -76,7 +65,7 @@ pub(crate) async fn get(req: HttpRequest) -> HttpResult {
         .await
         .map_err(to_volga_err)?;
     match outcome {
-        SseResponse::Stream { headers, stream } => {
+        StreamResponse::Stream { headers, stream } => {
             let session_id = headers
                 .get(handlers::MCP_SESSION_ID)
                 .and_then(|v| v.to_str().ok())
@@ -88,7 +77,7 @@ pub(crate) async fn get(req: HttpRequest) -> HttpResult {
                 sse!(stream)
             }
         }
-        SseResponse::Status(resp) => VolgaEngine::adapt_response(resp),
+        StreamResponse::Complete(resp) => VolgaEngine::adapt_response(resp),
     }
 }
 

--- a/neva/src/transport/http/server/volga/routes.rs
+++ b/neva/src/transport/http/server/volga/routes.rs
@@ -14,9 +14,14 @@ use ::volga::{
     HttpRequest, HttpResult, di::Dc, error::Error as VolgaError, http::sse::Message as SseMessage,
     sse,
 };
-use std::sync::Arc;
 
 use super::engine::VolgaEngine;
+
+// Extractor ordering matters in these signatures: `Dc<T>` reads the request
+// parts by reference (`Source::Parts`), while `HttpRequest` consumes them
+// (`Source::Request`, a `parts.take()`). Volga resolves handler arguments
+// left to right, so `Dc<HttpContext>` must come before `HttpRequest` --
+// swapped around, the `Dc` extractor finds nothing to read from.
 
 /// `POST /<endpoint>` -- JSON-RPC ingress.
 ///
@@ -26,8 +31,7 @@ use super::engine::VolgaEngine;
 /// followed by its response) and `Complete` is a single-body reply.
 /// Claims are attached inside [`VolgaEngine::adapt_request`], per the
 /// `HttpEngine` contract.
-pub(crate) async fn post(req: HttpRequest, manager: Dc<Arc<HttpContext>>) -> HttpResult {
-    //let manager: Dc<Arc<HttpContext>> = req.extract()?;
+pub(crate) async fn post(manager: Dc<HttpContext>, req: HttpRequest) -> HttpResult {
     let outcome = handlers::dispatch_post::<VolgaEngine>(req, &manager)
         .await
         .map_err(to_volga_err)?;
@@ -45,8 +49,7 @@ pub(crate) async fn post(req: HttpRequest, manager: Dc<Arc<HttpContext>>) -> Htt
 /// Not routed under `proto-2026-07-28-rc` (stateless: no sessions); kept
 /// compiled for the non-RC build.
 #[cfg_attr(feature = "proto-2026-07-28-rc", allow(dead_code))]
-pub(crate) async fn delete(req: HttpRequest) -> HttpResult {
-    let manager: Dc<Arc<HttpContext>> = req.extract()?;
+pub(crate) async fn delete(manager: Dc<HttpContext>, req: HttpRequest) -> HttpResult {
     let neutral = VolgaEngine::adapt_request(req)
         .await
         .map_err(to_volga_err)?;
@@ -59,8 +62,7 @@ pub(crate) async fn delete(req: HttpRequest) -> HttpResult {
 /// Not routed under `proto-2026-07-28-rc` (stateless: no SSE GET stream);
 /// kept compiled for the non-RC build.
 #[cfg_attr(feature = "proto-2026-07-28-rc", allow(dead_code))]
-pub(crate) async fn get(req: HttpRequest) -> HttpResult {
-    let manager: Dc<Arc<HttpContext>> = req.extract()?;
+pub(crate) async fn get(manager: Dc<HttpContext>, req: HttpRequest) -> HttpResult {
     let outcome = handlers::dispatch_get_sse::<VolgaEngine>(req, &manager)
         .await
         .map_err(to_volga_err)?;
@@ -89,8 +91,7 @@ pub(crate) async fn get(req: HttpRequest) -> HttpResult {
 /// without credentials -- it is what a client reads to find out *how* to
 /// authenticate.
 #[cfg(feature = "server-oauth")]
-pub(crate) async fn oauth_metadata(req: HttpRequest) -> HttpResult {
-    let manager: Dc<Arc<HttpContext>> = req.extract()?;
+pub(crate) async fn oauth_metadata(manager: Dc<HttpContext>) -> HttpResult {
     VolgaEngine::adapt_response(handlers::handle_oauth_metadata(&manager))
 }
 

--- a/neva/src/transport/http/server/volga/routes.rs
+++ b/neva/src/transport/http/server/volga/routes.rs
@@ -1,4 +1,4 @@
-//! Volga route shells — each is the thinnest possible bridge from a
+//! Volga route shells -- each is the thinnest possible bridge from a
 //! `volga::HttpRequest` into the engine-agnostic helpers in
 //! [`crate::transport::http::core::handlers`].
 //!
@@ -20,11 +20,11 @@ use super::engine::VolgaEngine;
 use crate::auth::Claims;
 use crate::transport::http::core::types::DefaultClaims;
 
-/// `POST /<endpoint>` — JSON-RPC ingress.
+/// `POST /<endpoint>` -- JSON-RPC ingress.
 pub(crate) async fn post(req: HttpRequest) -> HttpResult {
     let manager: Dc<Arc<HttpContext>> = req.extract()?;
 
-    // Claims decoded and validated by Volga's `authorize` middleware —
+    // Claims decoded and validated by Volga's `authorize` middleware --
     // the single decode path for both static-key and OAuth/JWKS modes.
     // Reading them from the request (rather than re-decoding the
     // `Authorization` header) also survives Volga's default
@@ -39,7 +39,7 @@ pub(crate) async fn post(req: HttpRequest) -> HttpResult {
     // Stash claims (if any) in the neutral request's extensions so the
     // engine-agnostic handler can attach them to the outgoing message.
     // The wire shape here is `Arc<dyn Claims>`, matching the contract
-    // documented on `HttpEngine` — every engine inserts its own
+    // documented on `HttpEngine` -- every engine inserts its own
     // `Claims`-implementing type wrapped in `Arc<dyn Claims>` so neva's
     // per-tool/prompt/resource gates run identically across engines.
     if let Some(claims) = claims {
@@ -51,7 +51,7 @@ pub(crate) async fn post(req: HttpRequest) -> HttpResult {
     VolgaEngine::adapt_response(resp)
 }
 
-/// `DELETE /<endpoint>` — explicit session termination.
+/// `DELETE /<endpoint>` -- explicit session termination.
 ///
 /// Not routed under `proto-2026-07-28-rc` (stateless: no sessions); kept
 /// compiled for the non-RC build.
@@ -65,7 +65,7 @@ pub(crate) async fn delete(req: HttpRequest) -> HttpResult {
     VolgaEngine::adapt_response(resp)
 }
 
-/// `GET /<endpoint>` — SSE subscribe.
+/// `GET /<endpoint>` -- SSE subscribe.
 ///
 /// Not routed under `proto-2026-07-28-rc` (stateless: no SSE GET stream);
 /// kept compiled for the non-RC build.
@@ -92,12 +92,12 @@ pub(crate) async fn get(req: HttpRequest) -> HttpResult {
     }
 }
 
-/// `GET /.well-known/oauth-protected-resource[/<endpoint>]` — the RFC 9728
+/// `GET /.well-known/oauth-protected-resource[/<endpoint>]` -- the RFC 9728
 /// Protected Resource Metadata document.
 ///
 /// Publicly reachable by design: authorization is scoped to the MCP
-/// endpoint group, and RFC 9728 §3 requires the metadata to be fetchable
-/// without credentials — it is what a client reads to find out *how* to
+/// endpoint group, and RFC 9728 section 3 requires the metadata to be fetchable
+/// without credentials -- it is what a client reads to find out *how* to
 /// authenticate.
 #[cfg(feature = "server-oauth")]
 pub(crate) async fn oauth_metadata(req: HttpRequest) -> HttpResult {

--- a/neva/src/transport/stdio.rs
+++ b/neva/src/transport/stdio.rs
@@ -118,25 +118,25 @@ impl StdIoSender {
     }
 }
 
-/// The direction an unreadable line has to travel — a parse failure is
+/// The direction an unreadable line has to travel -- a parse failure is
 /// answered or completed depending on what the line *was*, and routing it
 /// the wrong way loses it silently.
 enum Line {
-    /// A readable message — hand it to the receive loop.
+    /// A readable message -- hand it to the receive loop.
     Message(Message),
-    /// An unreadable inbound **request**: JSON-RPC 2.0 §5 says the peer
+    /// An unreadable inbound **request**: JSON-RPC 2.0 section 5 says the peer
     /// gets an error response, so this goes straight back out the
     /// transport's sender rather than into pending-request handling.
     Reply(Message),
-    /// Nothing actionable — logged and dropped.
+    /// Nothing actionable -- logged and dropped.
     Drop,
 }
 
 /// Parses one stdio line into a [`Message`].
 ///
-/// A line that isn't a readable `Message` — malformed JSON, or a JSON-RPC
+/// A line that isn't a readable `Message` -- malformed JSON, or a JSON-RPC
 /// error whose `code` falls outside neva's [`ErrorCode`] set (the TS SDK's
-/// `-32000` "server not initialized" family) — must **not** tear down the
+/// `-32000` "server not initialized" family) -- must **not** tear down the
 /// receive loop: the peer is alive and every following line is still
 /// readable. Pushing a bare `Err` did exactly that, and since the loop
 /// died before completing the pending request, the caller saw a timeout
@@ -145,7 +145,7 @@ enum Line {
 /// A malformed **response** carrying an `id` belongs to a request this side
 /// is waiting on: it is reported as an id-bound `ParseError` so the pending
 /// request completes with the real cause. That is what makes the RC
-/// client's dual-mode fallback reachable over stdio — it classifies such a
+/// client's dual-mode fallback reachable over stdio -- it classifies such a
 /// rejection as "legacy peer" and retries `initialize`, which a timeout
 /// never could.
 ///
@@ -155,14 +155,14 @@ enum Line {
 /// silently swallow it and leave the peer waiting out its own timeout.
 ///
 /// A line whose JSON is broken outright can't be classified at all, so
-/// JSON-RPC 2.0 §5.1 prescribes the answer directly: a parse error with
+/// JSON-RPC 2.0 section 5.1 prescribes the answer directly: a parse error with
 /// [`RequestId::Null`](crate::types::RequestId::Null).
 ///
 /// Dropped, because no move applies:
 ///
-/// * a malformed **notification** — a `method` but no `id`. JSON-RPC 2.0
-///   §4.1 forbids replying to notifications;
-/// * a response-shaped line with no usable `id` — it completes no pending
+/// * a malformed **notification** -- a `method` but no `id`. JSON-RPC 2.0
+///   section 4.1 forbids replying to notifications;
+/// * a response-shaped line with no usable `id` -- it completes no pending
 ///   request, and answering a response is not a thing.
 fn parse_line(line: &str) -> Line {
     let err = match serde_json::from_str::<Message>(line) {
@@ -177,7 +177,7 @@ fn parse_line(line: &str) -> Line {
         ))
     };
 
-    // Broken JSON: nothing to classify, and §5.1 answers exactly this case.
+    // Broken JSON: nothing to classify, and section 5.1 answers exactly this case.
     let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
         return Line::Reply(reply(crate::types::RequestId::Null));
     };
@@ -461,7 +461,7 @@ mod parse_line_tests {
     }
 
     /// The regression the fix is really about: the bad line must not end
-    /// the stream — the pending request completes *and* the following
+    /// the stream -- the pending request completes *and* the following
     /// lines keep arriving.
     #[tokio::test]
     async fn a_bad_line_neither_ends_the_stream_nor_is_swallowed() {
@@ -484,7 +484,7 @@ mod parse_line_tests {
         assert_eq!(resp.id, RequestId::Number(1));
         assert_eq!(resp.error.code, ErrorCode::ParseError);
 
-        // The garbage line is answered out-of-band (§5.1) rather than
+        // The garbage line is answered out-of-band (section 5.1) rather than
         // routed here, so the next thing the loop sees is the good line.
         assert!(
             matches!(receiver.recv().await, Ok(Message::Notification(_))),
@@ -516,7 +516,7 @@ mod parse_line_tests {
         assert_eq!(resp.id, RequestId::Number(42));
         assert_eq!(resp.error.code, ErrorCode::ParseError);
 
-        // The bad request never reaches the receive loop — the next thing
+        // The bad request never reaches the receive loop -- the next thing
         // it sees is the following, well-formed line.
         assert!(
             matches!(receiver.recv().await, Ok(Message::Notification(_))),
@@ -524,7 +524,7 @@ mod parse_line_tests {
         );
     }
 
-    /// JSON-RPC 2.0 §5.1: invalid JSON is answered with a parse error
+    /// JSON-RPC 2.0 section 5.1: invalid JSON is answered with a parse error
     /// carrying `"id": null`, since there is no id to salvage.
     #[test]
     fn broken_json_is_answered_with_a_null_id() {
@@ -536,7 +536,7 @@ mod parse_line_tests {
             let Line::Reply(Message::Response(crate::types::Response::Err(resp))) =
                 parse_line(line)
             else {
-                panic!("broken JSON must be answered per §5.1: {line}");
+                panic!("broken JSON must be answered per section 5.1: {line}");
             };
             assert_eq!(resp.id, RequestId::Null);
             assert_eq!(resp.error.code, ErrorCode::ParseError);
@@ -559,7 +559,7 @@ mod parse_line_tests {
 
     #[test]
     fn unanswerable_lines_are_dropped_not_fatal() {
-        // A `method` but no `id` — a notification, which JSON-RPC §4.1
+        // A `method` but no `id` -- a notification, which JSON-RPC section 4.1
         // forbids replying to. An explicit `null` id is just as unaddressable.
         for line in [
             r#"{"jsonrpc":"2.0","method":123}"#,

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -73,7 +73,7 @@ pub use tool::ToolHandler;
 /// matching the MCP 2026-07-28 RC requirement that tool schemas carry
 /// full JSON Schema 2020-12 documents.
 ///
-/// Use this alias in code that constructs or accepts tool schemas — it lets
+/// Use this alias in code that constructs or accepts tool schemas -- it lets
 /// the same call site compile on both feature sets. Both backing types
 /// implement [`Default`], serde derive, and the relevant
 /// `From<serde_json::Value>` / `From<schemars::Schema>` conversions, so a
@@ -91,7 +91,7 @@ pub type ToolInputSchema = tool::ToolSchema;
 
 /// The MCP schema type for tool input and output schemas.
 ///
-/// See the legacy-flag definition above for the full doc — under the
+/// See the legacy-flag definition above for the full doc -- under the
 /// `proto-2026-07-28-rc` feature this alias resolves to
 /// [`schema_2020::InputSchema`].
 ///
@@ -167,7 +167,7 @@ mod reference;
 mod request;
 pub mod resource;
 mod response;
-// Under the RC these are no longer capability-driven server→client requests,
+// Under the RC these are no longer capability-driven server->client requests,
 // but the types did not go away: they are the params/results of the deprecated
 // `roots/list` and `sampling/createMessage` MRTR input-request kinds (#85), so
 // both peers need them in every build.
@@ -256,7 +256,7 @@ pub struct MessageBatch {
     /// Copied onto each inner [`Request`] in `execute_batch` so that
     /// role/permission guards work correctly for batched HTTP calls.
     ///
-    /// Type-erased — the HTTP engine may insert any [`Claims`]-implementing
+    /// Type-erased -- the HTTP engine may insert any [`Claims`]-implementing
     /// type (e.g. neva's `DefaultClaims`, or a custom claims struct).
     #[cfg(feature = "http-server")]
     pub(crate) claims: Option<Arc<dyn Claims>>,
@@ -337,7 +337,7 @@ impl MessageBatch {
     /// Used by the HTTP transport alongside [`Self::has_requests`] to decide
     /// whether a pending reply slot must be allocated. Batches with error
     /// responses include synthetic `InvalidRequest` errors that the deserializer
-    /// injects for malformed items — those require an HTTP reply so the caller
+    /// injects for malformed items -- those require an HTTP reply so the caller
     /// receives the per-item error payloads.
     #[inline]
     #[cfg(feature = "http-server")]
@@ -359,7 +359,7 @@ impl IntoIterator for MessageBatch {
 
 impl Serialize for MessageBatch {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        // `id` and `session_id` are internal — only the items are sent over the wire.
+        // `id` and `session_id` are internal -- only the items are sent over the wire.
         self.items.serialize(serializer)
     }
 }
@@ -367,7 +367,7 @@ impl Serialize for MessageBatch {
 impl<'de> Deserialize<'de> for MessageBatch {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         // Parse as raw JSON values first so that a single malformed element
-        // does not discard the entire batch (JSON-RPC §6 requires per-item
+        // does not discard the entire batch (JSON-RPC section 6 requires per-item
         // Invalid Request responses, not a top-level failure).
         let raw = Vec::<serde_json::Value>::deserialize(deserializer)?;
         if raw.is_empty() {
@@ -377,7 +377,7 @@ impl<'de> Deserialize<'de> for MessageBatch {
         }
 
         // Every item either deserializes cleanly or produces an error response.
-        // Items without an id use RequestId::Null (JSON-RPC 2.0 §5.1 requires
+        // Items without an id use RequestId::Null (JSON-RPC 2.0 section 5.1 requires
         // `"id": null` when the id cannot be extracted from a malformed request).
         let items: Vec<MessageEnvelope> = raw
             .into_iter()
@@ -736,7 +736,7 @@ impl Message {
     /// Sets Authentication and Authorization claims for [`Request`] or [`MessageBatch`] message.
     ///
     /// Accepts an [`Arc`]-wrapped trait object so any HTTP engine can
-    /// attach its own [`Claims`]-implementing type — neva does not
+    /// attach its own [`Claims`]-implementing type -- neva does not
     /// require the concrete type, only that it can supply roles and
     /// permissions for the per-tool/prompt/resource gate.
     #[cfg(feature = "http-server")]
@@ -924,7 +924,7 @@ mod tests {
     #[test]
     fn message_batch_emits_null_error_for_malformed_item_without_id() {
         // A malformed item with no "id" yields an Invalid Request response with
-        // a null id (JSON-RPC 2.0 §5.1).
+        // a null id (JSON-RPC 2.0 section 5.1).
         let json = r#"[
             {"jsonrpc":"2.0","id":1,"method":"ping","params":null},
             {"not":"valid json-rpc"}
@@ -973,7 +973,7 @@ mod tests {
     #[test]
     fn message_batch_all_malformed_without_ids_produces_null_error_responses() {
         // Even when every item is malformed with no id, the batch deserializes
-        // successfully and produces null-id Invalid Request error responses —
+        // successfully and produces null-id Invalid Request error responses --
         // one per item.
         let json = r#"[{"not":"valid"},{"also":"not valid"}]"#;
         let batch: MessageBatch = serde_json::from_str(json).unwrap();

--- a/neva/src/types/mrtr.rs
+++ b/neva/src/types/mrtr.rs
@@ -4,23 +4,23 @@
 //! reply with [`InputRequiredResult`] to request additional input before
 //! completing. The kind of input is the [`InputRequest`] union: elicitation
 //! (first-class), plus the deprecated-on-arrival sampling and roots kinds the
-//! spec re-homed here when it removed their capability-driven server→client
+//! spec re-homed here when it removed their capability-driven server->client
 //! requests.
 //!
 //! # `requestState`: sealed, not merely signed
 //!
-//! MRTR is stateless — all cross-round progress travels through the client, which
+//! MRTR is stateless -- all cross-round progress travels through the client, which
 //! echoes the opaque `requestState` blob back on each retry. How that blob is
 //! protected is therefore a design decision, not a detail. neva **seals** it with
 //! ChaCha20-Poly1305 (AEAD) rather than **signing** it (HMAC).
 //!
 //! A signed state is tamper-*evident*: the client cannot alter it undetected, but
 //! it can **read** it. That suffices while the state carries only what the client
-//! already knows — the answers it supplied itself. It stops sufficing the moment
+//! already knows -- the answers it supplied itself. It stops sufficing the moment
 //! the server puts its *own* data in there, which is precisely what
 //! `Context::memo` does: a memoized value is
-//! server-computed — an upstream API response, a quoted price, a record looked up
-//! under the caller's identity, a downstream token — and it is written into the
+//! server-computed -- an upstream API response, a quoted price, a record looked up
+//! under the caller's identity, a downstream token -- and it is written into the
 //! state so the next round replays it instead of recomputing it. Signing alone
 //! would publish every such value to the client, and to anything that logs a
 //! request body in between.
@@ -37,32 +37,32 @@
 //!   `App::with_request_state_secret`
 //!   (rotated via
 //!   `App::with_request_state_keys`)
-//!   upholds confidentiality, not just integrity — treat it as a secret.
+//!   upholds confidentiality, not just integrity -- treat it as a secret.
 //!
 //! # Side effects across rounds are the framework's problem
 //!
 //! Re-run + replay means a handler executes from the top on *every* round, so
 //! anything with a side effect between rounds is at risk of running more than
-//! once. The protocol itself says nothing about this — it is left to each
+//! once. The protocol itself says nothing about this -- it is left to each
 //! implementation, and an SDK may reasonably hand the problem to the application
 //! author. neva does not:
 //!
-//! * `Context::memo` — compute once, replay the value on
+//! * `Context::memo` -- compute once, replay the value on
 //!   later rounds (sealed into `requestState`, hence the section above).
-//! * `Context::once` — run an effect at most once across
+//! * `Context::once` -- run an effect at most once across
 //!   the whole chain.
-//! * `Context::on_commit` — defer an effect until the
+//! * `Context::on_commit` -- defer an effect until the
 //!   handler actually reaches its final result, so an abandoned or failed chain
 //!   never applies it.
-//! * `RequestStateStore` — close the one gap the
+//! * `RequestStateStore` -- close the one gap the
 //!   sealed state structurally cannot: the final round mints no new state, so a
 //!   lost HTTP response would otherwise re-run the handler and its commits on
 //!   retry. The store caches the committed final response and replays it verbatim.
 //!   It is on by default (in-process); a multi-instance deployment supplies a
 //!   shared implementation.
 //!
-//! Together these make an MRTR handler safe to write in the obvious way — charge
-//! the card, send the receipt — without hand-rolling idempotency keys per tool.
+//! Together these make an MRTR handler safe to write in the obvious way -- charge
+//! the card, send the receipt -- without hand-rolling idempotency keys per tool.
 //! See `docs/specs/2026-05-30-mrtr-design.md` for the full design.
 
 // The encrypted `requestState` codec is server-only: the client treats
@@ -86,7 +86,7 @@ pub struct InputRequiredResult {
     #[serde(rename = "resultType")]
     pub result_type: InputRequiredTag,
 
-    /// Server-assigned-key → elicitation request the client must fulfil.
+    /// Server-assigned-key -> elicitation request the client must fulfil.
     ///
     /// `None` is **reserved** for a future async/streaming semantic where the
     /// server is making progress on its own and the client should simply retry
@@ -101,11 +101,11 @@ pub struct InputRequiredResult {
     pub request_state: Option<String>,
 }
 
-/// Map of server-assigned key → the input request envelope the client must
+/// Map of server-assigned key -> the input request envelope the client must
 /// fulfil.
 pub type InputRequests = HashMap<String, InputRequest>;
 
-/// Map of key (matching an [`InputRequests`] key) → the client's raw result.
+/// Map of key (matching an [`InputRequests`] key) -> the client's raw result.
 ///
 /// The value stays a [`serde_json::Value`] because the result *type* depends on
 /// the kind of input that was requested ([`ElicitResult`](crate::types::elicitation::ElicitResult),
@@ -115,18 +115,18 @@ pub type InputRequests = HashMap<String, InputRequest>;
 /// `ctx.memo` does.
 pub type InputResponses = HashMap<String, serde_json::Value>;
 
-/// One `{ method, params }` input-request envelope — the kind of input the
+/// One `{ method, params }` input-request envelope -- the kind of input the
 /// server is asking the client for.
 ///
 /// The spec did not delete sampling and roots when the capability-driven
-/// server→client requests went away: it re-homed them here, as MRTR input
+/// server->client requests went away: it re-homed them here, as MRTR input
 /// request kinds, keyed by `method`. Elicitation stays first-class; the other
 /// two arrive **already deprecated** (see the variant docs), matching the
 /// spec's own 12-month lifecycle for roots/sampling/logging.
 ///
 /// Intentionally *not* [`crate::types::Request`]: the wire shape is exactly
 /// `{ method, params }` (the per-key id is the map key), whereas `Request`
-/// has required `jsonrpc`/`id` fields — emitting it would add non-spec fields
+/// has required `jsonrpc`/`id` fields -- emitting it would add non-spec fields
 /// and deserializing a conformant peer's bare `{method,params}` would fail.
 /// Deserialization is hand-written rather than derived (see the `impl` below):
 /// the adjacent tag would make `params` mandatory, and a conforming peer may
@@ -134,11 +134,11 @@ pub type InputResponses = HashMap<String, serde_json::Value>;
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "method", content = "params")]
 pub enum InputRequest {
-    /// `elicitation/create` — ask the end user for structured input.
+    /// `elicitation/create` -- ask the end user for structured input.
     #[serde(rename = "elicitation/create")]
     Elicitation(ElicitRequestParams),
 
-    /// `sampling/createMessage` — ask the client's LLM for a completion.
+    /// `sampling/createMessage` -- ask the client's LLM for a completion.
     ///
     /// **Deprecated on arrival.** The ability returns re-homed onto MRTR, but
     /// it stays on the spec's deprecation path; prefer designing tools that do
@@ -149,7 +149,7 @@ pub enum InputRequest {
     )]
     Sampling(Box<CreateMessageRequestParams>),
 
-    /// `roots/list` — ask the client which filesystem roots it exposes.
+    /// `roots/list` -- ask the client which filesystem roots it exposes.
     ///
     /// **Deprecated on arrival**, same as [`Self::Sampling`].
     #[serde(rename = "roots/list")]
@@ -166,7 +166,7 @@ impl<'de> Deserialize<'de> for InputRequest {
     /// conforming peer may send a bare `{"method": "roots/list"}` (or an
     /// explicit `null`). An absent value is read as an empty object rather
     /// than as "use the default", so each kind's own params type still decides
-    /// what is acceptable — `roots/list` decodes (every field is optional)
+    /// what is acceptable -- `roots/list` decodes (every field is optional)
     /// while a paramless `elicitation/create` or `sampling/createMessage`
     /// fails with that type's own error, as it should.
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
@@ -229,13 +229,13 @@ pub struct ClientMrtrCapabilities {
 
     /// Whether the client can fulfil `sampling/createMessage` input requests.
     ///
-    /// A **deprecated** request kind — see [`InputRequest::Sampling`].
+    /// A **deprecated** request kind -- see [`InputRequest::Sampling`].
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub sampling: bool,
 
     /// Whether the client can fulfil `roots/list` input requests.
     ///
-    /// A **deprecated** request kind — see [`InputRequest::Roots`].
+    /// A **deprecated** request kind -- see [`InputRequest::Roots`].
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub roots: bool,
 }
@@ -325,7 +325,7 @@ mod tests {
     }
 
     /// The union must keep the flat `{ method, params }` envelope for every
-    /// kind — the `method` is the discriminator, not a nested tag.
+    /// kind -- the `method` is the discriminator, not a nested tag.
     #[test]
     fn every_input_kind_roundtrips_as_a_method_params_envelope() {
         #[allow(deprecated)]
@@ -432,7 +432,7 @@ mod tests {
         assert!(!caps.sampling);
         assert!(!caps.roots);
 
-        // …and a default set serializes to nothing at all.
+        // ...and a default set serializes to nothing at all.
         let json = serde_json::to_value(ClientMrtrCapabilities::default()).unwrap();
         assert_eq!(json, serde_json::json!({}));
     }

--- a/neva/src/types/mrtr/state.rs
+++ b/neva/src/types/mrtr/state.rs
@@ -4,7 +4,7 @@
 //! rationale is user-facing and lives in the [`mrtr`](crate::types::mrtr)
 //! module docs. Beyond confidentiality and the authentication tag, the payload
 //! carries a TTL, a binding to the originating request and a binding to the
-//! authenticated principal — see [`StatePayload`].
+//! authenticated principal -- see [`StatePayload`].
 
 use chacha20poly1305::aead::{Aead, Generate, KeyInit, Payload};
 use chacha20poly1305::{ChaCha20Poly1305, Nonce};
@@ -50,7 +50,7 @@ pub(crate) struct StatePayload {
     /// already present in [`StatePayload::answers`]); anything else is unsolicited and
     /// must be rejected, otherwise a client could pre-seed/overwrite answers
     /// for inputs the server never asked for. Defaults to empty so an older
-    /// payload schema still decodes — and, by design, rejects any
+    /// payload schema still decodes -- and, by design, rejects any
     /// `inputResponses` paired with it.
     #[serde(default)]
     pub requested: Vec<String>,
@@ -76,7 +76,7 @@ pub(crate) struct StateKeyring {
     /// Kid new blobs are sealed under. Must resolve in [`Self::keys`], or
     /// [`StateCodec::encode`] fails.
     active_kid: Box<str>,
-    /// Accepted `kid → secret` map used to select the decryption key by the
+    /// Accepted `kid -> secret` map used to select the decryption key by the
     /// kid segment of the inbound blob.
     keys: HashMap<Box<str>, Arc<[u8]>>,
 }
@@ -92,7 +92,7 @@ impl std::fmt::Debug for StateKeyring {
 }
 
 impl StateKeyring {
-    /// Single-key ring under [`DEFAULT_KID`] — the
+    /// Single-key ring under [`DEFAULT_KID`] -- the
     /// [`crate::App::with_request_state_secret`] path.
     pub(crate) fn single(secret: &[u8]) -> Self {
         Self::new(DEFAULT_KID, [(DEFAULT_KID, secret)])
@@ -194,7 +194,7 @@ impl<'a> StateCodec<'a> {
     }
 
     /// Decrypts and verifies integrity, selecting the key by the blob's kid
-    /// segment. Does NOT check `exp`/`req`/`principal` — callers do that
+    /// segment. Does NOT check `exp`/`req`/`principal` -- callers do that
     /// against the returned [`StatePayload`].
     pub(crate) fn decode(&self, blob: &str) -> Result<StatePayload, Error> {
         use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD as B64};
@@ -490,7 +490,7 @@ mod tests {
     #[test]
     fn legacy_two_segment_blob_is_rejected_as_malformed() {
         // The pre-versioning wire format (`b64(nonce).b64(ct)`) must not be
-        // taken for a v1 blob — segment-count parsing rejects it outright.
+        // taken for a v1 blob -- segment-count parsing rejects it outright.
         let ring = ring(b"secret-key");
         let codec = StateCodec::new(&ring);
         let blob = codec.encode(&payload()).unwrap();

--- a/neva/src/types/notification.rs
+++ b/neva/src/types/notification.rs
@@ -9,22 +9,25 @@ use crate::{
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
-#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
-pub use log_message::{LogMessage, LoggingLevel, SetLevelRequestParams};
+// `notifications/message` (and its `LoggingLevel`/`LogMessage` payload) is kept
+// under MCP 2026-07-28 as a deprecated, request-scoped notification. Only the
+// `logging/setLevel` handshake (`SetLevelRequestParams`) is removed under the RC.
+#[cfg(not(feature = "proto-2026-07-28-rc"))]
+pub use log_message::SetLevelRequestParams;
+pub use log_message::{LogMessage, LoggingLevel};
 
 #[cfg(feature = "server")]
 use crate::app::handler::{FromHandlerParams, HandlerParams};
 
 pub use progress::ProgressNotification;
 
-#[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "tracing")]
 pub use formatter::NotificationFormatter;
 
-#[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "tracing")]
 pub mod fmt;
-#[cfg(all(feature = "tracing", not(feature = "proto-2026-07-28-rc")))]
+#[cfg(feature = "tracing")]
 mod formatter;
-#[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
 mod log_message;
 mod progress;
 
@@ -37,7 +40,6 @@ pub mod commands {
     pub const CANCELLED: &str = "notifications/cancelled";
 
     /// Notification name that indicates that a new log message has been received.
-    #[cfg(any(not(feature = "proto-2026-07-28-rc"), feature = "client"))]
     pub const MESSAGE: &str = "notifications/message";
 
     /// Notification name that indicates that a progress notification has been received.
@@ -144,10 +146,7 @@ impl Notification {
 
     /// Writes the [`Notification`]
     #[inline]
-    #[cfg(all(
-        feature = "tracing",
-        any(not(feature = "proto-2026-07-28-rc"), feature = "client")
-    ))]
+    #[cfg(feature = "tracing")]
     pub fn write(self) {
         let is_stderr = self.is_stderr();
         let Some(params) = self.params else {

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -2,6 +2,8 @@
 
 use crate::shared::MessageRegistry;
 #[cfg(feature = "proto-2026-07-28-rc")]
+use crate::types::Message;
+#[cfg(feature = "proto-2026-07-28-rc")]
 use crate::types::notification::LoggingLevel;
 use crate::types::notification::{Notification, formatter::build_notification};
 use once_cell::sync::Lazy;
@@ -26,7 +28,53 @@ const MCP_LOG_LEVEL: &str = "mcp_log_level";
 
 pub(crate) static LOG_REGISTRY: Lazy<MessageRegistry> = Lazy::new(MessageRegistry::new);
 
+/// Per-request notification sinks for the RC stateless HTTP transport, keyed by
+/// the per-`POST` session id (each stateless `POST` mints a fresh one).
+///
+/// The RC transport has no `GET`/SSE stream, so request-scoped notifications
+/// (`notifications/message`, `notifications/progress`) flow on the originating
+/// request's `POST` response stream instead. `handle_post` registers a sink
+/// before dispatch and drains it into that response; the notification layer
+/// routes events fired while handling the request to the matching sink.
+#[cfg(feature = "proto-2026-07-28-rc")]
+pub(crate) static REQUEST_NOTIFICATIONS: Lazy<dashmap::DashMap<uuid::Uuid, Sender<Message>>> =
+    Lazy::new(dashmap::DashMap::new);
+
+/// Registers a per-request notification sink for `id` (the per-`POST` session
+/// id). Returns the receiving end for the `POST` response stream to drain.
+///
+/// Only the HTTP server writes sinks; the layer (which may run client-side too)
+/// merely reads [`REQUEST_NOTIFICATIONS`], so these live behind `http-server`.
+#[cfg(all(feature = "proto-2026-07-28-rc", feature = "http-server"))]
+pub(crate) fn register_request_sink(
+    id: uuid::Uuid,
+    capacity: usize,
+) -> tokio::sync::mpsc::Receiver<Message> {
+    let (tx, rx) = channel::<Message>(capacity);
+    REQUEST_NOTIFICATIONS.insert(id, tx);
+    rx
+}
+
+/// Removes the per-request notification sink for `id`.
+#[cfg(all(feature = "proto-2026-07-28-rc", feature = "http-server"))]
+pub(crate) fn unregister_request_sink(id: &uuid::Uuid) {
+    REQUEST_NOTIFICATIONS.remove(id);
+}
+
 /// Creates a custom tracing layer that delivers messages to MCP Client
+///
+/// This layer routes notifications to a connected client. On the legacy HTTP
+/// transport that is the session-scoped SSE `GET` stream.
+///
+/// # MCP 2026-07-28 (`proto-2026-07-28-rc`)
+///
+/// The RC HTTP transport is stateless (no `GET`/SSE stream, no sessions), so
+/// request-scoped notifications flow on the *originating request's `POST`
+/// response stream*, per the spec. This layer routes each event to the
+/// per-request sink registered by the POST handler (keyed by the per-`POST`
+/// session id the request span carries); the `POST` reply is then a
+/// `text/event-stream` carrying the notifications followed by the response.
+/// The same works over stdio, where notifications interleave on stdout.
 ///
 /// # Example
 /// ```no_run
@@ -116,6 +164,18 @@ where
                 if !super::formatter::message_delivered(requested, event_severity) {
                     return;
                 }
+            }
+
+            // RC: request-scoped notifications flow on the originating request's
+            // `POST` response stream (there is no session SSE `GET`). Route to the
+            // per-request sink registered by `handle_post` for this `POST` session
+            // id; fall through to the legacy session-SSE path otherwise.
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            if let Some(session_id) = notification.session_id
+                && let Some(sink) = REQUEST_NOTIFICATIONS.get(&session_id)
+            {
+                let _ = sink.try_send(Message::Notification(notification));
+                return;
             }
 
             self.sender.send_notification(notification);

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -24,7 +24,7 @@ const MCP_SESSION_ID: &str = "mcp_session_id";
 /// Span field carrying the request-scoped minimum severity (RC), as the
 /// [`LoggingLevel`] RFC-5424 severity rank rather than a redundant string.
 #[cfg(feature = "proto-2026-07-28-rc")]
-const MCP_LOG_LEVEL: &str = "mcp_log_level";
+pub(super) const MCP_LOG_LEVEL: &str = "mcp_log_level";
 
 pub(crate) static LOG_REGISTRY: Lazy<MessageRegistry> = Lazy::new(MessageRegistry::new);
 
@@ -197,10 +197,13 @@ where
 /// under MCP 2026-07-28, the request-scoped [`LoggingLevel`]) into a span's
 /// extensions.
 ///
-/// The [`layer`] function's `MpscLayer` records this itself; add
-/// [`span_context`] alongside a plain `tracing_subscriber::fmt` layer that uses
-/// [`NotificationFormatter`](super::NotificationFormatter) (the stdio setup) so
-/// that formatter can apply the request-scoped `notifications/message` filter.
+/// This is an optimization, not a requirement. The [`layer`] function's
+/// `MpscLayer` records the context itself, and the stdio
+/// [`NotificationFormatter`](super::NotificationFormatter) resolves the
+/// request-scoped level from the span fields `fmt::Layer` already records when no
+/// extension is present -- so both emission paths apply the request-scoped
+/// `notifications/message` filter with or without this layer. Adding it next to
+/// the stdio formatter just replaces that lookup with a typed one.
 #[derive(Debug, Default)]
 pub struct SpanContextLayer;
 

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -143,7 +143,13 @@ where
         let notification = build_notification(event);
         if let Some(span) = ctx.event_span(event) {
             let mut notification = notification;
-            notification.session_id = span.extensions().get::<uuid::Uuid>().cloned();
+            // Resolve the request context through the whole span scope, not just
+            // the immediate span: an event emitted from a child span (e.g. a
+            // `#[tracing::instrument]` handler) sits below the `request` span
+            // that carries the extensions.
+            notification.session_id = span
+                .scope()
+                .find_map(|s| s.extensions().get::<uuid::Uuid>().cloned());
 
             // RC: `logging/setLevel` is gone; the level is request-scoped. Deliver
             // a `notifications/message` only when the originating request carried
@@ -430,5 +436,50 @@ mod tests {
         let got = levels(&got);
         assert!(got.contains(&"emergency".to_owned()), "got: {got:?}");
         assert!(!got.contains(&"error".to_owned()), "got: {got:?}");
+    }
+
+    /// Drives `MpscLayer` (the HTTP/SSE emit path) with the request context on an
+    /// *ancestor* span, the way a `#[tracing::instrument]` handler emits: from a
+    /// child span that carries no MCP fields of its own.
+    #[tokio::test]
+    async fn routes_events_from_nested_spans_to_the_request_sink() {
+        use crate::types::Message;
+        use crate::types::notification::Notification;
+
+        let session_id = uuid::Uuid::new_v4();
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::channel::<Message>(8);
+        super::REQUEST_NOTIFICATIONS.insert(session_id, sink_tx);
+
+        let (fallback_tx, mut fallback_rx) = tokio::sync::mpsc::channel::<Notification>(8);
+        let subscriber = tracing_subscriber::registry().with(super::MpscLayer {
+            sender: super::NotificationSender::new(fallback_tx),
+        });
+
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                mcp_session_id = session_id.to_string(),
+                mcp_log_level = u64::from(LoggingLevel::Debug.severity())
+            );
+            let _entered = request.enter();
+            let handler = tracing::info_span!("handler");
+            let _handler = handler.enter();
+            tracing::warn!(logger = "tool", "nested message");
+        });
+
+        super::REQUEST_NOTIFICATIONS.remove(&session_id);
+
+        let msg = sink_rx
+            .try_recv()
+            .expect("an event from a nested span must still reach the request sink");
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["method"], "notifications/message");
+        assert_eq!(json["params"]["data"]["message"], "nested message");
+        // ...and it must not fall through to the legacy session-SSE registry,
+        // which has no reader on the RC stateless transport.
+        assert!(
+            fallback_rx.try_recv().is_err(),
+            "request-scoped notification leaked to the legacy path"
+        );
     }
 }

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -1,6 +1,8 @@
 //! A generic tracing/logging formatting layer for notifications
 
 use crate::shared::MessageRegistry;
+#[cfg(feature = "proto-2026-07-28-rc")]
+use crate::types::notification::LoggingLevel;
 use crate::types::notification::{Notification, formatter::build_notification};
 use once_cell::sync::Lazy;
 use std::io::{self, Write};
@@ -16,6 +18,11 @@ use tracing_subscriber::{
 };
 
 const MCP_SESSION_ID: &str = "mcp_session_id";
+
+/// Span field carrying the request-scoped minimum severity (RC), as the
+/// [`LoggingLevel`] RFC-5424 severity rank rather than a redundant string.
+#[cfg(feature = "proto-2026-07-28-rc")]
+const MCP_LOG_LEVEL: &str = "mcp_log_level";
 
 pub(crate) static LOG_REGISTRY: Lazy<MessageRegistry> = Lazy::new(MessageRegistry::new);
 
@@ -80,20 +87,35 @@ where
 {
     #[inline]
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
-        let mut visitor = SpanVisitor { session_id: None };
-        attrs.record(&mut visitor);
-        if let Some(span) = ctx.span(id)
-            && let Some(mcp_session_id) = visitor.session_id
-        {
-            span.extensions_mut().insert(mcp_session_id);
-        }
+        record_span_context(attrs, id, &ctx);
     }
 
     #[inline]
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
-        let mut notification = build_notification(event);
+        let notification = build_notification(event);
         if let Some(span) = ctx.event_span(event) {
+            let mut notification = notification;
             notification.session_id = span.extensions().get::<uuid::Uuid>().cloned();
+
+            // RC: `logging/setLevel` is gone; the level is request-scoped. Deliver
+            // a `notifications/message` only when the originating request carried
+            // `io.modelcontextprotocol/logLevel` and this event is at or above
+            // that severity. Without a requested level, log messages are
+            // suppressed. Progress notifications are never gated this way.
+            #[cfg(feature = "proto-2026-07-28-rc")]
+            if notification.method.as_str() == crate::types::notification::commands::MESSAGE {
+                let requested = span.scope().find_map(|s| {
+                    s.extensions()
+                        .get::<super::formatter::MinLogSeverity>()
+                        .map(|m| m.0)
+                });
+
+                let event_severity = LoggingLevel::from(event.metadata().level()).severity();
+                if !super::formatter::message_delivered(requested, event_severity) {
+                    return;
+                }
+            }
+
             self.sender.send_notification(notification);
         } else {
             let mut stderr = io::stderr();
@@ -103,8 +125,74 @@ where
     }
 }
 
+/// A tracing [`Layer`] that only records the MCP span context (session id and,
+/// under MCP 2026-07-28, the request-scoped [`LoggingLevel`]) into a span's
+/// extensions.
+///
+/// The [`layer`] function's `MpscLayer` records this itself; add
+/// [`span_context`] alongside a plain `tracing_subscriber::fmt` layer that uses
+/// [`NotificationFormatter`](super::NotificationFormatter) (the stdio setup) so
+/// that formatter can apply the request-scoped `notifications/message` filter.
+#[derive(Debug, Default)]
+pub struct SpanContextLayer;
+
+impl<S> Layer<S> for SpanContextLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    #[inline]
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        record_span_context(attrs, id, &ctx);
+    }
+}
+
+/// Creates a [`SpanContextLayer`].
+///
+/// # Example
+/// ```no_run
+/// use tracing_subscriber::prelude::*;
+/// use neva::types::notification;
+///
+/// tracing_subscriber::registry()
+///     .with(notification::fmt::span_context())
+///     .with(tracing_subscriber::fmt::layer().event_format(notification::NotificationFormatter))
+///     .init();
+/// ```
+pub fn span_context() -> SpanContextLayer {
+    SpanContextLayer
+}
+
+/// Records the MCP `request` span fields (`mcp_session_id`, and under RC
+/// `mcp_log_level`) into the span's typed extensions. Shared by [`MpscLayer`]
+/// and [`SpanContextLayer`] so both emission paths read an identical context.
+#[inline]
+fn record_span_context<S>(attrs: &Attributes<'_>, id: &Id, ctx: &Context<'_, S>)
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let mut visitor = SpanVisitor::default();
+    attrs.record(&mut visitor);
+    if let Some(span) = ctx.span(id) {
+        if let Some(mcp_session_id) = visitor.session_id {
+            span.extensions_mut().insert(mcp_session_id);
+        }
+        // RC: remember the request-scoped minimum severity so the emission path
+        // can filter `notifications/message` for events fired within this request.
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        if let Some(min) = visitor.min_severity {
+            span.extensions_mut()
+                .insert(super::formatter::MinLogSeverity(min));
+        }
+    }
+}
+
+#[derive(Default)]
 struct SpanVisitor {
     session_id: Option<uuid::Uuid>,
+    /// Minimum severity requested for this request (`mcp_log_level` span field),
+    /// carried as the level's RFC-5424 severity rank.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    min_severity: Option<u8>,
 }
 
 impl Visit for SpanVisitor {
@@ -114,6 +202,14 @@ impl Visit for SpanVisitor {
             && let Ok(session_id) = uuid::Uuid::parse_str(value)
         {
             self.session_id = Some(session_id);
+        }
+    }
+
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[inline]
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        if field.name() == MCP_LOG_LEVEL {
+            self.min_severity = Some(value as u8);
         }
     }
 
@@ -130,5 +226,109 @@ impl Visit for SpanVisitor {
                 self.session_id = Some(session_id);
             }
         }
+    }
+}
+
+// End-to-end coverage of RC request-scoped logging through the real tracing
+// pipeline: the `span_context` layer records `mcp_log_level` into a span, and
+// `NotificationFormatter` filters `notifications/message` accordingly.
+#[cfg(all(test, feature = "proto-2026-07-28-rc"))]
+mod tests {
+    use crate::types::notification::{LoggingLevel, NotificationFormatter};
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::prelude::*;
+
+    #[derive(Clone)]
+    struct BufWriter(Arc<Mutex<Vec<u8>>>);
+
+    struct BufGuard(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for BufGuard {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for BufWriter {
+        type Writer = BufGuard;
+        fn make_writer(&'a self) -> Self::Writer {
+            BufGuard(self.0.clone())
+        }
+    }
+
+    /// Drives the emit path within a `request` span carrying `log_level` (when
+    /// `Some`) and returns the JSON lines the stdio formatter would send.
+    fn emit_within_request(log_level: Option<LoggingLevel>) -> Vec<String> {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(super::span_context())
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .event_format(NotificationFormatter)
+                    .with_writer(BufWriter(buf.clone())),
+            );
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = match log_level {
+                Some(level) => {
+                    tracing::info_span!("request", mcp_log_level = u64::from(level.severity()))
+                }
+                None => tracing::info_span!("request"),
+            };
+            let _entered = span.enter();
+            tracing::error!(logger = "tool", "error message");
+            tracing::warn!(logger = "tool", "warning message");
+            tracing::info!(logger = "tool", "info message");
+            tracing::debug!(logger = "tool", "debug message");
+        });
+
+        let raw = buf.lock().unwrap().clone();
+        String::from_utf8(raw)
+            .unwrap()
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(str::to_owned)
+            .collect()
+    }
+
+    fn levels(lines: &[String]) -> Vec<String> {
+        lines
+            .iter()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .filter(|v| v["method"] == "notifications/message")
+            .filter_map(|v| v["params"]["level"].as_str().map(str::to_owned))
+            .collect()
+    }
+
+    #[test]
+    fn delivers_messages_at_or_above_requested_level() {
+        // Requesting `warning` delivers error + warning, drops info + debug.
+        let lines = emit_within_request(Some(LoggingLevel::Warning));
+        let got = levels(&lines);
+        assert!(got.contains(&"error".to_owned()), "got: {got:?}");
+        assert!(got.contains(&"warning".to_owned()), "got: {got:?}");
+        assert!(!got.contains(&"info".to_owned()), "got: {got:?}");
+        assert!(!got.contains(&"debug".to_owned()), "got: {got:?}");
+    }
+
+    #[test]
+    fn delivers_everything_at_debug() {
+        let got = levels(&emit_within_request(Some(LoggingLevel::Debug)));
+        for lvl in ["error", "warning", "info", "debug"] {
+            assert!(got.contains(&lvl.to_owned()), "missing {lvl}, got: {got:?}");
+        }
+    }
+
+    #[test]
+    fn suppresses_all_messages_without_requested_level() {
+        // No `logLevel` on the request => the server emits no log notifications.
+        let got = levels(&emit_within_request(None));
+        assert!(got.is_empty(), "expected none, got: {got:?}");
     }
 }

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -109,8 +109,10 @@ where
                         .get::<super::formatter::MinLogSeverity>()
                         .map(|m| m.0)
                 });
-
-                let event_severity = LoggingLevel::from(event.metadata().level()).severity();
+                // Filter on the notification's own level (which preserves MCP
+                // severities), not the lossy tracing level of the event.
+                let event_severity = super::formatter::notification_severity(&notification)
+                    .unwrap_or_else(|| LoggingLevel::from(event.metadata().level()).severity());
                 if !super::formatter::message_delivered(requested, event_severity) {
                     return;
                 }
@@ -330,5 +332,43 @@ mod tests {
         // No `logLevel` on the request => the server emits no log notifications.
         let got = levels(&emit_within_request(None));
         assert!(got.is_empty(), "expected none, got: {got:?}");
+    }
+
+    #[test]
+    fn preserves_mcp_specific_severity_past_tracing() {
+        use crate::types::notification::LogMessage;
+
+        // `LogMessage::write()` downgrades to a tracing ERROR for both, but the
+        // MCP level is preserved on the wire and used for filtering: a client
+        // requesting `emergency` gets the emergency log and not the error one.
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry()
+            .with(super::span_context())
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .event_format(NotificationFormatter)
+                    .with_writer(BufWriter(buf.clone())),
+            );
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                "request",
+                mcp_log_level = u64::from(LoggingLevel::Emergency.severity())
+            );
+            let _entered = span.enter();
+            LogMessage::new(LoggingLevel::Emergency, None, None).write();
+            LogMessage::new(LoggingLevel::Error, None, None).write();
+        });
+
+        let raw = buf.lock().unwrap().clone();
+        let got: Vec<String> = String::from_utf8(raw)
+            .unwrap()
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(str::to_owned)
+            .collect();
+        let got = levels(&got);
+        assert!(got.contains(&"emergency".to_owned()), "got: {got:?}");
+        assert!(!got.contains(&"error".to_owned()), "got: {got:?}");
     }
 }

--- a/neva/src/types/notification/formatter.rs
+++ b/neva/src/types/notification/formatter.rs
@@ -87,9 +87,47 @@ where
         event: &Event<'_>,
     ) -> std::fmt::Result {
         let notification = build_notification(event);
+
+        // RC: the stdio emission path honors the same request-scoped level as
+        // the HTTP path. A `notifications/message` is written only when the
+        // originating request carried `io.modelcontextprotocol/logLevel` and
+        // this event is at or above that severity (span context recorded by
+        // [`super::fmt::span_context`]). Progress notifications are not gated.
+        #[cfg(feature = "proto-2026-07-28-rc")]
+        if notification.method.as_str() == crate::types::notification::commands::MESSAGE {
+            let requested = _ctx.event_scope().and_then(|scope| {
+                scope
+                    .into_iter()
+                    .find_map(|s| s.extensions().get::<MinLogSeverity>().map(|m| m.0))
+            });
+
+            let event_severity = LoggingLevel::from(event.metadata().level()).severity();
+            if !message_delivered(requested, event_severity) {
+                return Ok(());
+            }
+        }
+
         let json = serde_json::to_string(&notification).unwrap();
         writeln!(writer, "{json}")
     }
+}
+
+/// The request-scoped minimum severity recorded on a `request` span's
+/// extensions (MCP 2026-07-28), as an RFC-5424 severity rank. Both emission
+/// paths ([`NotificationFormatter`] for stdio and [`super::fmt`] for HTTP) read
+/// it back to filter `notifications/message`.
+#[cfg(feature = "proto-2026-07-28-rc")]
+#[derive(Debug, Clone, Copy)]
+pub(super) struct MinLogSeverity(pub(super) u8);
+
+/// Whether a `notifications/message` at `event_severity` should be delivered to
+/// a client that requested a minimum severity (MCP 2026-07-28, request-scoped
+/// logging). No requested level means no delivery. Both values are
+/// [`LoggingLevel::severity`] ranks.
+#[cfg(feature = "proto-2026-07-28-rc")]
+#[inline]
+pub(super) fn message_delivered(requested: Option<u8>, event_severity: u8) -> bool {
+    requested.map(|min| event_severity >= min).unwrap_or(false)
 }
 
 #[inline]
@@ -172,5 +210,46 @@ impl Visit for Visitor<'_> {
                 serde_json::to_value(&formatted).unwrap_or(serde_json::Value::String(formatted));
             self.map.insert(field.name(), value);
         }
+    }
+}
+
+#[cfg(all(test, feature = "proto-2026-07-28-rc"))]
+mod tests {
+    use super::message_delivered;
+    use crate::types::notification::LoggingLevel;
+
+    fn sev(level: LoggingLevel) -> u8 {
+        level.severity()
+    }
+
+    #[test]
+    fn no_requested_level_delivers_nothing() {
+        for level in [
+            LoggingLevel::Debug,
+            LoggingLevel::Error,
+            LoggingLevel::Emergency,
+        ] {
+            assert!(!message_delivered(None, sev(level)));
+        }
+    }
+
+    #[test]
+    fn delivers_at_or_above_requested_severity() {
+        // Requested `warning` delivers warning and everything more severe.
+        let min = sev(LoggingLevel::Warning);
+        assert!(message_delivered(Some(min), sev(LoggingLevel::Warning)));
+        assert!(message_delivered(Some(min), sev(LoggingLevel::Error)));
+        assert!(message_delivered(Some(min), sev(LoggingLevel::Emergency)));
+    }
+
+    #[test]
+    fn drops_below_requested_severity() {
+        let warn = sev(LoggingLevel::Warning);
+        assert!(!message_delivered(Some(warn), sev(LoggingLevel::Info)));
+        assert!(!message_delivered(Some(warn), sev(LoggingLevel::Debug)));
+        assert!(!message_delivered(
+            Some(sev(LoggingLevel::Error)),
+            sev(LoggingLevel::Notice)
+        ));
     }
 }

--- a/neva/src/types/notification/formatter.rs
+++ b/neva/src/types/notification/formatter.rs
@@ -13,6 +13,30 @@ use crate::types::ProgressToken;
 use crate::types::notification::{LogMessage, LoggingLevel, Notification};
 
 /// A formatter that formats tracing events into MCP notification logs
+///
+/// This is the stdio emission path: each event is written to stdout as a
+/// JSON-RPC `notifications/message` (or `notifications/progress`), interleaved
+/// with the transport's other traffic.
+///
+/// # MCP 2026-07-28 (`proto-2026-07-28-rc`)
+///
+/// `logging/setLevel` is gone and the level is request-scoped, so a
+/// `notifications/message` is emitted only when the originating request carried
+/// `io.modelcontextprotocol/logLevel` and the event is at or above that
+/// severity. The level is picked up from the request span automatically -- the
+/// setup below needs nothing else. Adding
+/// [`notification::fmt::span_context()`](super::fmt::span_context) alongside
+/// resolves it from a typed span extension instead, which is marginally cheaper.
+///
+/// # Examples
+/// ```no_run
+/// use tracing_subscriber::prelude::*;
+/// use neva::types::notification;
+///
+/// tracing_subscriber::registry()
+///     .with(tracing_subscriber::fmt::layer().event_format(notification::NotificationFormatter))
+///     .init();
+/// ```
 #[allow(missing_debug_implementations)]
 pub struct NotificationFormatter;
 
@@ -91,15 +115,11 @@ where
         // RC: the stdio emission path honors the same request-scoped level as
         // the HTTP path. A `notifications/message` is written only when the
         // originating request carried `io.modelcontextprotocol/logLevel` and
-        // this event is at or above that severity (span context recorded by
-        // [`super::fmt::span_context`]). Progress notifications are not gated.
+        // this event is at or above that severity. Progress notifications are
+        // not gated.
         #[cfg(feature = "proto-2026-07-28-rc")]
         if notification.method.as_str() == crate::types::notification::commands::MESSAGE {
-            let requested = _ctx.event_scope().and_then(|scope| {
-                scope
-                    .into_iter()
-                    .find_map(|s| s.extensions().get::<MinLogSeverity>().map(|m| m.0))
-            });
+            let requested = requested_severity(_ctx);
 
             // Filter on the notification's own level (which preserves MCP
             // severities), not the lossy tracing level of the event.
@@ -122,6 +142,78 @@ where
 #[cfg(feature = "proto-2026-07-28-rc")]
 #[derive(Debug, Clone, Copy)]
 pub(super) struct MinLogSeverity(pub(super) u8);
+
+/// The minimum severity the originating request asked for, resolved from the
+/// event's span scope (the `request` span may be an ancestor, e.g. when a
+/// `#[tracing::instrument]` handler emits from its own span).
+///
+/// Prefers the typed [`MinLogSeverity`] extension recorded by
+/// [`span_context`](super::fmt::span_context), and otherwise recovers the rank
+/// from the span fields `fmt::Layer` records for every span on its own. That
+/// fallback is what lets a formatter-only subscriber -- `fmt::layer()
+/// .event_format(NotificationFormatter)` with no other layer -- honor
+/// `io.modelcontextprotocol/logLevel` without extra configuration.
+#[cfg(feature = "proto-2026-07-28-rc")]
+fn requested_severity<S, N>(ctx: &FmtContext<'_, S, N>) -> Option<u8>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    ctx.event_scope()?.find_map(|span| {
+        let ext = span.extensions();
+        if let Some(min) = ext.get::<MinLogSeverity>() {
+            return Some(min.0);
+        }
+        ext.get::<tracing_subscriber::fmt::FormattedFields<N>>()
+            .and_then(|fields| severity_from_fields(&fields.fields))
+    })
+}
+
+/// Reads the `mcp_log_level` rank out of a span's formatted fields, accepting
+/// both the default `key=value` shape and the JSON one (`"key":value`).
+#[cfg(feature = "proto-2026-07-28-rc")]
+fn severity_from_fields(fields: &str) -> Option<u8> {
+    let fields = strip_ansi(fields);
+    let rest = fields.split_once(super::fmt::MCP_LOG_LEVEL)?.1;
+    rest.trim_start_matches(['"', ':', '=', ' '])
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .parse()
+        .ok()
+}
+
+/// Removes ANSI escape sequences from formatted span fields.
+///
+/// `fmt::Layer` styles field names by default, so the rank sits behind escape
+/// sequences -- and those contain digits of their own, which would otherwise be
+/// read as the level. Borrows when there is nothing to strip.
+#[cfg(feature = "proto-2026-07-28-rc")]
+fn strip_ansi(fields: &str) -> std::borrow::Cow<'_, str> {
+    const ESC: char = '\u{1b}';
+    if !fields.contains(ESC) {
+        return std::borrow::Cow::Borrowed(fields);
+    }
+
+    let mut out = String::with_capacity(fields.len());
+    let mut chars = fields.chars();
+    while let Some(c) = chars.next() {
+        if c != ESC {
+            out.push(c);
+            continue;
+        }
+        // CSI: `ESC [ <params> <final>`, where the final byte is 0x40..=0x7E.
+        if chars.next() != Some('[') {
+            continue;
+        }
+        for c in chars.by_ref() {
+            if ('\u{40}'..='\u{7e}').contains(&c) {
+                break;
+            }
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}
 
 /// Whether a `notifications/message` at `event_severity` should be delivered to
 /// a client that requested a minimum severity (MCP 2026-07-28, request-scoped
@@ -239,7 +331,7 @@ impl Visit for Visitor<'_> {
 
 #[cfg(all(test, feature = "proto-2026-07-28-rc"))]
 mod tests {
-    use super::message_delivered;
+    use super::{message_delivered, severity_from_fields};
     use crate::types::notification::LoggingLevel;
 
     fn sev(level: LoggingLevel) -> u8 {
@@ -275,5 +367,149 @@ mod tests {
             Some(sev(LoggingLevel::Error)),
             sev(LoggingLevel::Notice)
         ));
+    }
+
+    #[test]
+    fn reads_the_requested_rank_from_formatted_span_fields() {
+        // Default field formatter, and with the session id alongside.
+        assert_eq!(severity_from_fields("mcp_log_level=3"), Some(3));
+        assert_eq!(
+            severity_from_fields("mcp_session_id=\"3f1a\" mcp_log_level=7"),
+            Some(7)
+        );
+        // JSON field formatter.
+        assert_eq!(
+            severity_from_fields(r#"{"mcp_session_id":"3f1a","mcp_log_level":0}"#),
+            Some(0)
+        );
+        // ANSI-styled field names (the `fmt::Layer` default): the escape
+        // sequences carry digits of their own, which must not be read as a rank.
+        assert_eq!(
+            severity_from_fields("\u{1b}[3mmcp_log_level\u{1b}[0m\u{1b}[2m=\u{1b}[0m3"),
+            Some(3)
+        );
+        assert_eq!(
+            severity_from_fields("\u{1b}[3mmcp_log_level\u{1b}[0m\u{1b}[2m=\u{1b}[0m0"),
+            Some(0)
+        );
+        // Spans that carry no requested level.
+        assert_eq!(severity_from_fields(""), None);
+        assert_eq!(severity_from_fields("mcp_session_id=\"3f1a\""), None);
+        assert_eq!(
+            severity_from_fields("\u{1b}[3mmcp_session_id\u{1b}[0m=\u{1b}[0m\"3f1a\""),
+            None
+        );
+    }
+
+    /// A formatter-only subscriber -- no `span_context()` layer -- must still
+    /// honor `io.modelcontextprotocol/logLevel`: `fmt::Layer` records the span
+    /// fields itself, so the requested level is recoverable without any extra
+    /// configuration.
+    #[test]
+    fn honors_the_requested_level_without_a_span_context_layer() {
+        use crate::types::notification::NotificationFormatter;
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt::MakeWriter;
+        use tracing_subscriber::prelude::*;
+
+        #[derive(Clone)]
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        struct BufGuard(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for BufGuard {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'a> MakeWriter<'a> for BufWriter {
+            type Writer = BufGuard;
+            fn make_writer(&'a self) -> Self::Writer {
+                BufGuard(self.0.clone())
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .event_format(NotificationFormatter)
+                .with_writer(BufWriter(buf.clone())),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!(
+                "request",
+                mcp_log_level = u64::from(LoggingLevel::Warning.severity())
+            );
+            let _entered = request.enter();
+            // Also from a nested span, the way an instrumented handler emits.
+            let handler = tracing::info_span!("handler");
+            let _handler = handler.enter();
+            tracing::error!(logger = "tool", "delivered");
+            tracing::info!(logger = "tool", "dropped");
+        });
+
+        let out = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(
+            out.contains("delivered"),
+            "requesting `warning` must deliver an error event, got: {out}"
+        );
+        assert!(
+            !out.contains("dropped"),
+            "an event below the requested level must be suppressed, got: {out}"
+        );
+    }
+
+    /// Without a requested level nothing is emitted, layer or no layer -- the
+    /// spec's suppression rule must not be defeated by the fallback.
+    #[test]
+    fn suppresses_everything_when_the_request_did_not_opt_in() {
+        use crate::types::notification::NotificationFormatter;
+        use std::io::Write;
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::fmt::MakeWriter;
+        use tracing_subscriber::prelude::*;
+
+        #[derive(Clone)]
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        struct BufGuard(Arc<Mutex<Vec<u8>>>);
+
+        impl Write for BufGuard {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'a> MakeWriter<'a> for BufWriter {
+            type Writer = BufGuard;
+            fn make_writer(&'a self) -> Self::Writer {
+                BufGuard(self.0.clone())
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .event_format(NotificationFormatter)
+                .with_writer(BufWriter(buf.clone())),
+        );
+
+        tracing::subscriber::with_default(subscriber, || {
+            let request = tracing::info_span!("request", mcp_session_id = "3f1a");
+            let _entered = request.enter();
+            tracing::error!(logger = "tool", "must not appear");
+        });
+
+        let out = String::from_utf8(buf.lock().unwrap().clone()).unwrap();
+        assert!(out.is_empty(), "expected no output, got: {out}");
     }
 }

--- a/neva/src/types/notification/formatter.rs
+++ b/neva/src/types/notification/formatter.rs
@@ -101,7 +101,10 @@ where
                     .find_map(|s| s.extensions().get::<MinLogSeverity>().map(|m| m.0))
             });
 
-            let event_severity = LoggingLevel::from(event.metadata().level()).severity();
+            // Filter on the notification's own level (which preserves MCP
+            // severities), not the lossy tracing level of the event.
+            let event_severity = notification_severity(&notification)
+                .unwrap_or_else(|| LoggingLevel::from(event.metadata().level()).severity());
             if !message_delivered(requested, event_severity) {
                 return Ok(());
             }
@@ -128,6 +131,20 @@ pub(super) struct MinLogSeverity(pub(super) u8);
 #[inline]
 pub(super) fn message_delivered(requested: Option<u8>, event_severity: u8) -> bool {
     requested.map(|min| event_severity >= min).unwrap_or(false)
+}
+
+/// Reads the RFC-5424 severity rank of a `notifications/message`'s own level,
+/// so filtering matches the level actually delivered to the client (which, via
+/// [`build_notification`], preserves MCP-specific severities).
+#[cfg(feature = "proto-2026-07-28-rc")]
+#[inline]
+pub(super) fn notification_severity(notification: &Notification) -> Option<u8> {
+    notification
+        .params
+        .as_ref()
+        .and_then(|params| params.get("level"))
+        .and_then(|level| serde_json::from_value::<LoggingLevel>(level.clone()).ok())
+        .map(LoggingLevel::severity)
 }
 
 #[inline]
@@ -161,8 +178,15 @@ pub(super) fn build_notification(event: &Event<'_>) -> Notification {
             let mut data_map = fields.clone();
             data_map.remove("logger");
 
+            // An explicit MCP level (from `LogMessage::write`) preserves
+            // severities tracing cannot express; otherwise map the tracing level.
+            let level = data_map
+                .remove("mcp_level")
+                .and_then(|v| serde_json::from_value::<LoggingLevel>(v).ok())
+                .unwrap_or_else(|| level.into());
+
             let log = LogMessage {
-                level: level.into(),
+                level,
                 data: serde_json::to_value(data_map).ok(),
                 logger,
             };

--- a/neva/src/types/notification/log_message.rs
+++ b/neva/src/types/notification/log_message.rs
@@ -1,11 +1,11 @@
 //! Utilities for log messages
 
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", not(feature = "proto-2026-07-28-rc")))]
 use crate::app::handler::{FromHandlerParams, HandlerParams};
 use crate::error::Error;
 use crate::types::notification::Notification;
 use crate::types::response::ErrorDetails;
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", not(feature = "proto-2026-07-28-rc")))]
 use crate::types::{FromRequest, Request};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "tracing")]
@@ -42,6 +42,30 @@ pub enum LoggingLevel {
     Emergency,
 }
 
+#[cfg(all(feature = "tracing", feature = "proto-2026-07-28-rc"))]
+impl LoggingLevel {
+    /// Severity rank where a higher number is more severe, following the
+    /// RFC-5424 ordering. A message at `self` is delivered to a client that
+    /// requested `min` when `self.severity() >= min.severity()`.
+    ///
+    /// The enum's declaration order is not the severity order, so this cannot
+    /// be derived; it is also what travels on the request span as a plain
+    /// integer field, avoiding a redundant string encoding of the level.
+    #[inline]
+    pub(crate) fn severity(self) -> u8 {
+        match self {
+            LoggingLevel::Debug => 0,
+            LoggingLevel::Info => 1,
+            LoggingLevel::Notice => 2,
+            LoggingLevel::Warning => 3,
+            LoggingLevel::Error => 4,
+            LoggingLevel::Critical => 5,
+            LoggingLevel::Alert => 6,
+            LoggingLevel::Emergency => 7,
+        }
+    }
+}
+
 /// Sent from the server as the payload of "notifications/message" notifications whenever a log message is generated.
 /// If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.
 ///
@@ -62,7 +86,12 @@ pub struct LogMessage {
 
 /// A request from the client to the server, to enable or adjust logging.
 ///
+/// Removed under MCP 2026-07-28: the global `logging/setLevel` handshake is
+/// gone; the desired level now rides per-request on
+/// `_meta["io.modelcontextprotocol/logLevel"]`.
+///
 /// See the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/) for details
+#[cfg(not(feature = "proto-2026-07-28-rc"))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetLevelRequestParams {
     /// The level of logging that the client wants to receive from the server.
@@ -89,7 +118,7 @@ impl From<LogMessage> for Notification {
     }
 }
 
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", not(feature = "proto-2026-07-28-rc")))]
 impl FromHandlerParams for SetLevelRequestParams {
     #[inline]
     fn from_params(params: &HandlerParams) -> Result<Self, Error> {
@@ -128,5 +157,34 @@ impl LogMessage {
             LoggingLevel::Info => tracing::event!(Level::INFO, %data),
             LoggingLevel::Debug => tracing::event!(Level::DEBUG, %data),
         };
+    }
+}
+
+#[cfg(all(test, feature = "tracing", feature = "proto-2026-07-28-rc"))]
+mod tests {
+    use super::LoggingLevel;
+
+    const ALL: [LoggingLevel; 8] = [
+        LoggingLevel::Debug,
+        LoggingLevel::Info,
+        LoggingLevel::Notice,
+        LoggingLevel::Warning,
+        LoggingLevel::Error,
+        LoggingLevel::Critical,
+        LoggingLevel::Alert,
+        LoggingLevel::Emergency,
+    ];
+
+    #[test]
+    fn severity_follows_rfc5424_ordering() {
+        // Strictly increasing from least to most severe.
+        for pair in ALL.windows(2) {
+            assert!(
+                pair[0].severity() < pair[1].severity(),
+                "{:?} should be less severe than {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
     }
 }

--- a/neva/src/types/notification/log_message.rs
+++ b/neva/src/types/notification/log_message.rs
@@ -154,7 +154,7 @@ impl LogMessage {
             .ok()
             .and_then(|v| v.as_str().map(str::to_owned))
             .unwrap_or_default();
-        
+
         let mcp_level = mcp_level.as_str();
         match self.level {
             LoggingLevel::Alert => tracing::event!(Level::ERROR, mcp_level, %data),

--- a/neva/src/types/notification/log_message.rs
+++ b/neva/src/types/notification/log_message.rs
@@ -147,15 +147,24 @@ impl LogMessage {
     #[cfg(feature = "tracing")]
     pub fn write(self) {
         let data = serde_json::to_value(&self.data).unwrap_or_default();
+        // Carry the original MCP level as a field: tracing has only
+        // ERROR/WARN/INFO/DEBUG, so Notice/Critical/Alert/Emergency would
+        // otherwise be lost when the notification is rebuilt and filtered.
+        let mcp_level = serde_json::to_value(self.level)
+            .ok()
+            .and_then(|v| v.as_str().map(str::to_owned))
+            .unwrap_or_default();
+        
+        let mcp_level = mcp_level.as_str();
         match self.level {
-            LoggingLevel::Alert => tracing::event!(Level::ERROR, %data),
-            LoggingLevel::Critical => tracing::event!(Level::ERROR, %data),
-            LoggingLevel::Emergency => tracing::event!(Level::ERROR, %data),
-            LoggingLevel::Error => tracing::event!(Level::ERROR, %data),
-            LoggingLevel::Warning => tracing::event!(Level::WARN, %data),
-            LoggingLevel::Notice => tracing::event!(Level::WARN, %data),
-            LoggingLevel::Info => tracing::event!(Level::INFO, %data),
-            LoggingLevel::Debug => tracing::event!(Level::DEBUG, %data),
+            LoggingLevel::Alert => tracing::event!(Level::ERROR, mcp_level, %data),
+            LoggingLevel::Critical => tracing::event!(Level::ERROR, mcp_level, %data),
+            LoggingLevel::Emergency => tracing::event!(Level::ERROR, mcp_level, %data),
+            LoggingLevel::Error => tracing::event!(Level::ERROR, mcp_level, %data),
+            LoggingLevel::Warning => tracing::event!(Level::WARN, mcp_level, %data),
+            LoggingLevel::Notice => tracing::event!(Level::WARN, mcp_level, %data),
+            LoggingLevel::Info => tracing::event!(Level::INFO, mcp_level, %data),
+            LoggingLevel::Debug => tracing::event!(Level::DEBUG, mcp_level, %data),
         };
     }
 }

--- a/neva/src/types/request.rs
+++ b/neva/src/types/request.rs
@@ -108,6 +108,20 @@ pub struct RequestParamsMeta {
     #[serde(rename = "requestState", skip_serializing_if = "Option::is_none")]
     pub(crate) request_state: Option<String>,
 
+    /// Request-scoped logging level (MCP 2026-07-28).
+    ///
+    /// The minimum severity the client wants to receive as
+    /// `notifications/message` while the server handles this request. This
+    /// replaces the removed global `logging/setLevel` handshake; the desired
+    /// level now rides on the originating request's `_meta`. Deprecated in the
+    /// 2026-07-28 draft together with the rest of the logging surface.
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[serde(
+        rename = "io.modelcontextprotocol/logLevel",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub(crate) log_level: Option<crate::types::notification::LoggingLevel>,
+
     /// MRTR/stateless: client capabilities declared per-request (v1: a single
     /// `elicitation` flag) so the server can honor "MUST NOT send an input
     /// type the client didn't declare".
@@ -277,6 +291,32 @@ mod tests {
         let v = serde_json::to_value(&meta).unwrap();
         assert!(v.get("traceparent").is_none());
         assert!(v.get("tracestate").is_none());
+    }
+
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[test]
+    fn log_level_roundtrips_under_spec_meta_key() {
+        use crate::types::notification::LoggingLevel;
+        use serde_json::json;
+
+        let meta = RequestParamsMeta {
+            log_level: Some(LoggingLevel::Warning),
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&meta).unwrap();
+        // The request-scoped level rides under the spec `_meta` key, lowercase.
+        assert_eq!(v["io.modelcontextprotocol/logLevel"], json!("warning"));
+
+        let back: RequestParamsMeta = serde_json::from_value(v).unwrap();
+        assert_eq!(back.log_level, Some(LoggingLevel::Warning));
+    }
+
+    #[cfg(feature = "proto-2026-07-28-rc")]
+    #[test]
+    fn absent_log_level_is_omitted() {
+        let meta = RequestParamsMeta::default();
+        let v = serde_json::to_value(&meta).unwrap();
+        assert!(v.get("io.modelcontextprotocol/logLevel").is_none());
     }
 
     #[cfg(all(feature = "client", feature = "proto-2026-07-28-rc"))]

--- a/neva/src/types/request.rs
+++ b/neva/src/types/request.rs
@@ -82,7 +82,7 @@ pub struct RequestParamsMeta {
     ///
     /// Companion to [`Self::traceparent`]; carries vendor-specific state
     /// alongside the parent identifier. Same source-compatibility rationale
-    /// applies — the field is unconditional and older peers ignore it.
+    /// applies -- the field is unconditional and older peers ignore it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tracestate: Option<String>,
 
@@ -208,8 +208,8 @@ impl Request {
     /// Merges `meta` into the request's `_meta`, creating the params/`_meta`
     /// objects when none exist. Symmetric counterpart to [`Self::meta`];
     /// existing (non-`_meta`) params keys are preserved, as are any `_meta`
-    /// entries the typed [`RequestParamsMeta`] does not model — e.g. custom
-    /// extension keys such as `com.example/foo` — which a full replacement
+    /// entries the typed [`RequestParamsMeta`] does not model -- e.g. custom
+    /// extension keys such as `com.example/foo` -- which a full replacement
     /// would silently drop. Only the fields populated on `meta` are written;
     /// unset (`None`) fields leave any existing entry untouched.
     ///

--- a/neva/src/types/request/request_id.rs
+++ b/neva/src/types/request/request_id.rs
@@ -29,7 +29,7 @@ pub enum RequestId {
     /// A null identifier.
     ///
     /// Used in error responses when the id cannot be extracted from a
-    /// malformed request (JSON-RPC 2.0 §5.1 requires `"id": null` in that
+    /// malformed request (JSON-RPC 2.0 section 5.1 requires `"id": null` in that
     /// case). Serializes as JSON `null`.
     Null,
 }

--- a/neva/src/types/resource/template.rs
+++ b/neva/src/types/resource/template.rs
@@ -31,7 +31,7 @@ pub struct ResourceTemplate {
     /// A human-readable name for this resource template.
     pub name: String,
 
-    /// Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+    /// Intended for UI and end-user contexts -- optimized to be human-readable and easily understood,
     /// even by those unfamiliar with domain-specific terminology.
     ///
     /// If not provided, the name should be used for display (except for Tool,

--- a/neva/src/types/sampling.rs
+++ b/neva/src/types/sampling.rs
@@ -179,7 +179,7 @@ pub enum ContextInclusion {
 /// Represents a server's preferences for model selection, requested of the client during sampling.
 ///
 /// > **Note:** Because LLMs can vary along multiple dimensions, choosing the _best_ model is
-/// > rarely straightforward.  Different models excel in different areas—some are
+/// > rarely straightforward.  Different models excel in different areas--some are
 /// > faster but less capable, others are more capable but more expensive, and so
 /// > on. This struct allows servers to express their priorities across multiple
 /// > dimensions to help clients make an appropriate selection for their use case.

--- a/neva/src/types/schema_2020.rs
+++ b/neva/src/types/schema_2020.rs
@@ -4,13 +4,13 @@
 //! and `outputSchema` fields carry full JSON Schema 2020-12 documents.
 //! Unlike the legacy `ToolSchema` (a typed struct
 //! mirroring a small Draft 7-ish subset), schemas under the new draft
-//! must be representable as **arbitrary** JSON — including `oneOf`,
+//! must be representable as **arbitrary** JSON -- including `oneOf`,
 //! `anyOf`, `$ref`, `additionalProperties`, conditional `if`/`then`,
 //! and any custom keywords the implementor chooses to embed.
 //!
 //! [`InputSchema`] is therefore a `#[serde(transparent)]` newtype around
-//! [`serde_json::Value`]. The schema **is** the value — there is no
-//! wrapper key — so it round-trips losslessly.
+//! [`serde_json::Value`]. The schema **is** the value -- there is no
+//! wrapper key -- so it round-trips losslessly.
 //!
 //! This module is intentionally minimal in Task 3.1: it only introduces
 //! the type. Wiring into [`crate::types::tool::Tool`] happens in later
@@ -23,7 +23,7 @@ use serde_json::{Value, json};
 ///
 /// The inner [`serde_json::Value`] holds the full schema verbatim. This is
 /// a transparent newtype, so [`InputSchema`] serializes and deserializes
-/// exactly as if it were a raw [`Value`] — no wrapper key is added.
+/// exactly as if it were a raw [`Value`] -- no wrapper key is added.
 ///
 /// # Examples
 ///
@@ -46,7 +46,7 @@ pub struct InputSchema(
     /// The underlying JSON Schema document.
     ///
     /// Kept `pub(crate)` so the type stays closed to arbitrary external
-    /// mutation — construct via [`InputSchema::from_value`] and read via
+    /// mutation -- construct via [`InputSchema::from_value`] and read via
     /// [`InputSchema::as_value`]/[`InputSchema::into_value`]. This leaves room
     /// to attach a lazily-compiled validator beside the schema later without a
     /// breaking change.
@@ -57,7 +57,7 @@ impl Default for InputSchema {
     /// Returns an empty object schema: `{"type": "object", "properties": {}}`.
     ///
     /// This mirrors the legacy `ToolSchema::default`
-    /// shape — an *empty object schema*, not a totally empty JSON object —
+    /// shape -- an *empty object schema*, not a totally empty JSON object --
     /// so the wire format remains compatible with existing clients that
     /// expect at minimum a `type` discriminator.
     #[inline]
@@ -120,7 +120,7 @@ impl InputSchema {
 impl InputSchema {
     /// Wraps an arbitrary [`serde_json::Value`] as an [`InputSchema`].
     ///
-    /// The value is stored verbatim — no validation is performed at this
+    /// The value is stored verbatim -- no validation is performed at this
     /// point. Validation of incoming tool arguments against the schema
     /// happens elsewhere (see `validate_call_args` in the `tool` module).
     ///
@@ -144,7 +144,7 @@ impl InputSchema {
     ///
     /// Returns [`crate::error::Error`] when the input is not valid JSON.
     /// Unlike the legacy `ToolSchema::from_json_str`,
-    /// this constructor never panics — library code must propagate errors
+    /// this constructor never panics -- library code must propagate errors
     /// rather than expect, per project conventions.
     ///
     /// # Examples
@@ -222,14 +222,14 @@ impl From<schemars::Schema> for InputSchema {
 // These items back the `#[tool]` macro's JSON Schema 2020-12 emission under
 // `proto-2026-07-28-rc`. The `schema_2020` module itself is always compiled
 // (the `InputSchema` type exists on every config), so the macro-support items
-// are individually gated on the RC flag — they are unused on the legacy path.
+// are individually gated on the RC flag -- they are unused on the legacy path.
 
 /// Autoref-specialization probe used by the `#[tool]` macro to build a
 /// per-argument JSON Schema 2020-12 subschema.
 ///
 /// Resolves to a `schemars`-derived (inlined, self-contained) subschema when
 /// the argument type implements [`schemars::JsonSchema`], and to an opaque
-/// `{"type":"object"}` otherwise — chosen at the call site without requiring a
+/// `{"type":"object"}` otherwise -- chosen at the call site without requiring a
 /// trait bound the macro cannot enforce.
 #[cfg(feature = "proto-2026-07-28-rc")]
 #[doc(hidden)]
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn transparent_serde_has_no_wrapper_key() {
         // Serializing must not introduce a wrapper field like `{"0": ...}`
-        // or `{"value": ...}` — the schema IS the value.
+        // or `{"value": ...}` -- the schema IS the value.
         let raw = json!({ "type": "string", "minLength": 1 });
         let schema = InputSchema(raw.clone());
         let serialized = serde_json::to_value(&schema).expect("serializes");
@@ -408,7 +408,7 @@ mod tests {
 
         // Re-serializing through serde_json::to_string yields a string that
         // deserializes back to the same Value (byte-exactness is not
-        // guaranteed across serde_json — key order in maps is preserved by
+        // guaranteed across serde_json -- key order in maps is preserved by
         // default but we compare as Value to be canonical).
         let re_serialized = serde_json::to_string(&schema).expect("serializes");
         let reparsed: Value = serde_json::from_str(&re_serialized).expect("reparses");
@@ -421,7 +421,7 @@ mod tests {
     fn from_value_preserves_arbitrary_keys() {
         // The whole point of Value-shaped schemas: full JSON Schema 2020-12
         // expressivity. `oneOf`, `$ref`, `additionalProperties`, custom
-        // keywords — all must round-trip verbatim.
+        // keywords -- all must round-trip verbatim.
         let raw = json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://example.com/widget.schema.json",

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -57,7 +57,7 @@ pub struct Tool {
     /// The name of the tool.
     pub name: String,
 
-    /// Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+    /// Intended for UI and end-user contexts -- optimized to be human-readable and easily understood,
     /// even by those unfamiliar with domain-specific terminology.
     ///
     /// If not provided, the name should be used for display (except for Tool,
@@ -505,7 +505,7 @@ impl ToolSchema {
     /// [`schemars`]-generated [`JsonSchema`] type.
     ///
     /// Note that this is distinct from the static [`ToolSchema::from_schema`]
-    /// — `with_schema` is a chainable instance method, while `from_schema` is
+    /// -- `with_schema` is a chainable instance method, while `from_schema` is
     /// a static constructor.
     pub fn with_schema<T: JsonSchema>(self) -> Self {
         let json_schema = schemars::schema_for!(T);
@@ -957,7 +957,7 @@ impl Tool {
     /// `proto-2026-07-28-rc` the schema is already a [`serde_json::Value`]
     /// (wrapped by [`crate::types::schema_2020::InputSchema`]), so we borrow
     /// it directly via [`crate::types::schema_2020::InputSchema::as_value`]
-    /// — no re-serialization is needed.
+    /// -- no re-serialization is needed.
     pub fn validate<'a>(&self, resp: &'a CallToolResponse) -> Result<&'a CallToolResponse, Error> {
         let Some(schema_ref) = self.output_schema.as_ref() else {
             return Err(Error::new(
@@ -1152,7 +1152,7 @@ mod tests {
         // `from_schemars`, so their outputs for the same input schema
         // must be identical. The wrapper retains the old behaviour
         // (non-generic, takes a `schemars::Schema`) under a renamed
-        // identifier — see deviation note for why we did not keep the
+        // identifier -- see deviation note for why we did not keep the
         // exact `from_schema` name.
         let a = ToolSchema::from_schemars(schemars::schema_for!(MyT));
         let b = ToolSchema::from_schema_legacy(schemars::schema_for!(MyT));

--- a/neva/src/types/tool/from_request.rs
+++ b/neva/src/types/tool/from_request.rs
@@ -91,6 +91,8 @@ mod tests {
                 request_state: None,
                 #[cfg(feature = "proto-2026-07-28-rc")]
                 client_capabilities: None,
+                #[cfg(feature = "proto-2026-07-28-rc")]
+                log_level: None,
                 context: None,
                 #[cfg(feature = "tasks")]
                 task: None,
@@ -120,6 +122,8 @@ mod tests {
                 request_state: None,
                 #[cfg(feature = "proto-2026-07-28-rc")]
                 client_capabilities: None,
+                #[cfg(feature = "proto-2026-07-28-rc")]
+                log_level: None,
                 context: None,
                 #[cfg(feature = "tasks")]
                 task: None,

--- a/neva/tests/dc_extractor_rc.rs
+++ b/neva/tests/dc_extractor_rc.rs
@@ -55,7 +55,10 @@ async fn dc_extractor_is_injected_not_advertised() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // --- tools/list: assert the Dc dependency is not advertised ---

--- a/neva/tests/http_logging_rc.rs
+++ b/neva/tests/http_logging_rc.rs
@@ -16,6 +16,8 @@ use neva::types::notification;
 use tracing_subscriber::prelude::*;
 
 const MARKER: &str = "distinctive-log-marker";
+const MARKER_A: &str = "marker-alpha";
+const MARKER_B: &str = "marker-bravo";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn request_scoped_logging_streams_over_post() {
@@ -33,6 +35,18 @@ async fn request_scoped_logging_streams_over_post() {
     app.map_tool("shout", || async move {
         tracing::warn!(logger = "tool", "{MARKER}");
         "pong".to_string()
+    });
+    // Two tools that log a distinct marker after a short delay, so two
+    // concurrent POSTs overlap in-flight -- exercising sink isolation.
+    app.map_tool("shout_a", || async move {
+        tracing::warn!(logger = "tool", "{MARKER_A}");
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        "a".to_string()
+    });
+    app.map_tool("shout_b", || async move {
+        tracing::warn!(logger = "tool", "{MARKER_B}");
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        "b".to_string()
     });
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
@@ -152,6 +166,44 @@ async fn request_scoped_logging_streams_over_post() {
     assert!(
         body.contains("notifications/message") && body.contains(MARKER),
         "batch SSE body must carry the inner request's log, got: {body}"
+    );
+
+    // (d) two concurrent opted-in POSTs sharing one client-supplied
+    // `Mcp-Session-Id` must not cross-talk: each stateless POST mints its own
+    // sink key, so each response carries only its own request's log.
+    let shared_session = uuid::Uuid::new_v4().to_string();
+    let call_for = |tool: &str| {
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 9, "method": "tools/call",
+            "params": {
+                "name": tool,
+                "arguments": {},
+                "_meta": { "io.modelcontextprotocol/logLevel": "info" }
+            }
+        })
+    };
+    let send = |call: serde_json::Value| {
+        client
+            .post(&url)
+            .header("MCP-Protocol-Version", "2026-07-28")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Mcp-Session-Id", shared_session.clone())
+            .json(&call)
+            .send()
+    };
+    let (resp_a, resp_b) = tokio::join!(send(call_for("shout_a")), send(call_for("shout_b")));
+    let body_a = resp_a.expect("a failed").text().await.unwrap();
+    let body_b = resp_b.expect("b failed").text().await.unwrap();
+
+    // Each response sees its own marker and not the other's -- no sink collision
+    // even though both POSTs carried the same `Mcp-Session-Id`.
+    assert!(
+        body_a.contains(MARKER_A) && !body_a.contains(MARKER_B),
+        "response A must carry only its own log, got: {body_a}"
+    );
+    assert!(
+        body_b.contains(MARKER_B) && !body_b.contains(MARKER_A),
+        "response B must carry only its own log, got: {body_b}"
     );
 
     handle.abort();

--- a/neva/tests/http_logging_rc.rs
+++ b/neva/tests/http_logging_rc.rs
@@ -18,6 +18,17 @@ use tracing_subscriber::prelude::*;
 const MARKER: &str = "distinctive-log-marker";
 const MARKER_A: &str = "marker-alpha";
 const MARKER_B: &str = "marker-bravo";
+const MARKER_AFTER_NEXT: &str = "marker-after-next";
+
+/// Reads a response body, failing loudly instead of hanging: a request-scoped
+/// SSE body that never closes (e.g. the notification sink outliving the
+/// pipeline) would otherwise stall the test forever.
+async fn body_within(resp: reqwest::Response, what: &str) -> String {
+    tokio::time::timeout(std::time::Duration::from_secs(5), resp.text())
+        .await
+        .unwrap_or_else(|_| panic!("{what}: SSE body did not close within 5s"))
+        .expect("body read failed")
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn request_scoped_logging_streams_over_post() {
@@ -30,8 +41,16 @@ async fn request_scoped_logging_streams_over_post() {
 
     let port = pick_free_port();
     let addr = format!("127.0.0.1:{port}");
-    let mut app =
-        App::new().with_options(|opt| opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp")));
+    let mut app = App::new()
+        .with_options(|opt| opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp")))
+        // Logs *after* `next(ctx)`: the terminal middleware has already completed
+        // the response by then, so this only reaches the client if the SSE body
+        // stays open until the whole pipeline is done.
+        .wrap(|ctx, next| async move {
+            let resp = next(ctx).await;
+            tracing::warn!(logger = "mw", "{MARKER_AFTER_NEXT}");
+            resp
+        });
     app.map_tool("shout", || async move {
         tracing::warn!(logger = "tool", "{MARKER}");
         "pong".to_string()
@@ -82,7 +101,7 @@ async fn request_scoped_logging_streams_over_post() {
         ctype.contains("text/event-stream"),
         "opted-in reply must be an SSE stream, got content-type {ctype:?}"
     );
-    let body = resp.text().await.unwrap();
+    let body = body_within(resp, "opted-in call").await;
     assert!(
         body.contains("notifications/message"),
         "SSE body must carry the log notification, got: {body}"
@@ -94,6 +113,19 @@ async fn request_scoped_logging_streams_over_post() {
     assert!(
         body.contains("pong"),
         "SSE body must carry the response, got: {body}"
+    );
+    // A log emitted by user middleware *after* `next(ctx)` must still reach the
+    // client: the stream stays open until the whole pipeline finishes.
+    assert!(
+        body.contains(MARKER_AFTER_NEXT),
+        "SSE body must carry the after-next middleware log, got: {body}"
+    );
+    // ...and the response closes the stream: every notification precedes it.
+    let resp_at = body.find("\"result\"").expect("response in body");
+    assert!(
+        body.find(MARKER).is_some_and(|at| at < resp_at)
+            && body.find(MARKER_AFTER_NEXT).is_some_and(|at| at < resp_at),
+        "notifications must precede the final response, got: {body}"
     );
 
     // (b) no `logLevel` -> plain JSON reply, no log notifications (suppressed).
@@ -162,7 +194,7 @@ async fn request_scoped_logging_streams_over_post() {
         ctype.contains("text/event-stream"),
         "a batch with an opted-in inner request must stream, got content-type {ctype:?}"
     );
-    let body = resp.text().await.unwrap();
+    let body = body_within(resp, "batch call").await;
     assert!(
         body.contains("notifications/message") && body.contains(MARKER),
         "batch SSE body must carry the inner request's log, got: {body}"
@@ -192,8 +224,8 @@ async fn request_scoped_logging_streams_over_post() {
             .send()
     };
     let (resp_a, resp_b) = tokio::join!(send(call_for("shout_a")), send(call_for("shout_b")));
-    let body_a = resp_a.expect("a failed").text().await.unwrap();
-    let body_b = resp_b.expect("b failed").text().await.unwrap();
+    let body_a = body_within(resp_a.expect("a failed"), "concurrent A").await;
+    let body_b = body_within(resp_b.expect("b failed"), "concurrent B").await;
 
     // Each response sees its own marker and not the other's -- no sink collision
     // even though both POSTs carried the same `Mcp-Session-Id`.

--- a/neva/tests/http_logging_rc.rs
+++ b/neva/tests/http_logging_rc.rs
@@ -70,7 +70,13 @@ async fn request_scoped_logging_streams_over_post() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    // `no_proxy`: reqwest honors `HTTP_PROXY`/`HTTPS_PROXY` from the environment,
+    // and an uppercase `NO_PROXY` that omits localhost would still send these
+    // loopback requests through the proxy. The server under test is local only.
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // (a) opted in via `_meta.logLevel` -> SSE reply with the log then response.

--- a/neva/tests/http_logging_rc.rs
+++ b/neva/tests/http_logging_rc.rs
@@ -1,0 +1,124 @@
+//! Request-scoped logging over the RC stateless HTTP transport (MCP 2026-07-28).
+//!
+//! A `POST` whose `_meta` carries `io.modelcontextprotocol/logLevel` gets a
+//! `text/event-stream` reply carrying the request's `notifications/message`
+//! followed by the response; a `POST` without it gets a plain JSON reply and no
+//! log notifications (the spec's suppression rule).
+#![cfg(all(
+    feature = "proto-2026-07-28-rc",
+    feature = "http-server-volga",
+    feature = "http-client",
+    feature = "tracing"
+))]
+
+use neva::App;
+use neva::types::notification;
+use tracing_subscriber::prelude::*;
+
+const MARKER: &str = "distinctive-log-marker";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn request_scoped_logging_streams_over_post() {
+    // The notification layer must be the active subscriber in the server task so
+    // the tool's `tracing` events become `notifications/message`. Each test file
+    // is its own process, so installing the global default here is safe.
+    tracing_subscriber::registry()
+        .with(notification::fmt::layer())
+        .init();
+
+    let port = pick_free_port();
+    let addr = format!("127.0.0.1:{port}");
+    let mut app =
+        App::new().with_options(|opt| opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp")));
+    app.map_tool("shout", || async move {
+        tracing::warn!(logger = "tool", "{MARKER}");
+        "pong".to_string()
+    });
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::new();
+    let url = format!("http://{addr}/mcp");
+
+    // (a) opted in via `_meta.logLevel` -> SSE reply with the log then response.
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {
+            "name": "shout",
+            "arguments": {},
+            "_meta": { "io.modelcontextprotocol/logLevel": "info" }
+        }
+    });
+    let resp = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&call)
+        .send()
+        .await
+        .expect("logged call failed");
+    assert!(resp.status().is_success());
+    let ctype = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        ctype.contains("text/event-stream"),
+        "opted-in reply must be an SSE stream, got content-type {ctype:?}"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("notifications/message"),
+        "SSE body must carry the log notification, got: {body}"
+    );
+    assert!(
+        body.contains(MARKER),
+        "SSE body must carry the log message, got: {body}"
+    );
+    assert!(
+        body.contains("pong"),
+        "SSE body must carry the response, got: {body}"
+    );
+
+    // (b) no `logLevel` -> plain JSON reply, no log notifications (suppressed).
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "shout", "arguments": {} }
+    });
+    let resp = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&call)
+        .send()
+        .await
+        .expect("plain call failed");
+    assert!(resp.status().is_success());
+    let ctype = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        !ctype.contains("text/event-stream"),
+        "reply without logLevel must be plain JSON, got content-type {ctype:?}"
+    );
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(
+        body.pointer("/result/content/0/text")
+            .and_then(|v| v.as_str()),
+        Some("pong")
+    );
+
+    handle.abort();
+}
+
+fn pick_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}

--- a/neva/tests/http_logging_rc.rs
+++ b/neva/tests/http_logging_rc.rs
@@ -35,7 +35,13 @@ async fn request_scoped_logging_streams_over_post() {
     // The notification layer must be the active subscriber in the server task so
     // the tool's `tracing` events become `notifications/message`. Each test file
     // is its own process, so installing the global default here is safe.
+    //
+    // The warning-only threshold is deliberate and mirrors a common application
+    // setup: every log below is emitted at WARN, so all of them stay enabled,
+    // and the request span that carries the routing context must survive the
+    // same filter.
     tracing_subscriber::registry()
+        .with(tracing::level_filters::LevelFilter::WARN)
         .with(notification::fmt::layer())
         .init();
 

--- a/neva/tests/http_logging_rc.rs
+++ b/neva/tests/http_logging_rc.rs
@@ -113,6 +113,47 @@ async fn request_scoped_logging_streams_over_post() {
         Some("pong")
     );
 
+    // (c) a batch whose inner request opts in streams too: the inner request's
+    // log rides the single SSE POST response alongside the batch response.
+    let batch = serde_json::json!([
+        {
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {
+                "name": "shout",
+                "arguments": {},
+                "_meta": { "io.modelcontextprotocol/logLevel": "info" }
+            }
+        },
+        {
+            "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+            "params": { "name": "shout", "arguments": {} }
+        }
+    ]);
+    let resp = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&batch)
+        .send()
+        .await
+        .expect("batch call failed");
+    assert!(resp.status().is_success());
+    let ctype = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        ctype.contains("text/event-stream"),
+        "a batch with an opted-in inner request must stream, got content-type {ctype:?}"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("notifications/message") && body.contains(MARKER),
+        "batch SSE body must carry the inner request's log, got: {body}"
+    );
+
     handle.abort();
 }
 

--- a/neva/tests/http_volga_integration.rs
+++ b/neva/tests/http_volga_integration.rs
@@ -1,4 +1,4 @@
-//! Volga adapter end-to-end smoke test — performs an init POST + tool-call
+//! Volga adapter end-to-end smoke test -- performs an init POST + tool-call
 //! POST + DELETE against a running `HttpServer<DefaultClaims, VolgaEngine>`
 //! bound to an ephemeral port. Asserts session-id round-trip and basic
 //! response shape.

--- a/neva/tests/http_volga_integration.rs
+++ b/neva/tests/http_volga_integration.rs
@@ -28,7 +28,10 @@ async fn volga_engine_round_trip() {
 
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     let init_body = serde_json::json!({

--- a/neva/tests/mrtr_rc.rs
+++ b/neva/tests/mrtr_rc.rs
@@ -39,7 +39,10 @@ async fn tool_elicits_then_completes_over_two_rounds() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // Round 1: tools/call -> input_required.
@@ -146,7 +149,10 @@ async fn final_round_replay_is_idempotent_after_a_lost_response() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // Round 1: tools/call -> input_required.
@@ -279,7 +285,10 @@ async fn concurrent_final_round_retries_commit_exactly_once() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // Round 1: tools/call -> input_required.
@@ -385,7 +394,10 @@ async fn distinct_answers_to_the_same_state_do_not_collide_in_the_cache() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     let call = serde_json::json!({
@@ -506,7 +518,10 @@ async fn effects_run_once_memo_caches_commit_fires_on_final_round() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // Round 1: input_required. Effect + memo ran; commit NOT yet.
@@ -621,7 +636,10 @@ async fn oversized_request_state_is_rejected() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     let call = serde_json::json!({
@@ -675,7 +693,10 @@ async fn oversized_inbound_request_state_is_rejected_before_decoding() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // A 4 KiB blob -- well over the 256-byte cap and never a valid signed state.
@@ -729,7 +750,10 @@ async fn replaying_request_state_against_a_different_request_is_rejected() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // Round 1: bind state to `arguments: {}`.
@@ -804,7 +828,10 @@ async fn eliciting_without_declared_capability_is_rejected() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // No `clientCapabilities.elicitation` -> the server cannot ask for input.
@@ -1230,7 +1257,10 @@ async fn tool_samples_then_completes_over_two_rounds() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     let call = serde_json::json!({
@@ -1325,7 +1355,10 @@ async fn tool_lists_roots_then_completes_over_two_rounds() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     let call = serde_json::json!({
@@ -1523,7 +1556,10 @@ async fn sampling_without_declared_capability_is_rejected() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // Elicitation is declared, sampling is not.

--- a/neva/tests/mrtr_rc.rs
+++ b/neva/tests/mrtr_rc.rs
@@ -1,8 +1,8 @@
 //! MRTR (elicitation) end-to-end over the stateless RC transport.
 //!
 //! Drives the raw protocol so the two-round wire contract is asserted
-//! directly: round 1 `tools/call` → `input_required` (+ `requestState`),
-//! round 2 retry (new id + `inputResponses` + echoed state) → final result.
+//! directly: round 1 `tools/call` -> `input_required` (+ `requestState`),
+//! round 2 retry (new id + `inputResponses` + echoed state) -> final result.
 #![cfg(all(
     feature = "proto-2026-07-28-rc",
     feature = "http-server-volga",
@@ -42,7 +42,7 @@ async fn tool_elicits_then_completes_over_two_rounds() {
     let client = reqwest::Client::new();
     let url = format!("http://{addr}/mcp");
 
-    // Round 1: tools/call → input_required.
+    // Round 1: tools/call -> input_required.
     let call = serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "tools/call",
         "params": { "name": "greet", "arguments": {},
@@ -117,7 +117,7 @@ static CONCURRENT_FINAL_COMMITS: AtomicUsize = AtomicUsize::new(0);
 async fn final_round_replay_is_idempotent_after_a_lost_response() {
     // The final POST commits and produces a result, but its HTTP response is
     // "lost"; the client retries the SAME requestState + inputResponses. The
-    // server must serve the cached result without re-running the handler — so
+    // server must serve the cached result without re-running the handler -- so
     // the on_commit side effect fires exactly once across both finals.
     LOST_RESPONSE_COMMITS.store(0, Ordering::SeqCst);
 
@@ -149,7 +149,7 @@ async fn final_round_replay_is_idempotent_after_a_lost_response() {
     let client = reqwest::Client::new();
     let url = format!("http://{addr}/mcp");
 
-    // Round 1: tools/call → input_required.
+    // Round 1: tools/call -> input_required.
     let call = serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "tools/call",
         "params": { "name": "greet", "arguments": {},
@@ -266,7 +266,7 @@ async fn concurrent_final_round_retries_commit_exactly_once() {
             .content
             .and_then(|c| c.get("name").and_then(|v| v.as_str().map(str::to_owned)))
             .unwrap_or_else(|| "stranger".into());
-        // Widen the get-miss → put window so both retries would overlap absent
+        // Widen the get-miss -> put window so both retries would overlap absent
         // the reservation.
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         ctx.on_commit(async move {
@@ -282,7 +282,7 @@ async fn concurrent_final_round_retries_commit_exactly_once() {
     let client = reqwest::Client::new();
     let url = format!("http://{addr}/mcp");
 
-    // Round 1: tools/call → input_required.
+    // Round 1: tools/call -> input_required.
     let call = serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "tools/call",
         "params": { "name": "greet", "arguments": {},
@@ -363,7 +363,7 @@ async fn distinct_answers_to_the_same_state_do_not_collide_in_the_cache() {
     // Two flows reach the SAME pre-answer requestState (same method/params/
     // principal, no nonce) but supply DIFFERENT inputResponses. The final cache
     // is keyed by the state tag plus the answers digest, so the second flow must
-    // see its own answer reflected — never the first flow's cached result.
+    // see its own answer reflected -- never the first flow's cached result.
     let port = pick_free_port();
     let addr = format!("127.0.0.1:{port}");
     let mut app = App::new()
@@ -554,7 +554,7 @@ async fn effects_run_once_memo_caches_commit_fires_on_final_round() {
         .expect("one input request")
         .clone();
 
-    // Round 2: retry → final result. memo HIT (no fetch), once HIT (no charge),
+    // Round 2: retry -> final result. memo HIT (no fetch), once HIT (no charge),
     // commit fires exactly once.
     let retry = serde_json::json!({
         "jsonrpc": "2.0", "id": 2, "method": "tools/call",
@@ -655,7 +655,7 @@ async fn oversized_request_state_is_rejected() {
 async fn oversized_inbound_request_state_is_rejected_before_decoding() {
     // An untrusted client supplies a bogus `requestState` far larger than the
     // configured cap. It must be rejected on size *before* base64 decoding and
-    // HMAC verification run, so the cap protects inbound retries — not just the
+    // HMAC verification run, so the cap protects inbound retries -- not just the
     // outbound states the server mints.
     let port = pick_free_port();
     let addr = format!("127.0.0.1:{port}");
@@ -678,7 +678,7 @@ async fn oversized_inbound_request_state_is_rejected_before_decoding() {
     let client = reqwest::Client::new();
     let url = format!("http://{addr}/mcp");
 
-    // A 4 KiB blob — well over the 256-byte cap and never a valid signed state.
+    // A 4 KiB blob -- well over the 256-byte cap and never a valid signed state.
     let bogus_state = "A".repeat(4096);
     let call = serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "tools/call",
@@ -753,7 +753,7 @@ async fn replaying_request_state_against_a_different_request_is_rejected() {
         .expect("requestState present")
         .to_string();
 
-    // Replay that state against a request with DIFFERENT arguments → the
+    // Replay that state against a request with DIFFERENT arguments -> the
     // request binding no longer matches.
     let replay = serde_json::json!({
         "jsonrpc": "2.0", "id": 2, "method": "tools/call",
@@ -807,7 +807,7 @@ async fn eliciting_without_declared_capability_is_rejected() {
     let client = reqwest::Client::new();
     let url = format!("http://{addr}/mcp");
 
-    // No `clientCapabilities.elicitation` → the server cannot ask for input.
+    // No `clientCapabilities.elicitation` -> the server cannot ask for input.
     let call = serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "tools/call",
         "params": { "name": "greet", "arguments": {} }
@@ -841,7 +841,7 @@ static C_CHARGES: AtomicUsize = AtomicUsize::new(0);
 static C_RECEIPTS: AtomicUsize = AtomicUsize::new(0);
 
 /// Real end-to-end: the neva MCP **client** (not raw reqwest) drives the whole
-/// MRTR loop — `connect()` runs `server/discover`, `call_tool` enters
+/// MRTR loop -- `connect()` runs `server/discover`, `call_tool` enters
 /// `run_with_mrtr`, and the registered elicitation handler answers the
 /// server's request transparently across the round-trip.
 #[tokio::test(flavor = "multi_thread")]
@@ -1014,7 +1014,7 @@ async fn client_drives_mrtr_across_a_batch_end_to_end() {
 /// three-request batch elicits on every slot; after the round-2 retry one tool
 /// returns `Err` (surfaced as an `is_error` `CallToolResponse`, not a JSON-RPC
 /// error), while the other two complete normally. The batch still resolves to
-/// `Ok` with all three slots filled in order — the failing slot carries the
+/// `Ok` with all three slots filled in order -- the failing slot carries the
 /// error result, its neighbours carry their final answers. This locks down that
 /// a per-slot tool failure is isolated, not fatal to the whole batch.
 #[tokio::test(flavor = "multi_thread")]
@@ -1104,7 +1104,7 @@ async fn batch_isolates_a_single_slot_failure_after_elicitation() {
 }
 
 /// The MRTR round cap is configurable via `with_max_mrtr_rounds`, and counts
-/// *re-issues* — not the initial send. A cap of 0 sends the request once and
+/// *re-issues* -- not the initial send. A cap of 0 sends the request once and
 /// fails the moment it elicits, so the client gives up with the max-rounds error
 /// instead of looping the default 8 times.
 #[tokio::test(flavor = "multi_thread")]
@@ -1149,8 +1149,8 @@ async fn configurable_max_rounds_caps_the_mrtr_loop() {
 }
 
 /// The cap counts re-issues, not the initial send: `with_max_mrtr_rounds(1)`
-/// must let a normal one-question flow converge (initial send → `input_required`
-/// → one retry → final), rather than spending its only iteration on the first
+/// must let a normal one-question flow converge (initial send -> `input_required`
+/// -> one retry -> final), rather than spending its only iteration on the first
 /// send and erroring before it can retry.
 #[tokio::test(flavor = "multi_thread")]
 async fn one_retry_budget_completes_a_single_question_flow() {
@@ -1201,7 +1201,7 @@ async fn one_retry_budget_completes_a_single_question_flow() {
 }
 
 /// #85: sampling returns as an MRTR input-request kind. The wire contract is
-/// the same two rounds elicitation uses — only the envelope's `method` and the
+/// the same two rounds elicitation uses -- only the envelope's `method` and the
 /// result type differ.
 #[tokio::test(flavor = "multi_thread")]
 async fn tool_samples_then_completes_over_two_rounds() {
@@ -1388,9 +1388,9 @@ async fn tool_lists_roots_then_completes_over_two_rounds() {
     handle.abort();
 }
 
-/// The real client fulfils both deprecated kinds through the MRTR loop —
-/// sampling from its configured handler, roots from its configured list — with
-/// no server→client push channel involved.
+/// The real client fulfils both deprecated kinds through the MRTR loop --
+/// sampling from its configured handler, roots from its configured list -- with
+/// no server->client push channel involved.
 #[tokio::test(flavor = "multi_thread")]
 async fn client_drives_sampling_and_roots_end_to_end() {
     use neva::types::sampling::{CreateMessageRequestParams, CreateMessageResult, SamplingMessage};
@@ -1455,7 +1455,7 @@ async fn client_drives_sampling_and_roots_end_to_end() {
     handle.abort();
 }
 
-/// A client that opted into roots but exposes none must still be askable — an
+/// A client that opted into roots but exposes none must still be askable -- an
 /// empty `ListRootsResult` is a valid answer, and gating it out would leave the
 /// server unable to complete the call at all.
 #[tokio::test(flavor = "multi_thread")]

--- a/neva/tests/stateless_http_rc.rs
+++ b/neva/tests/stateless_http_rc.rs
@@ -22,7 +22,10 @@ async fn stateless_discover_and_call() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // (a) discover, no session header.

--- a/neva/tests/tasks_extension_rc.rs
+++ b/neva/tests/tasks_extension_rc.rs
@@ -28,7 +28,10 @@ async fn tasks_capability_is_advertised_as_extension() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // (a) discover advertises tasks under the extensions map, not top-level.
@@ -111,7 +114,10 @@ async fn task_augmented_tool_elicits_via_suspend_resume() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     let post = |body: serde_json::Value| {
@@ -226,7 +232,10 @@ async fn mrtr_elicit_inside_a_task_is_rejected_with_guidance() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
     let post = |body: serde_json::Value| {
         let client = client.clone();
@@ -300,7 +309,10 @@ async fn mrtr_once_in_a_required_task_is_rejected() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
     let post = |body: serde_json::Value| {
         let client = client.clone();

--- a/neva/tests/tasks_extension_rc.rs
+++ b/neva/tests/tasks_extension_rc.rs
@@ -83,7 +83,7 @@ async fn task_augmented_tool_elicits_via_suspend_resume() {
     // background future suspends (task -> input_required), the client posts the
     // answer as a Response keyed by the task id (session-independent), the future
     // resumes in place, and the final result carries the elicited value. Side
-    // effects are just run inline (no MRTR `on_commit` needed — there is no
+    // effects are just run inline (no MRTR `on_commit` needed -- there is no
     // re-run); the counter below proves the resumed body ran to completion.
     TASK_COMMITS.store(0, Ordering::SeqCst);
 
@@ -149,7 +149,7 @@ async fn task_augmented_tool_elicits_via_suspend_resume() {
         }
     };
 
-    // 1. Task-augmented call → CreateTaskResult carrying a task id.
+    // 1. Task-augmented call -> CreateTaskResult carrying a task id.
     let r1 = post(serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "tools/call",
         "params": {
@@ -164,7 +164,7 @@ async fn task_augmented_tool_elicits_via_suspend_resume() {
         .unwrap_or_else(|| panic!("task id present, got: {r1}"))
         .to_string();
 
-    // 2. The tool elicits → the task suspends into input_required.
+    // 2. The tool elicits -> the task suspends into input_required.
     assert!(
         wait_status("input_required", task_id.clone()).await,
         "task must enter input_required when the tool elicits"
@@ -205,7 +205,7 @@ async fn task_augmented_tool_elicits_via_suspend_resume() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn mrtr_elicit_inside_a_task_is_rejected_with_guidance() {
-    // The MRTR `ctx.elicit` is not valid on the task substrate — it must guide
+    // The MRTR `ctx.elicit` is not valid on the task substrate -- it must guide
     // the author to `ctx.task().elicit(...)` rather than silently misbehave.
     let port = pick_free_port();
     let addr = format!("127.0.0.1:{port}");

--- a/neva/tests/tool_macro_rc.rs
+++ b/neva/tests/tool_macro_rc.rs
@@ -79,7 +79,10 @@ async fn tool_macro_emits_json_schema_2020() {
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
     let url = format!("http://{addr}/mcp");
 
     // Stateless RC transport: no handshake/session -- a single `tools/list`

--- a/neva/tests/tool_macro_rc.rs
+++ b/neva/tests/tool_macro_rc.rs
@@ -6,6 +6,7 @@
 
 #![cfg(all(
     feature = "proto-2026-07-28-rc",
+    feature = "server-macros",
     feature = "http-server-volga",
     feature = "http-client"
 ))]

--- a/neva/tests/tool_macro_rc.rs
+++ b/neva/tests/tool_macro_rc.rs
@@ -21,7 +21,7 @@ struct Profile {
     age: u32,
 }
 
-// No `JsonSchema` derive — must degrade to `{"type":"object"}`.
+// No `JsonSchema` derive -- must degrade to `{"type":"object"}`.
 #[derive(Deserialize)]
 #[allow(dead_code)]
 struct Opaque {
@@ -81,7 +81,7 @@ async fn tool_macro_emits_json_schema_2020() {
     let client = reqwest::Client::new();
     let url = format!("http://{addr}/mcp");
 
-    // Stateless RC transport: no handshake/session — a single `tools/list`
+    // Stateless RC transport: no handshake/session -- a single `tools/list`
     // POST carrying the required `MCP-Protocol-Version` header is enough.
     let list_body = serde_json::json!({
         "jsonrpc": "2.0",

--- a/neva_macros/src/server/tool.rs
+++ b/neva_macros/src/server/tool.rs
@@ -5,17 +5,17 @@
 //! Under the `proto-2026-07-28-rc` feature the generated `inputSchema` /
 //! `outputSchema` are full JSON Schema 2020-12 documents:
 //!
-//! - **Primitive arguments** (`String`, integers, `bool`, `Vec<_>`, …) become
+//! - **Primitive arguments** (`String`, integers, `bool`, `Vec<_>`, ...) become
 //!   inline primitive property schemas, exactly as before.
 //! - **Structured arguments** passed as `Json<T>` produce a rich, self-contained
 //!   subschema when the inner `T` derives `JsonSchema` (via
 //!   `#[derive(neva::json_schema)]` or `schemars::JsonSchema`). An inner type
 //!   that does **not** derive it degrades gracefully to `{"type":"object"}`.
 //!   Deriving is therefore recommended for structured argument and return types.
-//!   No `schemars` dependency is required in your crate — it is re-exported by
+//!   No `schemars` dependency is required in your crate -- it is re-exported by
 //!   neva.
 //! - **Recursive types cannot be inlined**; model them with an explicit
-//!   `input_schema = "…"` instead.
+//!   `input_schema = "..."` instead.
 //! - **Explicit `input_schema` / `output_schema` string literals** are validated
 //!   at compile time; malformed JSON is a compile error (on every feature
 //!   configuration).


### PR DESCRIPTION
## Summary

Re-home MCP server-side logging onto the request-scoped model introduced in the 2026-07-28 draft, and some repo housekeeping alongside it.

**Request-scoped logging (`proto-2026-07-28-rc`, #93).** The draft removes only `logging/setLevel`; it *keeps* `notifications/message` as a deprecated, request-scoped log notification. neva had compiled the entire logging surface
out under the RC — so RC servers had no way to emit log notifications at all. This brings the kept part back:

- The desired level now rides per-request on `_meta["io.modelcontextprotocol/logLevel"]` (`RequestParamsMeta.log_level`) instead of a global `setLevel` handshake. While the server handles a request, it emits `notifications/message` at or above that severity and suppresses the rest; with no requested level it emits none.
- The level is carried into the per-request tracing span (`tracing_middleware` → `create_tracing_span` → span extension) and both emission paths honor it: the HTTP `MpscLayer` (`notification::fmt::layer()`) and the stdio `NotificationFormatter`. A new `notification::fmt::span_context()` layer records the request context for the stdio formatter to read, so both paths
  filter identically.
- Client API: `McpOptions::with_log_level` (via `Client::with_options`), `#[deprecated]` on arrival to mirror the schema. `LoggingLevel` / `LogMessage` stay undecorated.
- `logging/setLevel`, `SetLevelRequestParams`, and `with_logging` / `set_log_level` stay removed under the RC.

## Breaking Change
* **Unified streaming-capable POST seam** for HTTP engine adapters. Streamable HTTP has allowed a POST reply to be either a single JSON body or an SSE stream since spec revision 2025-03-26; neva's engine seam only modeled the JSON shape. Now:
  * `SseResponse` is renamed to `StreamResponse` and its `Status` variant to `Complete` (it carries full JSON replies, not just error statuses). A deprecated `SseResponse` type alias remains for one release.
  * `handlers::dispatch_post` returns `StreamResponse<impl Stream<Item = E::SseEvent>>` instead of
    `E::Response`: engines handle the same two-arm match their GET route already has. Under `proto-2026-07-28-rc` + `tracing` the `Stream` arm carries request-scoped notifications followed by the response; other builds always produce `Complete` (no behavior change).
  * `handle_post` stays available as the JSON-only building block.
  * The default Volga adapter now goes through `dispatch_post` like every other engine (claims moved into `VolgaEngine::adapt_request`, per the `HttpEngine` contract); the axum/hyper/actix engine examples were updated to the two-arm match.

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [x] Refactor
- [ ] Security
- [x] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

## Notes for reviewers

- The issue's checklist under-scoped the work: the RC branch had gated out the *whole* log-emission subsystem (both the stdio `NotificationFormatter` path and the HTTP `LOG_REGISTRY`/SSE path, plus the `log_message`/`formatter`/`fmt`
  modules), not just `setLevel`. Most of the diff is flipping those `not(proto-2026-07-28-rc)` gates back on while keeping `setLevel` gone.
- The span field carries the level's **severity rank** (a plain integer), not a string — so no redundant wire-string encoding of `LoggingLevel`; only `severity()` remains (the enum's declaration order isn't severity order, so it can't be derived).
- I deliberately did **not** deprecate `notification::fmt::layer()` / `NotificationFormatter` / `span_context()`, since they also carry `notifications/progress` — deprecating them would wrongly flag progress usage.
- Verified: `cargo test --all-features` (743 passed, 0 failed) plus RC combos (`server-full` / `client-full` + `proto-2026-07-28-rc`); `clippy --all-features -D warnings` and RC combos clean; `fmt --check` and `doc --all-features` clean.