### PR TITLE
Implement `subscriptions/listen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     untouched, as does everything from a peer the dual-mode fallback landed on,
     which has no subscriptions to tag with. Batching changes none of this: an
     acknowledgment or a tagged notification inside a JSON-RPC batch goes
-    through the same gate a standalone one does.
+    through the same gate a standalone one does, and the HTTP transport no
+    longer treats such a batch as the request's terminal reply -- only a batch
+    that carries a response is one, so a stream dying before the real answer
+    still fails its (untimed) listen slot instead of looking orderly.
     Notifications keep flowing to the handlers registered with
     `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, so
     existing client code needs no change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,10 +29,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     falls wholly on one side of the handshake: a mutation racing it either
     predates the subscription or queues behind an acknowledgment already on the
     stream -- the sink is drained concurrently, so no ordering the caller could
-    arrange would do. And over HTTP the listen `POST` body carries the
-    subscription only: request-scoped `notifications/message` stay off it,
-    where middleware logging before `next(ctx)` would otherwise land ahead of
-    the acknowledgment (a batched listen included). `Context::add_tool`,
+    arrange would do. And over HTTP the listen `POST` body holds back whatever
+    reaches it before the acknowledgment -- middleware logging ahead of
+    `next(ctx)` is queued before `Context::listen` ever runs -- releasing it
+    immediately after (a batched listen included). Held, not dropped: those
+    request-scoped log messages were explicitly asked for via `_meta.logLevel`,
+    and in a mixed batch they may belong to another request on the same body.
+    `Context::add_tool`,
     `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
     `remove_resource` and `resource_updated` fan out to the streams that asked
     for them; `Context::is_subscribed` now answers from the live streams. A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   * **Client:** `Client::listen(SubscriptionFilter)` returns a `Subscription`
     once the server acknowledges, exposing `id()`, `requested()`,
     `acknowledged()`, `is_fully_honored()`, `cancel()` and
-    `closed() -> SubscriptionEnd` (`Graceful` / `Cancelled` / `Abrupt`).
+    `closed() -> SubscriptionEnd` (`Graceful` / `Cancelled` / `Abrupt`). The
+    graceful result names the subscription it closes, and that name is checked:
+    a reply that closes a different one is reported as `Abrupt` rather than
+    handed to the caller.
     Dropping the handle ends the subscription too, so one that falls out of
     scope cannot leave the peer streaming into handlers nothing can stop;
     either way its request slot is released, since a cancelled stream is never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     answered and those slots carry no TTL. `Client::disconnect` ends every live
     subscription: the listen `POST` closes, so the server drops its entry, and
     `closed()` reports `Abrupt` rather than awaiting a result the transport can
-    no longer carry.
+    no longer carry -- including when `cancel()` is what discovers the
+    connection is gone, since a cancel that never reached the wire ended
+    nothing.
   * Tagged notifications are checked against the filter their subscription
     acknowledged, and dropped if they fall outside it. The acknowledgment is a
     promise about the whole stream, not just its first message, and nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,17 +51,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     acknowledged, and dropped if they fall outside it. The acknowledgment is a
     promise about the whole stream, not just its first message, and nothing
     downstream could tell -- notifications reach the client's global handlers,
-    which know nothing about subscriptions. Untagged ones (request-scoped
-    progress and log messages) pass through untouched. Batching changes none of
-    this: an acknowledgment or a tagged notification inside a JSON-RPC batch
-    goes through the same gate a standalone one does.
+    which know nothing about subscriptions. A subscribable type arriving
+    *without* a usable subscription id is dropped too: under MCP 2026-07-28
+    those travel on a subscription and nowhere else, so an untagged
+    `tools/list_changed` has nothing to be checked against. Untagged
+    request-scoped notifications (progress and log messages) pass through
+    untouched, as does everything from a peer the dual-mode fallback landed on,
+    which has no subscriptions to tag with. Batching changes none of this: an
+    acknowledgment or a tagged notification inside a JSON-RPC batch goes
+    through the same gate a standalone one does.
     Notifications keep flowing to the handlers registered with
     `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, so
     existing client code needs no change.
   * Establishment races the acknowledgment against the request's own reply, so
     a peer that rejects the subscription outright surfaces *its* error instead
-    of a timeout; an acknowledgment broader than the filter that was requested
-    is refused outright. `cancel()` ends the stream on both transports --
+    of a timeout, and a transport that dies mid-establishment reports
+    `Connection closed` rather than a timeout it never waited out; an
+    acknowledgment broader than the filter that was requested is refused
+    outright. `cancel()` ends the stream on both transports --
     over HTTP by closing the listen response body, which is what the server
     acts on -- and so does giving up on an unacknowledged one, which would
     otherwise leave the peer streaming into a subscription the caller was told

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     untouched, as does everything from a peer the dual-mode fallback landed on,
     which has no subscriptions to tag with. Batching changes none of this: an
     acknowledgment or a tagged notification inside a JSON-RPC batch goes
-    through the same gate a standalone one does, and the HTTP transport no
-    longer treats such a batch as the request's terminal reply -- only a batch
-    that carries a response is one, so a stream dying before the real answer
+    through the same gate a standalone one does. The HTTP transport learned the
+    same distinction: a `POST` stream counts as answered only when a reply
+    resolves one of the requests *it* carried -- not on any batch, and not on a
+    response bearing some other id -- so a stream dying before the real answer
     still fails its (untimed) listen slot instead of looking orderly.
     Notifications keep flowing to the handlers registered with
     `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,18 +27,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
     `remove_resource` and `resource_updated` fan out to the streams that asked
     for them; `Context::is_subscribed` now answers from the live streams. A
-    subscription ends on `notifications/cancelled` (stdio's mechanism; over
-    HTTP a bare request id is only unique within one client, so an id naming
-    more than one live stream is refused), on transport close, or on server
-    shutdown. Client cancel answers with the graceful empty result; on the
-    shutdown path that answer is best-effort, since the transport writers stop
-    on the same signal.
+    subscription ends on `notifications/cancelled` (stdio's mechanism, and
+    stdio's only -- over HTTP that notification travels on its own `POST` and
+    proves nothing about who opened the stream, while request ids collide
+    across clients routinely), on the client closing the stream (HTTP's
+    mechanism), on transport close, or on server shutdown. The registry is
+    keyed server-side, not by the peer's request id, so colliding ids cannot
+    evict or cancel each other's subscriptions.
   * **Client:** `Client::listen(SubscriptionFilter)` returns a `Subscription`
     once the server acknowledges, exposing `id()`, `requested()`,
     `acknowledged()`, `is_fully_honored()`, `cancel()` and
-    `closed() -> SubscriptionEnd`. Notifications keep flowing to the handlers
-    registered with `Client::subscribe` / `on_tools_changed` /
-    `on_resource_changed`, so existing client code needs no change.
+    `closed() -> SubscriptionEnd` (`Graceful` / `Cancelled` / `Abrupt`).
+    Notifications keep flowing to the handlers registered with
+    `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, so
+    existing client code needs no change.
+  * Establishment races the acknowledgment against the request's own reply, so
+    a peer that rejects the subscription outright surfaces *its* error instead
+    of a timeout; an acknowledgment broader than the filter that was requested
+    is refused outright. `cancel()` ends the stream on both transports --
+    over HTTP by closing the listen response body, which is what the server
+    acts on -- and so does giving up on an unacknowledged one, which would
+    otherwise leave the peer streaming into a subscription the caller was told
+    had failed.
   * Works on both transports: over HTTP the subscription rides the listen
     `POST`'s own `text/event-stream` body (a client disconnect ends it); over
     stdio it interleaves on stdout and ends on `notifications/cancelled`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     and in a mixed batch they may belong to another request on the same body.
     The hold buffer is bounded by the sink's own capacity, and overflow past it
     is dropped rather than released early: the acknowledgment arriving first is
-    the requirement, the logs riding along are the accommodation.
+    the requirement, the logs riding along are the accommodation. Its room on
+    the body is reserved when the sink is registered, before any middleware can
+    run, so a request noisy enough to fill the buffer costs only the logs that
+    did not fit -- never the subscription itself.
     `Context::add_tool`,
     `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
     `remove_resource` and `resource_updated` fan out to the streams that asked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     over HTTP by closing the listen response body, which is what the server
     acts on -- and so does giving up on an unacknowledged one, which would
     otherwise leave the peer streaming into a subscription the caller was told
-    had failed.
+    had failed. Giving up includes dropping the `listen` future itself (an
+    outer `tokio::time::timeout`, a lost `select!` branch): the establishment
+    is guarded, so a caller that never sees a result still ends what it
+    started.
   * `Client::call_batch` rejects a batched `subscriptions/listen` with
     `InvalidRequest`. A batch slot is an ordinary request slot -- finite TTL, a
     plain `Response`, no handle -- so a subscription opened that way would have

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,74 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## 0.5.1
+
+### Added
+* **`subscriptions/listen`** (MCP 2026-07-28, #95). The final spec replaced the
+  HTTP `GET` stream *and* `resources/subscribe`/`unsubscribe` with one
+  long-lived request carrying a notification filter. This is how server-push
+  works again on the stateless transport, and it **retracts the note carried
+  since 0.4.x that "server-initiated notifications are inert; clients poll
+  instead"** -- that limitation described the RC, not the final spec.
+  * New `SubscriptionFilter` (`toolsListChanged` / `promptsListChanged` /
+    `resourcesListChanged` / `resourceSubscriptions`) with `intersection`,
+    `is_subset_of`, `supported_by` and `matches`, plus
+    `SubscriptionsListenRequestParams`, `SubscriptionsListenResult`,
+    `SubscriptionsAcknowledgedNotificationParams` and `SubscriptionMeta`.
+  * **Server:** `subscriptions/listen` is handled by neva itself -- there is no
+    handler to write. The accepted filter is the requested one narrowed to the
+    advertised capabilities, acknowledged first on the stream
+    (`notifications/subscriptions/acknowledged`), and every message carries
+    `_meta["io.modelcontextprotocol/subscriptionId"]`. `Context::add_tool`,
+    `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
+    `remove_resource` and `resource_updated` fan out to the streams that asked
+    for them; `Context::is_subscribed` now answers from the live streams. A
+    subscription ends on `notifications/cancelled`, on transport close, or on
+    server shutdown -- the last two after a graceful empty result.
+  * **Client:** `Client::listen(SubscriptionFilter)` returns a `Subscription`
+    once the server acknowledges, exposing `id()`, `requested()`,
+    `acknowledged()`, `is_fully_honored()`, `cancel()` and
+    `closed() -> SubscriptionEnd`. Notifications keep flowing to the handlers
+    registered with `Client::subscribe` / `on_tools_changed` /
+    `on_resource_changed`, so existing client code needs no change.
+  * Works on both transports: over HTTP the subscription rides the listen
+    `POST`'s own `text/event-stream` body (a client disconnect ends it); over
+    stdio it interleaves on stdout and ends on `notifications/cancelled`.
+  * New `examples/subscriptions/` (server + client over HTTP).
+
+### Changed (breaking)
+* **`listChanged` and `resources.subscribe` are advertised again.** Both were
+  masked off in the default build because nothing could deliver them; a listen
+  stream now can. Servers that configure `with_list_changed()` /
+  `with_subscribe()` start seeing those capabilities on the wire, and clients
+  narrow their listen filter against exactly what a server advertises.
+* **`resources/subscribe` / `resources/unsubscribe` are legacy-only.** The RPC
+  pair is not deleted by the spec, it is folded into
+  `SubscriptionFilter::resource_subscriptions` -- a subscription is now a URI on
+  a stream rather than server-side state.
+  * `Context::subscribe_to_resource` / `unsubscribe_from_resource` and
+    `resource::commands::{SUBSCRIBE, UNSUBSCRIBE}` are behind `legacy-spec`;
+    `UnsubscribeRequestParams` is behind `any(legacy-spec, client)`.
+    `SubscribeRequestParams` stays in both profiles -- it is the `{uri}` payload
+    of `notifications/resources/updated`.
+  * `Client::subscribe_to_resource` / `unsubscribe_from_resource` stay compiled
+    (the dual-mode fallback still reaches legacy peers) but now reject a
+    2026-07-28 peer with `MethodNotFound`. Use `Client::listen` with a
+    `resourceSubscriptions` entry instead.
+  * Migration: replace `client.subscribe_to_resource(uri)` with
+    `client.listen(SubscriptionFilter::new().with_resource(uri))`, and drop
+    `ctx.subscribe_to_resource(..)` from server handlers -- the client owns the
+    subscription now.
+
+### Changed
+* `ServerCapabilities` now derives `Default`, so a filter can be narrowed
+  against a partially-built capability set.
+* **The streaming `POST` reply no longer requires the `tracing` feature.**
+  `dispatch_post` produces the `StreamResponse::Stream` arm in any default-build
+  configuration -- a subscription stream is not a logging concern. Internally
+  the per-`POST` notification sink moved out of the `tracing`-gated
+  `notification::fmt` into a new internal `notification::sink`.
+
 ## 0.5.0
 
 ### Changed (breaking)
@@ -152,8 +220,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   * Client-hosted tasks are legacy-only: they existed to answer server->client
     task-augmented requests, and MCP 2026-07-28 has no server->client requests.
   * Not covered here: `subscriptions/listen`, which is how the spec has clients
-    opt into `notifications/tasks`. That mechanism does not exist in neva yet
-    and is tracked separately.
+    opt into `notifications/tasks`. It lands in 0.5.1, though the task category
+    itself is not in the filter yet.
 * **`resultType` on every result** (MCP 2026-07-28, #97). The final spec makes
   the discriminator mandatory on results, not just on MRTR continuations. neva
   emitted it only on `InputRequiredResult`; now every success result carries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `InvalidRequest`. A batch slot is an ordinary request slot -- finite TTL, a
     plain `Response`, no handle -- so a subscription opened that way would have
     nothing to cancel it and would outlive the call that made it.
+  * A listen that arrives over HTTP without a response stream to write to --
+    an engine adapter that cannot stream (the JSON-only `handlers::handle_post`),
+    or a client that dropped the body first -- is answered with an error
+    instead of being served on a channel that goes nowhere.
   * Works on both transports: over HTTP the subscription rides the listen
     `POST`'s own `text/event-stream` body (a client disconnect ends it); over
     stdio it interleaves on stdout and ends on `notifications/cancelled`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     once the server acknowledges, exposing `id()`, `requested()`,
     `acknowledged()`, `is_fully_honored()`, `cancel()` and
     `closed() -> SubscriptionEnd` (`Graceful` / `Cancelled` / `Abrupt`).
+    Dropping the handle ends the subscription too, so one that falls out of
+    scope cannot leave the peer streaming into handlers nothing can stop.
     Notifications keep flowing to the handlers registered with
     `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, so
     existing client code needs no change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     advertised capabilities, acknowledged first on the stream
     (`notifications/subscriptions/acknowledged`), and every message carries
     `_meta["io.modelcontextprotocol/subscriptionId"]`. "First" holds against
-    both things that could displace it: the acknowledgment is queued and the
-    registry entry published with no await in between, so a mutation racing the
-    handshake cannot be dropped by a subscription the client has already been
-    told is live; and over HTTP the listen `POST` body carries the subscription
-    only -- request-scoped `notifications/message` stay off it, where
-    middleware logging before `next(ctx)` would otherwise land ahead of the
-    acknowledgment. `Context::add_tool`,
+    both things that could displace it. The registry queues the acknowledgment
+    itself, under the same lock that publishes the entry, so every broadcast
+    falls wholly on one side of the handshake: a mutation racing it either
+    predates the subscription or queues behind an acknowledgment already on the
+    stream -- the sink is drained concurrently, so no ordering the caller could
+    arrange would do. And over HTTP the listen `POST` body carries the
+    subscription only: request-scoped `notifications/message` stay off it,
+    where middleware logging before `next(ctx)` would otherwise land ahead of
+    the acknowledgment (a batched listen included). `Context::add_tool`,
     `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
     `remove_resource` and `resource_updated` fan out to the streams that asked
     for them; `Context::is_subscribed` now answers from the live streams. A
@@ -82,7 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     had failed. Giving up includes dropping the `listen` future itself (an
     outer `tokio::time::timeout`, a lost `select!` branch): the establishment
     is guarded, so a caller that never sees a result still ends what it
-    started.
+    started. The transport registers a listen's abort handle in its connection
+    loop rather than in the task it spawns, so a cancel written right behind
+    its listen -- which is exactly what giving up writes -- is ordered by the
+    wire rather than by the scheduler.
   * `Client::call_batch` rejects a batched `subscriptions/listen` with
     `InvalidRequest`. A batch slot is an ordinary request slot -- finite TTL, a
     plain `Response`, no handle -- so a subscription opened that way would have

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     connection is gone, since a cancel that never reached the wire ended
     nothing.
   * Tagged notifications are checked against the filter their subscription
-    acknowledged, and dropped if they fall outside it. The acknowledgment is a
-    promise about the whole stream, not just its first message, and nothing
-    downstream could tell -- notifications reach the client's global handlers,
-    which know nothing about subscriptions. A subscribable type arriving
+    acknowledged, and dropped if they fall outside it -- or if there is no
+    acknowledgment yet. The acknowledgment is a promise about the whole stream,
+    not just its first message, and it has to *be* first: a subscription still
+    pending may yet be rejected, and delivering its events would report through
+    the handlers what `Client::listen` goes on to report as failed. Nothing
+    downstream could tell either way -- notifications reach the client's global
+    handlers, which know nothing about subscriptions. A subscribable type arriving
     *without* a usable subscription id is dropped too: under MCP 2026-07-28
     those travel on a subscription and nowhere else, so an untagged
     `tools/list_changed` has nothing to be checked against. Untagged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     handler to write. The accepted filter is the requested one narrowed to the
     advertised capabilities, acknowledged first on the stream
     (`notifications/subscriptions/acknowledged`), and every message carries
-    `_meta["io.modelcontextprotocol/subscriptionId"]`. `Context::add_tool`,
+    `_meta["io.modelcontextprotocol/subscriptionId"]`. "First" holds against
+    both things that could displace it: the acknowledgment is queued and the
+    registry entry published with no await in between, so a mutation racing the
+    handshake cannot be dropped by a subscription the client has already been
+    told is live; and over HTTP the listen `POST` body carries the subscription
+    only -- request-scoped `notifications/message` stay off it, where
+    middleware logging before `next(ctx)` would otherwise land ahead of the
+    acknowledgment. `Context::add_tool`,
     `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
     `remove_resource` and `resource_updated` fan out to the streams that asked
     for them; `Context::is_subscribed` now answers from the live streams. A
@@ -116,6 +123,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   fails every still-pending request on the way out. Over HTTP the receiver
   holds a sender clone of its own channel, so the loop never ended by itself
   and outlived the connection it served; a disconnect now ends both.
+* **A `subscriptions/listen` `POST` body no longer carries request-scoped log
+  messages.** A listen request stamped with `_meta.logLevel` (which neva's own
+  client does for every request when a level is configured) used to stream
+  `notifications/message` on the subscription's body. That body is the
+  subscription's stream, and anything emitted before the handler runs -- user
+  middleware logging ahead of `next(ctx)`, most directly -- arrived before the
+  acknowledgment. Logging on every other request is unchanged.
 * **The streaming `POST` reply no longer requires the `tracing` feature.**
   `dispatch_post` produces the `StreamResponse::Stream` arm in any default-build
   configuration -- a subscription stream is not a logging concern. Internally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
     `remove_resource` and `resource_updated` fan out to the streams that asked
     for them; `Context::is_subscribed` now answers from the live streams. A
-    subscription ends on `notifications/cancelled`, on transport close, or on
-    server shutdown -- the last two after a graceful empty result.
+    subscription ends on `notifications/cancelled` (stdio's mechanism; over
+    HTTP a bare request id is only unique within one client, so an id naming
+    more than one live stream is refused), on transport close, or on server
+    shutdown. Client cancel answers with the graceful empty result; on the
+    shutdown path that answer is best-effort, since the transport writers stop
+    on the same signal.
   * **Client:** `Client::listen(SubscriptionFilter)` returns a `Subscription`
     once the server acknowledges, exposing `id()`, `requested()`,
     `acknowledged()`, `is_fully_honored()`, `cancel()` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,9 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   * Tagged notifications are checked against the filter their subscription
     acknowledged, and dropped if they fall outside it -- or if there is no
     acknowledgment yet. The acknowledgment is a promise about the whole stream,
-    not just its first message, and it has to *be* first: a subscription still
-    pending may yet be rejected, and delivering its events would report through
-    the handlers what `Client::listen` goes on to report as failed. Nothing
+    not just its first message, and it has to *be* first -- and be one this
+    client accepts: a subscription stays pending until then, since an
+    acknowledgment `listen` is about to refuse as overbroad would otherwise
+    deliver the requested categories in the meantime, from a subscription the
+    caller is then told never opened. Nothing
     downstream could tell either way -- notifications reach the client's global
     handlers, which know nothing about subscriptions. A subscribable type arriving
     *without* a usable subscription id is dropped too: under MCP 2026-07-28
@@ -89,8 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     otherwise leave the peer streaming into a subscription the caller was told
     had failed. Giving up includes dropping the `listen` future itself (an
     outer `tokio::time::timeout`, a lost `select!` branch): the establishment
-    is guarded, so a caller that never sees a result still ends what it
-    started. The transport registers a listen's abort handle in its connection
+    is guarded from before the request is written -- the waiter, the untimed
+    request slot and the pending state all exist by then -- so a caller that
+    never sees a result still ends what it started. The transport registers a listen's abort handle in its connection
     loop rather than in the task it spawns, so a cancel written right behind
     its listen -- which is exactly what giving up writes -- is ordered by the
     wire rather than by the scheduler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `acknowledged()`, `is_fully_honored()`, `cancel()` and
     `closed() -> SubscriptionEnd` (`Graceful` / `Cancelled` / `Abrupt`).
     Dropping the handle ends the subscription too, so one that falls out of
-    scope cannot leave the peer streaming into handlers nothing can stop.
+    scope cannot leave the peer streaming into handlers nothing can stop;
+    either way its request slot is released, since a cancelled stream is never
+    answered and those slots carry no TTL.
+  * Tagged notifications are checked against the filter their subscription
+    acknowledged, and dropped if they fall outside it. The acknowledgment is a
+    promise about the whole stream, not just its first message, and nothing
+    downstream could tell -- notifications reach the client's global handlers,
+    which know nothing about subscriptions. Untagged ones (request-scoped
+    progress and log messages) pass through untouched.
     Notifications keep flowing to the handlers registered with
     `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, so
     existing client code needs no change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,103 +21,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     `SubscriptionsAcknowledgedNotificationParams` and `SubscriptionMeta`.
   * **Server:** `subscriptions/listen` is handled by neva itself -- there is no
     handler to write. The accepted filter is the requested one narrowed to the
-    advertised capabilities, acknowledged first on the stream
+    advertised capabilities, acknowledged as the first message on the stream
     (`notifications/subscriptions/acknowledged`), and every message carries
-    `_meta["io.modelcontextprotocol/subscriptionId"]`. "First" holds against
-    both things that could displace it. The registry queues the acknowledgment
-    itself, under the same lock that publishes the entry, so every broadcast
-    falls wholly on one side of the handshake: a mutation racing it either
-    predates the subscription or queues behind an acknowledgment already on the
-    stream -- the sink is drained concurrently, so no ordering the caller could
-    arrange would do. And over HTTP the listen `POST` body holds back whatever
-    reaches it before the acknowledgment -- middleware logging ahead of
-    `next(ctx)` is queued before `Context::listen` ever runs -- releasing it
-    immediately after (a batched listen included). Held, not dropped: those
-    request-scoped log messages were explicitly asked for via `_meta.logLevel`,
-    and in a mixed batch they may belong to another request on the same body.
-    The hold buffer is bounded by the sink's own capacity, and overflow past it
-    is dropped rather than released early: the acknowledgment arriving first is
-    the requirement, the logs riding along are the accommodation. Its room on
-    the body is reserved when the sink is registered, before any middleware can
-    run, so a request noisy enough to fill the buffer costs only the logs that
-    did not fit -- never the subscription itself.
-    `Context::add_tool`,
+    `_meta["io.modelcontextprotocol/subscriptionId"]`. `Context::add_tool`,
     `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
     `remove_resource` and `resource_updated` fan out to the streams that asked
     for them; `Context::is_subscribed` now answers from the live streams. A
     subscription ends on `notifications/cancelled` (stdio's mechanism, and
     stdio's only -- over HTTP that notification travels on its own `POST` and
-    proves nothing about who opened the stream, while request ids collide
-    across clients routinely), on the client closing the stream (HTTP's
-    mechanism), on transport close, or on server shutdown. The registry is
-    keyed server-side, not by the peer's request id, so colliding ids cannot
-    evict or cancel each other's subscriptions.
+    proves nothing about who opened the stream), on the client closing the
+    stream (HTTP's mechanism), on transport close, or on server shutdown.
   * **Client:** `Client::listen(SubscriptionFilter)` returns a `Subscription`
     once the server acknowledges, exposing `id()`, `requested()`,
     `acknowledged()`, `is_fully_honored()`, `cancel()` and
-    `closed() -> SubscriptionEnd` (`Graceful` / `Cancelled` / `Abrupt`). The
-    graceful result names the subscription it closes, and that name is checked:
-    a reply that closes a different one is reported as `Abrupt` rather than
-    handed to the caller.
-    Dropping the handle ends the subscription too, so one that falls out of
-    scope cannot leave the peer streaming into handlers nothing can stop;
-    either way its request slot is released, since a cancelled stream is never
-    answered and those slots carry no TTL. `Client::disconnect` ends every live
-    subscription: the listen `POST` closes, so the server drops its entry, and
-    `closed()` reports `Abrupt` rather than awaiting a result the transport can
-    no longer carry -- including when `cancel()` is what discovers the
-    connection is gone, since a cancel that never reached the wire ended
-    nothing.
-  * Tagged notifications are checked against the filter their subscription
-    acknowledged, and dropped if they fall outside it -- or if there is no
-    acknowledgment yet. The acknowledgment is a promise about the whole stream,
-    not just its first message, and it has to *be* first -- and be one this
-    client accepts: a subscription stays pending until then, since an
-    acknowledgment `listen` is about to refuse as overbroad would otherwise
-    deliver the requested categories in the meantime, from a subscription the
-    caller is then told never opened. Nothing
-    downstream could tell either way -- notifications reach the client's global
-    handlers, which know nothing about subscriptions. A subscribable type arriving
-    *without* a usable subscription id is dropped too: under MCP 2026-07-28
-    those travel on a subscription and nowhere else, so an untagged
-    `tools/list_changed` has nothing to be checked against. Untagged
-    request-scoped notifications (progress and log messages) pass through
-    untouched, as does everything from a peer the dual-mode fallback landed on,
-    which has no subscriptions to tag with. Batching changes none of this: an
-    acknowledgment or a tagged notification inside a JSON-RPC batch goes
-    through the same gate a standalone one does. The HTTP transport learned the
-    same distinction: a `POST` stream counts as answered only when a reply
-    resolves one of the requests *it* carried -- not on any batch, and not on a
-    response bearing some other id -- so a stream dying before the real answer
-    still fails its (untimed) listen slot instead of looking orderly.
-    Notifications keep flowing to the handlers registered with
+    `closed() -> SubscriptionEnd` (`Graceful` / `Cancelled` / `Abrupt`).
+    Dropping the handle ends the subscription too, and so does
+    `Client::disconnect`, so neither can leave the peer streaming into a client
+    with no way left to stop it.
+  * Notifications keep flowing to the handlers registered with
     `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, so
-    existing client code needs no change.
-  * Establishment races the acknowledgment against the request's own reply, so
-    a peer that rejects the subscription outright surfaces *its* error instead
-    of a timeout, and a transport that dies mid-establishment reports
-    `Connection closed` rather than a timeout it never waited out; an
-    acknowledgment broader than the filter that was requested is refused
-    outright. `cancel()` ends the stream on both transports --
-    over HTTP by closing the listen response body, which is what the server
-    acts on -- and so does giving up on an unacknowledged one, which would
-    otherwise leave the peer streaming into a subscription the caller was told
-    had failed. Giving up includes dropping the `listen` future itself (an
-    outer `tokio::time::timeout`, a lost `select!` branch): the establishment
-    is guarded from before the request is written -- the waiter, the untimed
-    request slot and the pending state all exist by then -- so a caller that
-    never sees a result still ends what it started. The transport registers a listen's abort handle in its connection
-    loop rather than in the task it spawns, so a cancel written right behind
-    its listen -- which is exactly what giving up writes -- is ordered by the
-    wire rather than by the scheduler.
+    existing client code needs no change. What reaches them is what the
+    subscription acknowledged: the acknowledgment is a promise about the whole
+    stream, and anything outside it -- or ahead of it -- is dropped rather than
+    dispatched to handlers that know nothing about subscriptions.
   * `Client::call_batch` rejects a batched `subscriptions/listen` with
     `InvalidRequest`. A batch slot is an ordinary request slot -- finite TTL, a
     plain `Response`, no handle -- so a subscription opened that way would have
     nothing to cancel it and would outlive the call that made it.
-  * A listen that arrives over HTTP without a response stream to write to --
-    an engine adapter that cannot stream (the JSON-only `handlers::handle_post`),
-    or a client that dropped the body first -- is answered with an error
-    instead of being served on a channel that goes nowhere.
   * Works on both transports: over HTTP the subscription rides the listen
     `POST`'s own `text/event-stream` body (a client disconnect ends it); over
     stdio it interleaves on stdout and ends on `notifications/cancelled`.
@@ -157,13 +87,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   fails every still-pending request on the way out. Over HTTP the receiver
   holds a sender clone of its own channel, so the loop never ended by itself
   and outlived the connection it served; a disconnect now ends both.
-* **A `subscriptions/listen` `POST` body no longer carries request-scoped log
-  messages.** A listen request stamped with `_meta.logLevel` (which neva's own
-  client does for every request when a level is configured) used to stream
-  `notifications/message` on the subscription's body. That body is the
-  subscription's stream, and anything emitted before the handler runs -- user
-  middleware logging ahead of `next(ctx)`, most directly -- arrived before the
-  acknowledgment. Logging on every other request is unchanged.
 * **The streaming `POST` reply no longer requires the `tracing` feature.**
   `dispatch_post` produces the `StreamResponse::Stream` arm in any default-build
   configuration -- a subscription stream is not a logging concern. Internally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     immediately after (a batched listen included). Held, not dropped: those
     request-scoped log messages were explicitly asked for via `_meta.logLevel`,
     and in a mixed batch they may belong to another request on the same body.
+    The hold buffer is bounded by the sink's own capacity, and overflow past it
+    is dropped rather than released early: the acknowledgment arriving first is
+    the requirement, the logs riding along are the accommodation.
     `Context::add_tool`,
     `remove_tool`, `add_prompt`, `remove_prompt`, `add_resource`,
     `remove_resource` and `resource_updated` fan out to the streams that asked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   * Works on both transports: over HTTP the subscription rides the listen
     `POST`'s own `text/event-stream` body (a client disconnect ends it); over
     stdio it interleaves on stdout and ends on `notifications/cancelled`.
+  * `Subscription` and `SubscriptionEnd` are re-exported from `neva::prelude`
+    alongside `Client`; the filter types arrive there with the rest of
+    `neva::types`.
   * New `examples/subscriptions/` (server + client over HTTP).
 
 ### Changed (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,13 +41,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     Dropping the handle ends the subscription too, so one that falls out of
     scope cannot leave the peer streaming into handlers nothing can stop;
     either way its request slot is released, since a cancelled stream is never
-    answered and those slots carry no TTL.
+    answered and those slots carry no TTL. `Client::disconnect` ends every live
+    subscription: the listen `POST` closes, so the server drops its entry, and
+    `closed()` reports `Abrupt` rather than awaiting a result the transport can
+    no longer carry.
   * Tagged notifications are checked against the filter their subscription
     acknowledged, and dropped if they fall outside it. The acknowledgment is a
     promise about the whole stream, not just its first message, and nothing
     downstream could tell -- notifications reach the client's global handlers,
     which know nothing about subscriptions. Untagged ones (request-scoped
-    progress and log messages) pass through untouched.
+    progress and log messages) pass through untouched. Batching changes none of
+    this: an acknowledgment or a tagged notification inside a JSON-RPC batch
+    goes through the same gate a standalone one does.
     Notifications keep flowing to the handlers registered with
     `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, so
     existing client code needs no change.
@@ -59,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     acts on -- and so does giving up on an unacknowledged one, which would
     otherwise leave the peer streaming into a subscription the caller was told
     had failed.
+  * `Client::call_batch` rejects a batched `subscriptions/listen` with
+    `InvalidRequest`. A batch slot is an ordinary request slot -- finite TTL, a
+    plain `Response`, no handle -- so a subscription opened that way would have
+    nothing to cancel it and would outlive the call that made it.
   * Works on both transports: over HTTP the subscription rides the listen
     `POST`'s own `text/event-stream` body (a client disconnect ends it); over
     stdio it interleaves on stdout and ends on `notifications/cancelled`.
@@ -94,6 +103,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 * `ServerCapabilities` now derives `Default`, so a filter can be narrowed
   against a partially-built capability set.
+* **The client's receive loop now stops when the transport is cancelled**, and
+  fails every still-pending request on the way out. Over HTTP the receiver
+  holds a sender clone of its own channel, so the loop never ended by itself
+  and outlived the connection it served; a disconnect now ends both.
 * **The streaming `POST` reply no longer requires the `tracing` feature.**
   `dispatch_post` produces the `StreamResponse::Stream` arm in any default-build
   configuration -- a subscription stream is not a logging concern. Internally

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "bytes",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "neva_macros"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,16 @@ exclude = [
     "examples/sampling", 
     "examples/elicitation",
     "examples/mrtr",
+    "examples/subscriptions",
     "examples/tasks"
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
-authors = ["Roman Emreis <roman.emreis@outlook.com>"]
+authors = ["Roman Emreis <me@romanemreis.com>"]
 repository = "https://github.com/RomanEmreis/neva"
 homepage = "https://romanemreis.github.io/neva-docs/"
 documentation = "https://docs.rs/neva"
@@ -29,7 +30,7 @@ categories = [
 ]
 
 [workspace.dependencies]
-neva_macros = { path = "neva_macros", version = "0.5.0" }
+neva_macros = { path = "neva_macros", version = "0.5.1" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blazingly fast and easily configurable [Model Context Protocol (MCP)](https://mo
 With simple configuration and ergonomic APIs, it provides everything you need to quickly build MCP clients and servers, 
 fully aligned with the latest MCP specification.
 
-[![latest](https://img.shields.io/badge/latest-0.5.0-d8eb34)](https://crates.io/crates/neva)
+[![latest](https://img.shields.io/badge/latest-0.5.1-d8eb34)](https://crates.io/crates/neva)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-624bd1.svg)](https://github.com/RomanEmreis/neva/blob/main/LICENSE)
 [![CI](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml)
@@ -30,7 +30,7 @@ fully aligned with the latest MCP specification.
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.5.0", features = ["client-full"] }
+neva = { version = "0.5.1", features = ["client-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Error> {
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.5.0", features = ["server-full"] }
+neva = { version = "0.5.1", features = ["server-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 #### Code

--- a/examples/subscriptions/Cargo.toml
+++ b/examples/subscriptions/Cargo.toml
@@ -1,0 +1,6 @@
+[workspace]
+members = ["client", "server"]
+resolver = "2"
+
+[workspace.package]
+rust-version = "1.90.0"

--- a/examples/subscriptions/README.md
+++ b/examples/subscriptions/README.md
@@ -32,10 +32,10 @@ subscription 1 established
 accepted filter: SubscriptionFilter { tools_list_changed: true, ... resource_subscriptions: [res://config] }
 the tool list changed -- time to re-list
 resource updated: {"_meta": {"io.modelcontextprotocol/subscriptionId": 1}, "uri": "res://config"}
-subscription ended: Graceful(...)
+subscription ended: Cancelled
 ```
 
-Three things this shows:
+Four things this shows:
 
 * **The server writes no subscription code.** `subscriptions/listen` is handled
   by neva; the server only calls `ctx.add_tool` and `ctx.resource_updated`, and
@@ -47,6 +47,11 @@ Three things this shows:
 * **Every message carries `io.modelcontextprotocol/subscriptionId`.** That is
   what lets a client demultiplex several subscriptions sharing one channel,
   which on stdio is always the case.
+* **Cancelling closes the stream.** That is the spec's mechanism over HTTP, and
+  the only sound one: a `notifications/cancelled` travels on its own POST and
+  proves nothing about who opened the subscription. So the end state is
+  `Cancelled` rather than `Graceful` -- there is no channel left for a final
+  result, and none is expected.
 
 Notifications are dispatched to the handlers registered *before* listening
 (`on_tools_changed`, `on_resource_changed`); the `Subscription` handle is about

--- a/examples/subscriptions/README.md
+++ b/examples/subscriptions/README.md
@@ -1,0 +1,53 @@
+# Subscriptions Example -- MCP 2026-07-28
+
+`subscriptions/listen` over **stateless HTTP**. One long-lived POST carries the
+notifications the client opted in to, and nothing else.
+
+The 2026-07-28 spec replaced the HTTP `GET` stream and the
+`resources/subscribe` / `resources/unsubscribe` RPC pair with this single
+request. A per-resource subscription did not disappear -- it became a URI in the
+listen filter, scoped to the stream that carries it.
+
+## Run
+
+Two terminals, from this directory (`examples/subscriptions/`):
+
+```bash
+# terminal 1 -- start the server (binds 127.0.0.1:3000/mcp)
+cargo run -p server
+```
+
+```bash
+# terminal 2 -- run the client
+cargo run -p client
+```
+
+## What to watch
+
+The client opens one subscription for two categories -- tool-list changes and
+updates to `res://config` -- then triggers both:
+
+```
+subscription 1 established
+accepted filter: SubscriptionFilter { tools_list_changed: true, ... resource_subscriptions: [res://config] }
+the tool list changed -- time to re-list
+resource updated: {"_meta": {"io.modelcontextprotocol/subscriptionId": 1}, "uri": "res://config"}
+subscription ended: Graceful(...)
+```
+
+Three things this shows:
+
+* **The server writes no subscription code.** `subscriptions/listen` is handled
+  by neva; the server only calls `ctx.add_tool` and `ctx.resource_updated`, and
+  the notification reaches every stream whose filter admits it.
+* **The accepted filter is narrowed to advertised capabilities.** Drop
+  `with_list_changed()` from the server's options and the acknowledgment comes
+  back without `toolsListChanged` -- the client learns immediately instead of
+  waiting forever for a push that was never going to arrive.
+* **Every message carries `io.modelcontextprotocol/subscriptionId`.** That is
+  what lets a client demultiplex several subscriptions sharing one channel,
+  which on stdio is always the case.
+
+Notifications are dispatched to the handlers registered *before* listening
+(`on_tools_changed`, `on_resource_changed`); the `Subscription` handle is about
+the stream's lifecycle -- what was accepted, cancelling it, and how it ended.

--- a/examples/subscriptions/client/Cargo.toml
+++ b/examples/subscriptions/client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "client"
+version = "0.1.0"
+edition = "2024"
+publish = false
+rust-version.workspace = true
+
+[dependencies]
+neva = { path = "../../../neva", features = ["client-macros", "http-client", "tracing"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/examples/subscriptions/client/src/main.rs
+++ b/examples/subscriptions/client/src/main.rs
@@ -6,7 +6,6 @@
 //! about the stream's lifecycle, not its contents.
 
 use neva::prelude::*;
-use neva::types::SubscriptionFilter;
 use std::time::Duration;
 use tracing_subscriber::prelude::*;
 

--- a/examples/subscriptions/client/src/main.rs
+++ b/examples/subscriptions/client/src/main.rs
@@ -1,0 +1,69 @@
+//! MCP 2026-07-28 example client for `subscriptions/listen`.
+//!
+//! Opens one long-lived subscription, triggers the mutations that produce the
+//! notifications it asked for, and closes it. Notifications are dispatched to
+//! the handlers registered before listening -- the [`Subscription`] handle is
+//! about the stream's lifecycle, not its contents.
+
+use neva::prelude::*;
+use neva::types::SubscriptionFilter;
+use std::time::Duration;
+use tracing_subscriber::prelude::*;
+
+const WATCHED: &str = "res://config";
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| http.bind("127.0.0.1:3000").with_endpoint("/mcp"))
+            .with_timeout(Duration::from_secs(5))
+    });
+
+    client.connect().await?;
+
+    // After `connect`: these helpers assert the server advertises the matching
+    // capability, which is only known once it has been discovered.
+    client.on_tools_changed(|_| async {
+        tracing::info!("the tool list changed -- time to re-list");
+    });
+    client.on_resource_changed(|n| async move {
+        tracing::info!("resource updated: {:?}", n.params);
+    });
+
+    // One stream, two notification types. `resourceSubscriptions` is where the
+    // removed `resources/subscribe` RPC went.
+    let mut subscription = client
+        .listen(
+            SubscriptionFilter::new()
+                .with_tools_changed()
+                .with_resource(WATCHED),
+        )
+        .await?;
+
+    tracing::info!("subscription {} established", subscription.id());
+    tracing::info!("accepted filter: {:?}", subscription.acknowledged());
+    if !subscription.is_fully_honored() {
+        tracing::warn!("the server narrowed the filter; some types will never arrive");
+    }
+
+    // Both calls mutate server state, and both notifications come back on the
+    // subscription rather than on the call's own reply.
+    client.call_tool("publish", ("name", "greet")).await?;
+    client.call_tool("touch", ()).await?;
+
+    // The stream is live and independent of these calls, so give the
+    // notifications a moment to land before tearing it down.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    subscription.cancel().await?;
+    tracing::info!("subscription ended: {:?}", subscription.closed().await);
+
+    client.disconnect().await
+}

--- a/examples/subscriptions/server/Cargo.toml
+++ b/examples/subscriptions/server/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "server"
+version = "0.1.0"
+edition = "2024"
+publish = false
+rust-version.workspace = true
+
+[dependencies]
+neva = { path = "../../../neva", features = ["server-macros", "http-server-volga", "tracing"] }
+tokio = { version = "1.47.1", features = ["full"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/examples/subscriptions/server/src/main.rs
+++ b/examples/subscriptions/server/src/main.rs
@@ -1,0 +1,59 @@
+//! MCP 2026-07-28 example server for `subscriptions/listen`.
+//!
+//! Nothing here handles the subscription: neva answers `subscriptions/listen`
+//! itself, narrowing the client's filter to the capabilities configured below.
+//! A server just mutates its own state -- `ctx.add_tool`, `ctx.resource_updated`
+//! -- and the notification reaches every stream that asked for it.
+
+use neva::prelude::*;
+use tracing_subscriber::prelude::*;
+
+const WATCHED: &str = "res://config";
+
+/// Adds a tool, which emits `notifications/tools/list_changed`.
+#[tool]
+async fn publish(mut ctx: Context, name: String) -> Result<String, Error> {
+    ctx.add_tool(Tool::new(name.clone(), || async { "hello" }))
+        .await?;
+    tracing::info!("published tool `{name}`");
+    Ok(format!("published `{name}`"))
+}
+
+/// Marks the watched resource dirty, which emits
+/// `notifications/resources/updated` -- but only to the streams whose filter
+/// lists this URI.
+#[tool]
+async fn touch(mut ctx: Context) -> Result<String, Error> {
+    ctx.resource_updated(WATCHED).await?;
+    tracing::info!("touched {WATCHED}");
+    Ok(format!("touched {WATCHED}"))
+}
+
+#[resource(uri = "res://config")]
+async fn config() -> TextResourceContents {
+    TextResourceContents::new(WATCHED, "{ \"answer\": 42 }")
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    // The advertised capabilities are exactly what a listen filter can ask for:
+    // a category the server does not announce is dropped from the accepted
+    // filter rather than refused.
+    App::new()
+        .with_options(|opt| {
+            opt.with_http(|http| http.bind("127.0.0.1:3000").with_endpoint("/mcp"))
+                .with_tools(|tools| tools.with_list_changed())
+                .with_resources(|res| res.with_list_changed().with_subscribe())
+        })
+        .run()
+        .await;
+
+    Ok(())
+}

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -22,11 +22,13 @@ use crate::types::{
     notification::{CancelledNotificationParams, Notification},
     resource::template::ResourceFunc,
 };
-// Subscribe/unsubscribe handlers exist only under the legacy transport, which
-// can push `notifications/resources/updated`; the 2026-07-28 stateless build masks the
-// capability and skips the handlers, so these params are unused there.
 #[cfg(feature = "legacy-spec")]
 use crate::types::{InitializeRequestParams, InitializeResult};
+// The subscribe/unsubscribe RPCs exist only under the legacy transport; MCP
+// 2026-07-28 folds them into the `subscriptions/listen` filter, so these params
+// are unused there.
+#[cfg(not(feature = "legacy-spec"))]
+use crate::types::{RequestId, SubscriptionsListenRequestParams, SubscriptionsListenResult};
 #[cfg(feature = "legacy-spec")]
 use crate::types::{SubscribeRequestParams, UnsubscribeRequestParams};
 use tokio_util::sync::CancellationToken;
@@ -67,6 +69,8 @@ pub(crate) mod handler;
 #[cfg(not(feature = "legacy-spec"))]
 pub mod mrtr_store;
 pub mod options;
+#[cfg(not(feature = "legacy-spec"))]
+pub(crate) mod subscriptions;
 
 const DEFAULT_PAGE_SIZE: usize = 10;
 
@@ -131,12 +135,10 @@ impl App {
             Self::resource_templates,
         );
         app.map_handler(crate::types::resource::commands::READ, Self::resource);
-        // The stateless MCP 2026-07-28 transport cannot push
-        // `notifications/resources/updated`, so the `resources.subscribe`
-        // capability is masked off (see `McpOptions::resources_capability`).
-        // Don't register subscribe/unsubscribe handlers under MCP 2026-07-28 either, so the
-        // advertised surface and the accepted methods stay in sync -- the server
-        // won't accept a subscription it never announces.
+        // MCP 2026-07-28 folds `resources/subscribe` into the
+        // `subscriptions/listen` filter: a per-resource subscription is a URI
+        // in `notifications.resourceSubscriptions`, scoped to that stream. The
+        // two RPCs stay legacy-only.
         #[cfg(feature = "legacy-spec")]
         {
             app.map_handler(
@@ -148,6 +150,11 @@ impl App {
                 Self::resource_unsubscribe,
             );
         }
+        #[cfg(not(feature = "legacy-spec"))]
+        app.map_handler(
+            crate::types::subscription::commands::LISTEN,
+            Self::subscriptions_listen,
+        );
 
         app.map_handler(crate::types::prompt::commands::LIST, Self::prompts);
         app.map_handler(crate::types::prompt::commands::GET, Self::prompt);
@@ -305,6 +312,11 @@ impl App {
         let mut transport = self.options.transport();
         let cancellation_token = transport.start();
         self.wait_for_shutdown_signal(cancellation_token.clone());
+        // Long-lived requests (`subscriptions/listen`) watch the same signal
+        // the dispatch loop breaks on, so they can close gracefully instead of
+        // being dropped mid-stream.
+        #[cfg(not(feature = "legacy-spec"))]
+        self.options.set_shutdown_token(cancellation_token.clone());
 
         let (sender, mut receiver) = transport.split();
         let runtime = ServerRuntime::new(
@@ -854,9 +866,8 @@ impl App {
 
     /// A subscription to a resource change request handler
     ///
-    /// Not registered under MCP 2026-07-28: the stateless transport
-    /// cannot push `notifications/resources/updated`, so subscriptions are not
-    /// advertised and the method is not accepted.
+    /// Not registered under MCP 2026-07-28, where the method is folded into the
+    /// `subscriptions/listen` filter; see [`Self::subscriptions_listen`].
     #[cfg(feature = "legacy-spec")]
     async fn resource_subscribe(mut ctx: Context, params: SubscribeRequestParams) {
         ctx.subscribe_to_resource(params.uri);
@@ -868,6 +879,21 @@ impl App {
     #[cfg(feature = "legacy-spec")]
     async fn resource_unsubscribe(mut ctx: Context, params: UnsubscribeRequestParams) {
         ctx.unsubscribe_from_resource(&params.uri);
+    }
+
+    /// A `subscriptions/listen` request handler (MCP 2026-07-28).
+    ///
+    /// The request stays open for the life of the subscription: the accepted
+    /// filter is acknowledged first, notifications matching it flow on the same
+    /// stream, and the reply -- an empty result carrying the subscription id --
+    /// is what marks a graceful close.
+    #[cfg(not(feature = "legacy-spec"))]
+    async fn subscriptions_listen(
+        ctx: Context,
+        id: RequestId,
+        params: SubscriptionsListenRequestParams,
+    ) -> Result<SubscriptionsListenResult, Error> {
+        ctx.listen(id, params.notifications).await
     }
 
     /// Tasks request handler
@@ -1007,11 +1033,7 @@ impl App {
         // middleware pipeline has run -- is what lets a request-scoped SSE POST
         // response know no more notifications are coming, so logs emitted by
         // user middleware after `next(ctx)` still make it onto the stream.
-        #[cfg(all(
-            not(feature = "legacy-spec"),
-            feature = "tracing",
-            feature = "http-server"
-        ))]
+        #[cfg(all(not(feature = "legacy-spec"), feature = "http-server"))]
         let _sink_guard = RequestSinkGuard(msg.session_id().copied());
         runtime.execute(msg).await;
     }
@@ -1031,11 +1053,7 @@ impl App {
         // `ServerRuntime::execute`, so they never close the shared sink early):
         // the request-scoped SSE response stays open until every inner request
         // and its middleware have finished. See `App::execute`.
-        #[cfg(all(
-            not(feature = "legacy-spec"),
-            feature = "tracing",
-            feature = "http-server"
-        ))]
+        #[cfg(all(not(feature = "legacy-spec"), feature = "http-server"))]
         let _sink_guard = RequestSinkGuard(batch_session_id);
         #[cfg(feature = "http-server")]
         let batch_headers = batch.headers.clone();
@@ -1544,6 +1562,14 @@ impl App {
                     && let Ok(params) =
                         serde_json::from_value::<CancelledNotificationParams>(params)
                 {
+                    // A cancel aimed at a `subscriptions/listen` ends that
+                    // subscription only. Cancelling the request itself would
+                    // race the handler for its own response and rob the client
+                    // of the graceful-close result.
+                    #[cfg(not(feature = "legacy-spec"))]
+                    if runtime.options().subscriptions().cancel(&params.request_id) {
+                        return;
+                    }
                     runtime.options().cancel_request(&params.request_id);
                 }
             }
@@ -1569,22 +1595,14 @@ impl App {
 /// response waits for: only then does it know every notification -- including
 /// ones user middleware emitted after `next(ctx)` -- has been queued, so it can
 /// drain them and close with the final response.
-#[cfg(all(
-    not(feature = "legacy-spec"),
-    feature = "tracing",
-    feature = "http-server"
-))]
+#[cfg(all(not(feature = "legacy-spec"), feature = "http-server"))]
 struct RequestSinkGuard(Option<uuid::Uuid>);
 
-#[cfg(all(
-    not(feature = "legacy-spec"),
-    feature = "tracing",
-    feature = "http-server"
-))]
+#[cfg(all(not(feature = "legacy-spec"), feature = "http-server"))]
 impl Drop for RequestSinkGuard {
     fn drop(&mut self) {
         if let Some(id) = self.0 {
-            crate::types::notification::fmt::unregister_request_sink(&id);
+            crate::types::notification::sink::unregister(&id);
         }
     }
 }

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -1820,7 +1820,7 @@ impl Context {
             ))
             .ok(),
         );
-        
+
         sink.send(Message::Notification(ack))
             .await
             .map_err(|_| Error::new(ErrorCode::InternalError, "Subscription stream is closed"))?;

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -2196,7 +2196,7 @@ mod subscription_sink_tests {
     #[tokio::test]
     async fn it_uses_the_registered_response_sink() {
         let session_id = uuid::Uuid::new_v4();
-        let _rx = crate::types::notification::sink::register(session_id, 4, true);
+        let _rx = crate::types::notification::sink::register(session_id, 4);
 
         let (_sink, pump) = ctx(Some(session_id))
             .subscription_sink()

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -1807,7 +1807,7 @@ impl Context {
         requested: SubscriptionFilter,
     ) -> Result<SubscriptionsListenResult, Error> {
         let accepted = requested.supported_by(&self.options.advertised_capabilities());
-        let (sink, pump) = self.subscription_sink();
+        let (sink, pump) = self.subscription_sink()?;
 
         // The acknowledgment MUST be the first message on the subscription.
         // `register` is what queues it, together with publishing the entry:
@@ -1881,18 +1881,37 @@ impl Context {
     /// long-lived response body, and its closure is how the handler learns the
     /// client disconnected. Every other transport (stdio) gets a channel of its
     /// own, pumped into the transport sender by the returned task.
+    ///
+    /// # Errors
+    /// Returns [`Error`] for a request that came in over HTTP without a
+    /// response stream to write to. A transport session id and no registered
+    /// sink means either an engine adapter that cannot stream (the JSON-only
+    /// `handlers::handle_post`) or a client that dropped the body before the
+    /// runtime got here -- and neither can carry a subscription. Falling back
+    /// to a channel of our own would be worse than failing: the acknowledgment
+    /// would go to the generic transport sender instead of this request's body,
+    /// and since we would then hold the only receiver, the handler would never
+    /// see the disconnect that ends it -- the entry would sit in the registry
+    /// until the server shut down.
     fn subscription_sink(
         &self,
-    ) -> (
-        tokio::sync::mpsc::Sender<Message>,
-        Option<tokio::task::JoinHandle<()>>,
-    ) {
+    ) -> Result<
+        (
+            tokio::sync::mpsc::Sender<Message>,
+            Option<tokio::task::JoinHandle<()>>,
+        ),
+        Error,
+    > {
         #[cfg(feature = "http-server")]
-        if let Some(sink) = self
-            .session_id
-            .and_then(|id| crate::types::notification::sink::get(&id))
-        {
-            return (sink, None);
+        if let Some(session_id) = self.session_id {
+            return crate::types::notification::sink::get(&session_id)
+                .map(|sink| (sink, None))
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorCode::InternalError,
+                        "Subscriptions need a streaming response; this request has none",
+                    )
+                });
         }
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Message>(
@@ -1906,7 +1925,7 @@ impl Context {
                 }
             }
         });
-        (tx, Some(pump))
+        Ok((tx, Some(pump)))
     }
 }
 
@@ -2135,5 +2154,67 @@ mod mrtr_tests {
         m.push_commit(Box::pin(async { Ok(()) }));
         m.push_commit(Box::pin(async { Ok(()) }));
         assert_eq!(m.commits.lock().unwrap().len(), 2);
+    }
+}
+
+#[cfg(all(test, not(feature = "legacy-spec"), feature = "http-server"))]
+mod subscription_sink_tests {
+    use super::*;
+
+    fn ctx(session_id: Option<uuid::Uuid>) -> Context {
+        Context {
+            session_id,
+            headers: HeaderMap::new(),
+            claims: None,
+            pending: RequestQueue::new(Duration::from_secs(5)),
+            sender: TransportProtoSender::None,
+            options: Arc::new(McpOptions::default()),
+            timeout: Duration::from_secs(5),
+            exec: ExecMode::None,
+            #[cfg(feature = "di")]
+            scope: None,
+        }
+    }
+
+    /// A transport session id and no registered sink means the request came in
+    /// over HTTP without a response stream -- a JSON-only engine adapter, or a
+    /// client that dropped the body first. Falling back to a channel of our own
+    /// would send the acknowledgment to the generic transport sender instead of
+    /// this request's body, and leave the handler holding the only receiver, so
+    /// the disconnect that ends the subscription would never arrive.
+    #[tokio::test]
+    async fn it_refuses_an_http_request_with_no_response_stream() {
+        let err = ctx(Some(uuid::Uuid::new_v4()))
+            .subscription_sink()
+            .expect_err("a subscription needs a stream to write to");
+
+        assert_eq!(err.code, ErrorCode::InternalError);
+    }
+
+    /// The registered sink is used as is: it *is* the response body, so there
+    /// is nothing to pump.
+    #[tokio::test]
+    async fn it_uses_the_registered_response_sink() {
+        let session_id = uuid::Uuid::new_v4();
+        let _rx = crate::types::notification::sink::register(session_id, 4, true);
+
+        let (_sink, pump) = ctx(Some(session_id))
+            .subscription_sink()
+            .expect("the registered sink must be used");
+
+        assert!(pump.is_none(), "the response body needs no pump task");
+        crate::types::notification::sink::unregister(&session_id);
+    }
+
+    /// Without a transport session there is no per-request body to write to --
+    /// that is stdio, where the subscription interleaves on the shared output
+    /// through a pump of its own.
+    #[tokio::test]
+    async fn it_pumps_into_the_transport_without_a_session() {
+        let (_sink, pump) = ctx(None)
+            .subscription_sink()
+            .expect("stdio always has somewhere to write");
+
+        assert!(pump.is_some(), "stdio needs a pump task");
     }
 }

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -1825,10 +1825,12 @@ impl Context {
             .await
             .map_err(|_| Error::new(ErrorCode::InternalError, "Subscription stream is closed"))?;
 
-        let (token, guard) =
-            self.options
-                .subscriptions()
-                .register(id.clone(), accepted, sink.clone());
+        let (token, guard) = self.options.subscriptions().register(
+            id.clone(),
+            self.session_id,
+            accepted,
+            sink.clone(),
+        );
 
         // Whichever comes first: the client cancelled this subscription, the
         // stream went away under us (an HTTP client that closed the response

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -6,12 +6,16 @@ use super::{
 };
 use crate::error::{Error, ErrorCode};
 use crate::transport::Sender;
-#[cfg(feature = "legacy-spec")]
 use crate::types::notification::Notification;
 #[cfg(feature = "legacy-spec")]
 use crate::types::root::{ListRootsRequestParams, ListRootsResult};
 #[cfg(feature = "legacy-spec")]
 use crate::types::sampling::{CreateMessageRequestParams, CreateMessageResult};
+#[cfg(not(feature = "legacy-spec"))]
+use crate::types::{
+    RequestId, SubscriptionFilter, SubscriptionsAcknowledgedNotificationParams,
+    SubscriptionsListenResult,
+};
 use crate::{
     middleware::{MwContext, Next},
     shared::{IntoArgs, RequestQueue},
@@ -24,6 +28,7 @@ use crate::{
         resource::SubscribeRequestParams,
     },
 };
+
 // `RequestId` is only referenced by the server->client request paths (legacy
 // elicitation/sampling) and the task API; under the stateless 2026-07-28 build without
 // tasks it is unused -- including in tests, whose `RequestId` uses live in
@@ -654,18 +659,49 @@ impl Context {
     }
 
     /// Adds a subscription to the resource with the [`Uri`]
+    ///
+    /// Legacy only: under MCP 2026-07-28 a per-resource subscription is a URI
+    /// in the `subscriptions/listen` filter, established by the client and
+    /// scoped to that stream, so there is nothing for the server to add.
+    #[cfg(feature = "legacy-spec")]
     pub fn subscribe_to_resource(&mut self, uri: impl Into<Uri>) {
         self.options.resource_subscriptions.insert(uri.into());
     }
 
     /// Removes a subscription to the resource with the [`Uri`]
+    ///
+    /// Legacy only; see [`Self::subscribe_to_resource`].
+    #[cfg(feature = "legacy-spec")]
     pub fn unsubscribe_from_resource(&mut self, uri: &Uri) {
         self.options.resource_subscriptions.remove(uri);
     }
 
     /// Returns `true` if there is a subscription to changes of the resource with the [`Uri`]
+    #[cfg(feature = "legacy-spec")]
     pub fn is_subscribed(&self, uri: &Uri) -> bool {
         self.options.resource_subscriptions.contains(uri)
+    }
+
+    /// Returns `true` if any live `subscriptions/listen` stream watches the
+    /// resource with the [`Uri`].
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # #[cfg(all(feature = "server-macros", not(feature = "legacy-spec")))] {
+    /// use neva::prelude::*;
+    ///
+    /// #[tool]
+    /// async fn touch(ctx: Context) -> Result<(), Error> {
+    ///     if ctx.is_subscribed(&"res://config".into()) {
+    ///         // somebody is listening for this resource
+    ///     }
+    /// # Ok(())
+    /// }
+    /// # }
+    /// ```
+    #[cfg(not(feature = "legacy-spec"))]
+    pub fn is_subscribed(&self, uri: &Uri) -> bool {
+        self.options.subscriptions().is_resource_subscribed(uri)
     }
 
     /// Adds a new prompt and notifies clients
@@ -1706,29 +1742,33 @@ impl Context {
 
     /// Sends a notification to a client.
     ///
-    /// Under the stateless MCP 2026-07-28 transport there is no
-    /// out-of-band server->client channel, so this is a no-op: progress,
-    /// list-changed, resource-updated, task-status and elicitation
-    /// notifications are inert and clients poll instead.
+    /// Under MCP 2026-07-28 the only server->client channel is a
+    /// `subscriptions/listen` stream, so a subscribable notification
+    /// (`tools`/`prompts`/`resources` list-changed and `resources/updated`) is
+    /// fanned out to every stream whose filter admits it. The rest -- progress,
+    /// task status, elicitation -- are request-scoped and have no subscription
+    /// to travel on.
     #[inline]
     async fn send_notification(
         &mut self,
-        #[cfg_attr(not(feature = "legacy-spec"), allow(unused_variables))] method: &str,
-        #[cfg_attr(not(feature = "legacy-spec"), allow(unused_variables))] params: Option<
-            serde_json::Value,
-        >,
+        method: &str,
+        params: Option<serde_json::Value>,
     ) -> Result<(), Error> {
         #[cfg(not(feature = "legacy-spec"))]
         {
-            // No out-of-band server->client channel on the stateless transport,
-            // so this is an intentional no-op. Surface it once at debug so a
-            // server author who calls e.g. `resource_updated`/`add_tool` and
-            // expects a push isn't silently misled -- the masked capabilities
-            // already tell clients to poll instead.
+            if self
+                .options
+                .subscriptions()
+                .broadcast(method, params.as_ref())
+            {
+                return Ok(());
+            }
+            // Not a type a client can subscribe to. Surface it once at debug so
+            // a server author who expects a push isn't silently misled.
             #[cfg(feature = "tracing")]
             tracing::debug!(
                 method,
-                "notifications are not delivered on the stateless 2026-07-28 transport; clients poll instead"
+                "notification is not deliverable under MCP 2026-07-28: no subscription carries this type"
             );
             Ok(())
         }
@@ -1740,6 +1780,102 @@ impl Context {
             }
             self.sender.send(notification.into()).await
         }
+    }
+}
+
+/// The `subscriptions/listen` implementation (MCP 2026-07-28).
+#[cfg(not(feature = "legacy-spec"))]
+impl Context {
+    /// Opens a subscription and holds it until it ends.
+    ///
+    /// The returned future resolves when the client cancels the subscription,
+    /// the transport drops it, or the server shuts down; resolving is what
+    /// answers the long-lived `subscriptions/listen` request with its
+    /// graceful-close result.
+    pub(crate) async fn listen(
+        &self,
+        id: RequestId,
+        requested: SubscriptionFilter,
+    ) -> Result<SubscriptionsListenResult, Error> {
+        let accepted = requested.supported_by(&self.options.advertised_capabilities());
+        let (sink, pump) = self.subscription_sink();
+
+        // The acknowledgment MUST be the first message on the subscription, so
+        // it is queued before the entry goes live and any broadcast can reach
+        // it.
+        let ack = Notification::new(
+            crate::types::subscription::commands::ACKNOWLEDGED,
+            serde_json::to_value(SubscriptionsAcknowledgedNotificationParams::new(
+                id.clone(),
+                accepted.clone(),
+            ))
+            .ok(),
+        );
+        sink.send(Message::Notification(ack))
+            .await
+            .map_err(|_| Error::new(ErrorCode::InternalError, "Subscription stream is closed"))?;
+
+        let (token, guard) =
+            self.options
+                .subscriptions()
+                .register(id.clone(), accepted, sink.clone());
+
+        // Whichever comes first: the client cancelled this subscription, the
+        // stream went away under us (an HTTP client that closed the response
+        // body), or the server is shutting down.
+        let shutdown = self.options.shutdown_token();
+        tokio::select! {
+            _ = token.cancelled() => {},
+            _ = sink.closed() => {},
+            _ = shutdown.cancelled() => {},
+        }
+
+        // Deregistering and dropping this end closes the subscription's own
+        // channel, which is what lets the pump drain whatever is still queued
+        // and exit -- aborting it instead would drop those notifications on the
+        // floor a moment before the request answers.
+        drop(guard);
+        drop(sink);
+        if let Some(pump) = pump {
+            let _ = pump.await;
+        }
+
+        Ok(SubscriptionsListenResult::new(id))
+    }
+
+    /// Picks where this subscription's notifications go.
+    ///
+    /// Over HTTP that is the `POST` response sink the transport registered for
+    /// this request -- writing into it puts notifications straight onto the
+    /// long-lived response body, and its closure is how the handler learns the
+    /// client disconnected. Every other transport (stdio) gets a channel of its
+    /// own, pumped into the transport sender by the returned task.
+    fn subscription_sink(
+        &self,
+    ) -> (
+        tokio::sync::mpsc::Sender<Message>,
+        Option<tokio::task::JoinHandle<()>>,
+    ) {
+        #[cfg(feature = "http-server")]
+        if let Some(sink) = self
+            .session_id
+            .and_then(|id| crate::types::notification::sink::get(&id))
+        {
+            return (sink, None);
+        }
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<Message>(
+            crate::app::subscriptions::DEFAULT_SUBSCRIPTION_CAPACITY,
+        );
+        let mut sender = self.sender.clone();
+        let pump = tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                if sender.send(msg).await.is_err() {
+                    break;
+                }
+            }
+        });
+        (tx, Some(pump))
     }
 }
 

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -1792,6 +1792,15 @@ impl Context {
     /// the transport drops it, or the server shuts down; resolving is what
     /// answers the long-lived `subscriptions/listen` request with its
     /// graceful-close result.
+    ///
+    /// On the shutdown path that answer is **best-effort**: both transports
+    /// break out of their writer loops on the same token (`biased` selects in
+    /// `http::core::dispatch` and `stdio`), so the result races a channel that
+    /// may already have stopped being read. The branch is still what stops the
+    /// handler from outliving the runtime, and a client that sees the stream
+    /// close without a result treats it as an abrupt end -- which is what the
+    /// spec prescribes, and subscriptions are not resumable anyway. Delivering
+    /// it reliably needs a drain phase ahead of the transport teardown.
     pub(crate) async fn listen(
         &self,
         id: RequestId,
@@ -1811,6 +1820,7 @@ impl Context {
             ))
             .ok(),
         );
+        
         sink.send(Message::Notification(ack))
             .await
             .map_err(|_| Error::new(ErrorCode::InternalError, "Subscription stream is closed"))?;
@@ -1822,7 +1832,8 @@ impl Context {
 
         // Whichever comes first: the client cancelled this subscription, the
         // stream went away under us (an HTTP client that closed the response
-        // body), or the server is shutting down.
+        // body), or the server is shutting down (see the best-effort caveat
+        // above).
         let shutdown = self.options.shutdown_token();
         tokio::select! {
             _ = token.cancelled() => {},

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -1807,7 +1807,7 @@ impl Context {
         requested: SubscriptionFilter,
     ) -> Result<SubscriptionsListenResult, Error> {
         let accepted = requested.supported_by(&self.options.advertised_capabilities());
-        let (sink, pump) = self.subscription_sink()?;
+        let (sink, ack_slot, pump) = self.subscription_sink().await?;
 
         // The acknowledgment MUST be the first message on the subscription.
         // `register` is what queues it, together with publishing the entry:
@@ -1828,27 +1828,14 @@ impl Context {
             .ok(),
         );
 
-        let (token, guard) = self
-            .options
-            .subscriptions()
-            .register(
-                id.clone(),
-                self.session_id,
-                accepted,
-                sink.clone(),
-                Message::Notification(ack),
-            )
-            .map_err(|err| {
-                use crate::app::subscriptions::RegisterError;
-                match err {
-                    RegisterError::Closed => {
-                        Error::new(ErrorCode::InternalError, "Subscription stream is closed")
-                    }
-                    RegisterError::Full => {
-                        Error::new(ErrorCode::InternalError, "Subscription stream is full")
-                    }
-                }
-            })?;
+        let (token, guard) = self.options.subscriptions().register(
+            id.clone(),
+            self.session_id,
+            accepted,
+            sink.clone(),
+            Message::Notification(ack),
+            ack_slot,
+        );
 
         // Whichever comes first: the client cancelled this subscription, the
         // stream went away under us (an HTTP client that closed the response
@@ -1882,6 +1869,11 @@ impl Context {
     /// client disconnected. Every other transport (stdio) gets a channel of its
     /// own, pumped into the transport sender by the returned task.
     ///
+    /// Comes with the capacity slot reserved for the acknowledgment: over HTTP
+    /// the transport took it when it registered the sink, before any middleware
+    /// could log into the body, so a noisy request cannot leave the handshake
+    /// without room.
+    ///
     /// # Errors
     /// Returns [`Error`] for a request that came in over HTTP without a
     /// response stream to write to. A transport session id and no registered
@@ -1892,31 +1884,42 @@ impl Context {
     /// would go to the generic transport sender instead of this request's body,
     /// and since we would then hold the only receiver, the handler would never
     /// see the disconnect that ends it -- the entry would sit in the registry
-    /// until the server shut down.
-    fn subscription_sink(
+    /// until the server shut down. A registered sink whose reserved slot is
+    /// already gone fails the same way: two listens sharing one body cannot
+    /// both open it.
+    async fn subscription_sink(
         &self,
     ) -> Result<
         (
             tokio::sync::mpsc::Sender<Message>,
+            tokio::sync::mpsc::OwnedPermit<Message>,
             Option<tokio::task::JoinHandle<()>>,
         ),
         Error,
     > {
         #[cfg(feature = "http-server")]
         if let Some(session_id) = self.session_id {
-            return crate::types::notification::sink::get(&session_id)
-                .map(|sink| (sink, None))
-                .ok_or_else(|| {
-                    Error::new(
-                        ErrorCode::InternalError,
-                        "Subscriptions need a streaming response; this request has none",
-                    )
-                });
+            let stream = crate::types::notification::sink::get(&session_id).zip(
+                crate::types::notification::sink::take_ack_permit(&session_id),
+            );
+
+            return stream.map(|(sink, ack)| (sink, ack, None)).ok_or_else(|| {
+                Error::new(
+                    ErrorCode::InternalError,
+                    "Subscriptions need a streaming response; this request has none",
+                )
+            });
         }
 
         let (tx, mut rx) = tokio::sync::mpsc::channel::<Message>(
             crate::app::subscriptions::DEFAULT_SUBSCRIPTION_CAPACITY,
         );
+        // Immediate: nothing has written to this channel yet.
+        let ack =
+            tx.clone().reserve_owned().await.map_err(|_| {
+                Error::new(ErrorCode::InternalError, "Subscription stream is closed")
+            })?;
+
         let mut sender = self.sender.clone();
         let pump = tokio::spawn(async move {
             while let Some(msg) = rx.recv().await {
@@ -1925,7 +1928,7 @@ impl Context {
                 }
             }
         });
-        Ok((tx, Some(pump)))
+        Ok((tx, ack, Some(pump)))
     }
 }
 
@@ -2186,6 +2189,7 @@ mod subscription_sink_tests {
     async fn it_refuses_an_http_request_with_no_response_stream() {
         let err = ctx(Some(uuid::Uuid::new_v4()))
             .subscription_sink()
+            .await
             .expect_err("a subscription needs a stream to write to");
 
         assert_eq!(err.code, ErrorCode::InternalError);
@@ -2196,10 +2200,11 @@ mod subscription_sink_tests {
     #[tokio::test]
     async fn it_uses_the_registered_response_sink() {
         let session_id = uuid::Uuid::new_v4();
-        let _rx = crate::types::notification::sink::register(session_id, 4);
+        let _rx = crate::types::notification::sink::register(session_id, 4, true).await;
 
-        let (_sink, pump) = ctx(Some(session_id))
+        let (_sink, _ack, pump) = ctx(Some(session_id))
             .subscription_sink()
+            .await
             .expect("the registered sink must be used");
 
         assert!(pump.is_none(), "the response body needs no pump task");
@@ -2211,8 +2216,9 @@ mod subscription_sink_tests {
     /// through a pump of its own.
     #[tokio::test]
     async fn it_pumps_into_the_transport_without_a_session() {
-        let (_sink, pump) = ctx(None)
+        let (_sink, _ack, pump) = ctx(None)
             .subscription_sink()
+            .await
             .expect("stdio always has somewhere to write");
 
         assert!(pump.is_some(), "stdio needs a pump task");

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -1821,9 +1821,30 @@ impl Context {
             .ok(),
         );
 
-        sink.send(Message::Notification(ack))
-            .await
-            .map_err(|_| Error::new(ErrorCode::InternalError, "Subscription stream is closed"))?;
+        // `try_send`, deliberately, not `send().await`: an await between
+        // queueing the acknowledgment and registering the entry is a window in
+        // which the client has been told the subscription is established while
+        // nothing can reach it, so a concurrent mutation broadcasting in that
+        // window would be dropped for good. Nothing else can write to this sink
+        // until `register` publishes the entry, so queueing first and
+        // registering second -- with no await in between -- is what makes
+        // "acknowledgment first" and "no lost events" hold at the same time.
+        //
+        // The sink is empty at this point -- a listen `POST` body carries no
+        // request-scoped logging (see `notification::sink::RequestSink`) and a
+        // subscription reports no progress -- so `Full` here means a sink far
+        // too small to carry a subscription at all, and says so.
+        sink.try_send(Message::Notification(ack)).map_err(|err| {
+            use tokio::sync::mpsc::error::TrySendError;
+            match err {
+                TrySendError::Closed(_) => {
+                    Error::new(ErrorCode::InternalError, "Subscription stream is closed")
+                }
+                TrySendError::Full(_) => {
+                    Error::new(ErrorCode::InternalError, "Subscription stream is full")
+                }
+            }
+        })?;
 
         let (token, guard) = self.options.subscriptions().register(
             id.clone(),

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -1809,9 +1809,16 @@ impl Context {
         let accepted = requested.supported_by(&self.options.advertised_capabilities());
         let (sink, pump) = self.subscription_sink();
 
-        // The acknowledgment MUST be the first message on the subscription, so
-        // it is queued before the entry goes live and any broadcast can reach
-        // it.
+        // The acknowledgment MUST be the first message on the subscription.
+        // `register` is what queues it, together with publishing the entry:
+        // the two have to be atomic against a concurrent broadcast, and the
+        // registry is the only thing that can make them so -- see its docs for
+        // why doing it here instead cannot work, whatever the caller does.
+        //
+        // The sink is empty at this point -- a listen `POST` body carries no
+        // request-scoped logging (see `notification::sink::RequestSink`) and a
+        // subscription reports no progress -- so `Full` here means a sink far
+        // too small to carry a subscription at all, and says so.
         let ack = Notification::new(
             crate::types::subscription::commands::ACKNOWLEDGED,
             serde_json::to_value(SubscriptionsAcknowledgedNotificationParams::new(
@@ -1821,37 +1828,27 @@ impl Context {
             .ok(),
         );
 
-        // `try_send`, deliberately, not `send().await`: an await between
-        // queueing the acknowledgment and registering the entry is a window in
-        // which the client has been told the subscription is established while
-        // nothing can reach it, so a concurrent mutation broadcasting in that
-        // window would be dropped for good. Nothing else can write to this sink
-        // until `register` publishes the entry, so queueing first and
-        // registering second -- with no await in between -- is what makes
-        // "acknowledgment first" and "no lost events" hold at the same time.
-        //
-        // The sink is empty at this point -- a listen `POST` body carries no
-        // request-scoped logging (see `notification::sink::RequestSink`) and a
-        // subscription reports no progress -- so `Full` here means a sink far
-        // too small to carry a subscription at all, and says so.
-        sink.try_send(Message::Notification(ack)).map_err(|err| {
-            use tokio::sync::mpsc::error::TrySendError;
-            match err {
-                TrySendError::Closed(_) => {
-                    Error::new(ErrorCode::InternalError, "Subscription stream is closed")
+        let (token, guard) = self
+            .options
+            .subscriptions()
+            .register(
+                id.clone(),
+                self.session_id,
+                accepted,
+                sink.clone(),
+                Message::Notification(ack),
+            )
+            .map_err(|err| {
+                use crate::app::subscriptions::RegisterError;
+                match err {
+                    RegisterError::Closed => {
+                        Error::new(ErrorCode::InternalError, "Subscription stream is closed")
+                    }
+                    RegisterError::Full => {
+                        Error::new(ErrorCode::InternalError, "Subscription stream is full")
+                    }
                 }
-                TrySendError::Full(_) => {
-                    Error::new(ErrorCode::InternalError, "Subscription stream is full")
-                }
-            }
-        })?;
-
-        let (token, guard) = self.options.subscriptions().register(
-            id.clone(),
-            self.session_id,
-            accepted,
-            sink.clone(),
-        );
+            })?;
 
         // Whichever comes first: the client cancelled this subscription, the
         // stream went away under us (an HTTP client that closed the response

--- a/neva/src/app/options.rs
+++ b/neva/src/app/options.rs
@@ -4,7 +4,9 @@ use crate::app::{collection::Collection, handler::RequestHandler};
 #[cfg(feature = "http-server")]
 use crate::transport::{HttpEngine, HttpServer};
 use crate::transport::{StdIoServer, TransportProto};
-use dashmap::{DashMap, DashSet};
+use dashmap::DashMap;
+#[cfg(feature = "legacy-spec")]
+use dashmap::DashSet;
 use std::fmt::{Debug, Formatter};
 use std::{sync::Arc, time::Duration};
 use tokio_util::sync::CancellationToken;
@@ -62,7 +64,21 @@ pub struct McpOptions {
     pub(super) resources_templates: Collection<ResourceTemplate>,
 
     /// Holds current subscriptions to resource changes
+    #[cfg(feature = "legacy-spec")]
     pub(super) resource_subscriptions: DashSet<Uri>,
+
+    /// Live `subscriptions/listen` streams (MCP 2026-07-28).
+    ///
+    /// Replaces [`Self::resource_subscriptions`]: a per-resource subscription
+    /// is now a URI inside a listen filter, scoped to that stream's lifetime.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(crate) subscriptions: crate::app::subscriptions::SubscriptionRegistry,
+
+    /// Cancelled when the server shuts down, so long-lived requests
+    /// (`subscriptions/listen`) can close gracefully instead of being dropped
+    /// mid-stream.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(crate) shutdown: CancellationToken,
 
     /// An ordered list of middlewares
     pub(super) middlewares: Option<Middlewares>,
@@ -186,7 +202,12 @@ impl Default for McpOptions {
             extensions: Default::default(),
             resource_routes: Default::default(),
             requests: Default::default(),
+            #[cfg(feature = "legacy-spec")]
             resource_subscriptions: Default::default(),
+            #[cfg(not(feature = "legacy-spec"))]
+            subscriptions: Default::default(),
+            #[cfg(not(feature = "legacy-spec"))]
+            shutdown: CancellationToken::new(),
             middlewares: None,
             #[cfg(all(feature = "tracing", feature = "legacy-spec"))]
             log_level: Default::default(),
@@ -638,52 +659,56 @@ impl McpOptions {
     /// If not configured but at least one [`Tool`] exists, returns [`Default`].
     /// Otherwise, returns `None`.
     pub(crate) fn tools_capability(&self) -> Option<ToolsCapability> {
-        #[allow(unused_mut)]
-        let mut cap = self.tools_capability.clone();
-        // The stateless MCP 2026-07-28 transport cannot push
-        // `notifications/tools/list_changed`, so never advertise `listChanged`
-        // under MCP 2026-07-28 -- clients refresh on cache-TTL / the next `tools/list`
-        // instead of relying on a push that will never arrive.
-        #[cfg(not(feature = "legacy-spec"))]
-        if let Some(c) = cap.as_mut() {
-            c.list_changed = false;
-        }
-        cap
+        self.tools_capability.clone()
     }
 
     /// Returns [`ResourcesCapability`] if configured.
     /// If not configured but at least one [`Resource`] or [`ResourceTemplate`] exists, returns [`Default`].
     /// Otherwise, returns `None`.
     pub(crate) fn resources_capability(&self) -> Option<ResourcesCapability> {
-        #[allow(unused_mut)]
-        let mut cap = self.resources_capability.clone();
-        // The stateless MCP 2026-07-28 transport cannot push
-        // `notifications/resources/updated` or `.../list_changed`, so mask both
-        // `subscribe` and `listChanged` under MCP 2026-07-28. Subscribe handlers are also
-        // not registered (see `App::new`), keeping the advertised surface and
-        // the accepted methods in sync.
-        #[cfg(not(feature = "legacy-spec"))]
-        if let Some(c) = cap.as_mut() {
-            c.subscribe = false;
-            c.list_changed = false;
-        }
-        cap
+        self.resources_capability.clone()
     }
 
     /// Returns [`PromptsCapability`] if configured.
     /// If not configured but at least one [`Prompt`] exists, returns [`Default`].
     /// Otherwise, returns `None`.
     pub(crate) fn prompts_capability(&self) -> Option<PromptsCapability> {
-        #[allow(unused_mut)]
-        let mut cap = self.prompts_capability.clone();
-        // The stateless MCP 2026-07-28 transport cannot push
-        // `notifications/prompts/list_changed`, so never advertise `listChanged`
-        // under MCP 2026-07-28 -- see `tools_capability` for the rationale.
-        #[cfg(not(feature = "legacy-spec"))]
-        if let Some(c) = cap.as_mut() {
-            c.list_changed = false;
+        self.prompts_capability.clone()
+    }
+
+    /// Returns the capabilities this server advertises, which is what a
+    /// `subscriptions/listen` filter is narrowed against: a client cannot
+    /// subscribe to a notification type the server never announced.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(crate) fn advertised_capabilities(&self) -> crate::types::ServerCapabilities {
+        crate::types::ServerCapabilities {
+            tools: self.tools_capability(),
+            resources: self.resources_capability(),
+            prompts: self.prompts_capability(),
+            ..Default::default()
         }
-        cap
+    }
+
+    /// Returns the registry of live `subscriptions/listen` streams.
+    #[cfg(not(feature = "legacy-spec"))]
+    #[inline]
+    pub(crate) fn subscriptions(&self) -> &crate::app::subscriptions::SubscriptionRegistry {
+        &self.subscriptions
+    }
+
+    /// Returns the token cancelled when the server shuts down.
+    #[cfg(not(feature = "legacy-spec"))]
+    #[inline]
+    pub(crate) fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    /// Points the server's shutdown token at the transport's, so long-lived
+    /// requests observe the same signal the dispatch loop does.
+    #[cfg(not(feature = "legacy-spec"))]
+    #[inline]
+    pub(crate) fn set_shutdown_token(&mut self, token: CancellationToken) {
+        self.shutdown = token;
     }
 
     /// Returns [`ServerTasksCapability`] if configured.
@@ -1096,12 +1121,10 @@ mod tests {
 
         let tools_capability = options.tools_capability().unwrap();
 
-        // Under the stateless 2026-07-28 transport `listChanged` is masked off because
-        // the server cannot push it; otherwise it round-trips the config.
-        #[cfg(feature = "legacy-spec")]
+        // `listChanged` round-trips the config in both profiles: under MCP
+        // 2026-07-28 a `subscriptions/listen` stream delivers it, so the
+        // capability is honest again.
         assert!(tools_capability.list_changed);
-        #[cfg(not(feature = "legacy-spec"))]
-        assert!(!tools_capability.list_changed);
     }
 
     #[test]
@@ -1127,11 +1150,7 @@ mod tests {
 
         let resources_capability = options.resources_capability().unwrap();
 
-        // Masked off under the stateless 2026-07-28 transport (see `tools` test above).
-        #[cfg(feature = "legacy-spec")]
         assert!(resources_capability.list_changed);
-        #[cfg(not(feature = "legacy-spec"))]
-        assert!(!resources_capability.list_changed);
     }
 
     #[test]
@@ -1210,11 +1229,7 @@ mod tests {
 
         let prompts_capability = options.prompts_capability().unwrap();
 
-        // Masked off under the stateless 2026-07-28 transport (see `tools` test above).
-        #[cfg(feature = "legacy-spec")]
         assert!(prompts_capability.list_changed);
-        #[cfg(not(feature = "legacy-spec"))]
-        assert!(!prompts_capability.list_changed);
     }
 
     #[test]

--- a/neva/src/app/subscriptions.rs
+++ b/neva/src/app/subscriptions.rs
@@ -11,7 +11,10 @@ use crate::types::{
     Message, RequestId, SubscriptionFilter, SubscriptionMeta, Uri, notification::Notification,
 };
 use dashmap::DashMap;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use tokio::sync::mpsc::Sender;
 use tokio_util::sync::CancellationToken;
 
@@ -22,9 +25,25 @@ use tokio_util::sync::CancellationToken;
 /// by `sse_log_queue_capacity`.
 pub(crate) const DEFAULT_SUBSCRIPTION_CAPACITY: usize = 64;
 
+/// Server-assigned key of a registry entry.
+///
+/// Deliberately *not* the JSON-RPC id of the listen request: that id is chosen
+/// by the peer, and every fresh neva client starts its counter at the same
+/// value, so two clients on one server routinely pick the same one. Keying on
+/// it would let a second client evict the first from this process-wide
+/// registry, silently stop its delivery, and have either client's teardown
+/// remove the other's entry.
+type Key = u64;
+
 /// One live subscription.
 #[derive(Debug)]
 struct Subscription {
+    /// The JSON-RPC id of the `subscriptions/listen` request, as the peer chose
+    /// it. Unique only within one client, so it identifies the subscription
+    /// *on the wire* (it is what `_meta` is tagged with) but never keys this
+    /// registry.
+    id: RequestId,
+
     /// The subset of the requested filter the server agreed to honor.
     accepted: SubscriptionFilter,
 
@@ -38,24 +57,24 @@ struct Subscription {
     token: CancellationToken,
 }
 
-/// Registry of live `subscriptions/listen` streams, keyed by the JSON-RPC id of
-/// the request that opened each one.
+/// Registry of live `subscriptions/listen` streams.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct SubscriptionRegistry {
-    entries: Arc<DashMap<RequestId, Subscription>>,
+    entries: Arc<DashMap<Key, Subscription>>,
+    next_key: Arc<AtomicU64>,
 }
 
 /// Removes a subscription from the registry when the `subscriptions/listen`
 /// handler ends, whatever ends it: cancellation, disconnect or a panic.
 #[derive(Debug)]
 pub(crate) struct SubscriptionGuard {
-    id: RequestId,
+    key: Key,
     registry: SubscriptionRegistry,
 }
 
 impl Drop for SubscriptionGuard {
     fn drop(&mut self) {
-        self.registry.entries.remove(&self.id);
+        self.registry.entries.remove(&self.key);
     }
 }
 
@@ -69,9 +88,11 @@ impl SubscriptionRegistry {
         sink: Sender<Message>,
     ) -> (CancellationToken, SubscriptionGuard) {
         let token = CancellationToken::new();
+        let key = self.next_key.fetch_add(1, Ordering::Relaxed);
         self.entries.insert(
-            id.clone(),
+            key,
             Subscription {
+                id,
                 accepted,
                 sink,
                 token: token.clone(),
@@ -80,19 +101,49 @@ impl SubscriptionRegistry {
         (
             token,
             SubscriptionGuard {
-                id,
+                key,
                 registry: self.clone(),
             },
         )
     }
 
-    /// Cancels the subscription opened by `id`, if there is one.
+    /// Cancels the subscription a `notifications/cancelled` names.
     ///
     /// Returns whether a subscription was found -- the caller uses that to tell
-    /// a `notifications/cancelled` aimed at a subscription apart from one aimed
-    /// at an ordinary in-flight request.
+    /// a cancel aimed at a subscription apart from one aimed at an ordinary
+    /// in-flight request.
+    ///
+    /// A bare request id is only unique *within* one client, and over HTTP the
+    /// cancel arrives on its own `POST`, carrying no evidence of who opened the
+    /// stream. So when two clients happen to have picked the same id -- which
+    /// is routine, every fresh neva client starts its counter at the same value
+    /// -- this refuses rather than guessing which one to end. Those clients
+    /// cancel by closing the stream instead, which is what the spec prescribes
+    /// over HTTP; stdio, where a bare id *is* unambiguous, is where
+    /// `notifications/cancelled` is the prescribed mechanism.
     pub(crate) fn cancel(&self, id: &RequestId) -> bool {
-        match self.entries.get(id) {
+        let mut matching = self
+            .entries
+            .iter()
+            .filter(|entry| entry.id == *id)
+            .map(|entry| *entry.key());
+
+        let Some(key) = matching.next() else {
+            return false;
+        };
+        
+        if matching.next().is_some() {
+            #[cfg(feature = "tracing")]
+            tracing::warn!(
+                logger = "neva",
+                subscription = %id,
+                "ignoring a subscription cancel: the id names more than one live stream"
+            );
+            return false;
+        }
+        drop(matching);
+
+        match self.entries.get(&key) {
             Some(entry) => {
                 entry.token.cancel();
                 true
@@ -133,7 +184,7 @@ impl SubscriptionRegistry {
             if !entry.accepted.matches(method, uri.as_ref()) {
                 continue;
             }
-            let notification = Notification::new(method, Some(tag(params, entry.key().clone())));
+            let notification = Notification::new(method, Some(tag(params, entry.id.clone())));
             if entry
                 .sink
                 .try_send(Message::Notification(notification))
@@ -143,7 +194,7 @@ impl SubscriptionRegistry {
                 tracing::warn!(
                     logger = "neva",
                     method,
-                    subscription = %entry.key(),
+                    subscription = %entry.id,
                     "dropped a notification: the subscription stream is full or closed"
                 );
             }
@@ -336,6 +387,83 @@ mod tests {
         registry.broadcast(tool::commands::LIST_CHANGED, None);
         assert!(rx.try_recv().is_err());
         assert!(!registry.cancel(&RequestId::Number(1)));
+    }
+
+    /// Two clients routinely pick the same JSON-RPC id -- every fresh neva
+    /// client starts its counter at the same value -- so the registry must not
+    /// be keyed on it: the second registration would evict the first, silently
+    /// ending its delivery.
+    #[tokio::test]
+    async fn it_keeps_two_clients_that_picked_the_same_id_apart() {
+        let registry = SubscriptionRegistry::default();
+        let (tx_a, mut rx_a) = channel::<Message>(8);
+        let (tx_b, mut rx_b) = channel::<Message>(8);
+
+        let (_ta, _ga) = registry.register(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+            tx_a,
+        );
+        let (_tb, _gb) = registry.register(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+            tx_b,
+        );
+
+        registry.broadcast(tool::commands::LIST_CHANGED, None);
+
+        // Both streams get it, and each is tagged with the id its own client
+        // chose -- which here happens to be the same one.
+        for rx in [&mut rx_a, &mut rx_b] {
+            let json = serde_json::to_value(rx.try_recv().unwrap()).unwrap();
+            assert_eq!(json["params"]["_meta"][SUBSCRIPTION_ID_KEY], 1);
+        }
+    }
+
+    /// ...and one client's teardown must not deregister the other's.
+    #[tokio::test]
+    async fn it_does_not_deregister_a_colliding_id_on_teardown() {
+        let registry = SubscriptionRegistry::default();
+        let (tx_a, _rx_a) = channel::<Message>(8);
+        let (tx_b, mut rx_b) = channel::<Message>(8);
+
+        let (_ta, guard_a) = registry.register(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+            tx_a,
+        );
+        let (_tb, _gb) = registry.register(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+            tx_b,
+        );
+
+        drop(guard_a);
+        registry.broadcast(tool::commands::LIST_CHANGED, None);
+
+        assert!(
+            rx_b.try_recv().is_ok(),
+            "the surviving subscription must still receive"
+        );
+    }
+
+    /// A cancel naming an id two clients happen to share must end neither: the
+    /// notification arrives on its own `POST` and says nothing about who sent
+    /// it, so guessing would let one client silence another.
+    #[tokio::test]
+    async fn it_refuses_an_ambiguous_cancel() {
+        let registry = SubscriptionRegistry::default();
+        let (tx_a, _rx_a) = channel::<Message>(8);
+        let (tx_b, _rx_b) = channel::<Message>(8);
+
+        let (token_a, _ga) =
+            registry.register(RequestId::Number(1), SubscriptionFilter::new(), tx_a);
+        let (token_b, _gb) =
+            registry.register(RequestId::Number(1), SubscriptionFilter::new(), tx_b);
+
+        assert!(!registry.cancel(&RequestId::Number(1)));
+        assert!(!token_a.is_cancelled());
+        assert!(!token_b.is_cancelled());
     }
 
     #[tokio::test]

--- a/neva/src/app/subscriptions.rs
+++ b/neva/src/app/subscriptions.rs
@@ -9,6 +9,7 @@
 
 use crate::types::{
     Message, RequestId, SubscriptionFilter, SubscriptionMeta, Uri, notification::Notification,
+    subscription::is_subscribable,
 };
 use dashmap::DashMap;
 use std::sync::{
@@ -193,20 +194,6 @@ impl SubscriptionRegistry {
         }
         true
     }
-}
-
-/// Whether `method` is one of the notification types a `subscriptions/listen`
-/// filter can opt in to.
-fn is_subscribable(method: &str) -> bool {
-    use crate::types::{prompt, resource, tool};
-
-    matches!(
-        method,
-        tool::commands::LIST_CHANGED
-            | prompt::commands::LIST_CHANGED
-            | resource::commands::LIST_CHANGED
-            | resource::commands::UPDATED
-    )
 }
 
 /// Stamps `_meta.io.modelcontextprotocol/subscriptionId` onto a copy of

--- a/neva/src/app/subscriptions.rs
+++ b/neva/src/app/subscriptions.rs
@@ -44,6 +44,11 @@ struct Subscription {
     /// registry.
     id: RequestId,
 
+    /// Transport session this subscription is bound to: the per-`POST` session
+    /// id over HTTP, `None` over stdio. It is what scopes cancellation, see
+    /// [`SubscriptionRegistry::cancel`].
+    session_id: Option<uuid::Uuid>,
+
     /// The subset of the requested filter the server agreed to honor.
     accepted: SubscriptionFilter,
 
@@ -81,9 +86,12 @@ impl Drop for SubscriptionGuard {
 impl SubscriptionRegistry {
     /// Registers a subscription and returns its cancellation token together
     /// with the guard that deregisters it.
+    /// `session_id` is the transport session the subscription is bound to (the
+    /// per-`POST` session id over HTTP, `None` over stdio).
     pub(crate) fn register(
         &self,
         id: RequestId,
+        session_id: Option<uuid::Uuid>,
         accepted: SubscriptionFilter,
         sink: Sender<Message>,
     ) -> (CancellationToken, SubscriptionGuard) {
@@ -93,6 +101,7 @@ impl SubscriptionRegistry {
             key,
             Subscription {
                 id,
+                session_id,
                 accepted,
                 sink,
                 token: token.clone(),
@@ -107,49 +116,32 @@ impl SubscriptionRegistry {
         )
     }
 
-    /// Cancels the subscription a `notifications/cancelled` names.
+    /// Cancels the subscription a `notifications/cancelled` names, if this
+    /// notification is one that may reach it.
     ///
     /// Returns whether a subscription was found -- the caller uses that to tell
     /// a cancel aimed at a subscription apart from one aimed at an ordinary
     /// in-flight request.
     ///
-    /// A bare request id is only unique *within* one client, and over HTTP the
-    /// cancel arrives on its own `POST`, carrying no evidence of who opened the
-    /// stream. So when two clients happen to have picked the same id -- which
-    /// is routine, every fresh neva client starts its counter at the same value
-    /// -- this refuses rather than guessing which one to end. Those clients
-    /// cancel by closing the stream instead, which is what the spec prescribes
-    /// over HTTP; stdio, where a bare id *is* unambiguous, is where
-    /// `notifications/cancelled` is the prescribed mechanism.
+    /// Only subscriptions with no transport session binding can be cancelled
+    /// this way, which means stdio -- where one process serves one client, so a
+    /// bare request id is unambiguous, and where the spec names
+    /// `notifications/cancelled` as *the* mechanism. Over HTTP the cancel
+    /// arrives on its own `POST` and carries no evidence of who opened the
+    /// stream, while ids collide routinely (every fresh neva client starts its
+    /// counter at the same value); honoring it there would let one client end
+    /// another's subscription. HTTP clients cancel by closing the stream, which
+    /// the handler observes through its sink -- neva's own client does exactly
+    /// that in `Subscription::cancel`.
     pub(crate) fn cancel(&self, id: &RequestId) -> bool {
-        let mut matching = self
-            .entries
-            .iter()
-            .filter(|entry| entry.id == *id)
-            .map(|entry| *entry.key());
-
-        let Some(key) = matching.next() else {
-            return false;
-        };
-
-        if matching.next().is_some() {
-            #[cfg(feature = "tracing")]
-            tracing::warn!(
-                logger = "neva",
-                subscription = %id,
-                "ignoring a subscription cancel: the id names more than one live stream"
-            );
-            return false;
-        }
-        drop(matching);
-
-        match self.entries.get(&key) {
-            Some(entry) => {
+        let mut found = false;
+        for entry in self.entries.iter() {
+            if entry.session_id.is_none() && entry.id == *id {
                 entry.token.cancel();
-                true
+                found = true;
             }
-            None => false,
         }
+        found
     }
 
     /// Returns whether any live subscription is watching `uri`.
@@ -252,7 +244,7 @@ mod tests {
     ) {
         let registry = SubscriptionRegistry::default();
         let (tx, rx) = channel::<Message>(8);
-        let (_token, guard) = registry.register(id, accepted, tx);
+        let (_token, guard) = registry.register(id, None, accepted, tx);
         (registry, rx, guard)
     }
 
@@ -341,11 +333,13 @@ mod tests {
 
         let (_t1, _g1) = registry.register(
             RequestId::Number(1),
+            None,
             SubscriptionFilter::new().with_tools_changed(),
             tx1,
         );
         let (_t2, _g2) = registry.register(
             RequestId::Number(2),
+            None,
             SubscriptionFilter::new().with_prompts_changed(),
             tx2,
         );
@@ -363,8 +357,10 @@ mod tests {
         let (tx1, _rx1) = channel::<Message>(8);
         let (tx2, _rx2) = channel::<Message>(8);
 
-        let (token1, _g1) = registry.register(RequestId::Number(1), SubscriptionFilter::new(), tx1);
-        let (token2, _g2) = registry.register(RequestId::Number(2), SubscriptionFilter::new(), tx2);
+        let (token1, _g1) =
+            registry.register(RequestId::Number(1), None, SubscriptionFilter::new(), tx1);
+        let (token2, _g2) =
+            registry.register(RequestId::Number(2), None, SubscriptionFilter::new(), tx2);
 
         assert!(registry.cancel(&RequestId::Number(1)));
         assert!(token1.is_cancelled());
@@ -378,6 +374,7 @@ mod tests {
         let (tx, mut rx) = channel::<Message>(8);
         let (_token, guard) = registry.register(
             RequestId::Number(1),
+            None,
             SubscriptionFilter::new().with_tools_changed(),
             tx,
         );
@@ -401,11 +398,13 @@ mod tests {
 
         let (_ta, _ga) = registry.register(
             RequestId::Number(1),
+            Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new().with_tools_changed(),
             tx_a,
         );
         let (_tb, _gb) = registry.register(
             RequestId::Number(1),
+            Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new().with_tools_changed(),
             tx_b,
         );
@@ -429,11 +428,13 @@ mod tests {
 
         let (_ta, guard_a) = registry.register(
             RequestId::Number(1),
+            Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new().with_tools_changed(),
             tx_a,
         );
         let (_tb, _gb) = registry.register(
             RequestId::Number(1),
+            Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new().with_tools_changed(),
             tx_b,
         );
@@ -447,19 +448,28 @@ mod tests {
         );
     }
 
-    /// A cancel naming an id two clients happen to share must end neither: the
-    /// notification arrives on its own `POST` and says nothing about who sent
-    /// it, so guessing would let one client silence another.
+    /// A `notifications/cancelled` must not reach a session-bound (HTTP)
+    /// subscription: it arrives on its own `POST` and says nothing about who
+    /// sent it, while ids collide routinely -- honoring it would let one client
+    /// silence another. Those clients cancel by closing the stream.
     #[tokio::test]
-    async fn it_refuses_an_ambiguous_cancel() {
+    async fn it_refuses_to_cancel_a_session_bound_subscription() {
         let registry = SubscriptionRegistry::default();
         let (tx_a, _rx_a) = channel::<Message>(8);
         let (tx_b, _rx_b) = channel::<Message>(8);
 
-        let (token_a, _ga) =
-            registry.register(RequestId::Number(1), SubscriptionFilter::new(), tx_a);
-        let (token_b, _gb) =
-            registry.register(RequestId::Number(1), SubscriptionFilter::new(), tx_b);
+        let (token_a, _ga) = registry.register(
+            RequestId::Number(1),
+            Some(uuid::Uuid::new_v4()),
+            SubscriptionFilter::new(),
+            tx_a,
+        );
+        let (token_b, _gb) = registry.register(
+            RequestId::Number(1),
+            Some(uuid::Uuid::new_v4()),
+            SubscriptionFilter::new(),
+            tx_b,
+        );
 
         assert!(!registry.cancel(&RequestId::Number(1)));
         assert!(!token_a.is_cancelled());

--- a/neva/src/app/subscriptions.rs
+++ b/neva/src/app/subscriptions.rs
@@ -1,0 +1,351 @@
+//! Live `subscriptions/listen` streams (MCP 2026-07-28).
+//!
+//! Each `subscriptions/listen` request registers one entry here for as long as
+//! it is held open. Any other in-flight request can then fan a notification out
+//! to the streams that asked for it -- the registry lives on the shared
+//! [`McpOptions`](crate::app::options::McpOptions), so a tool handler calling
+//! [`Context::add_tool`](crate::Context::add_tool) reaches every listener
+//! without knowing anything about them.
+
+use crate::types::{
+    Message, RequestId, SubscriptionFilter, SubscriptionMeta, Uri, notification::Notification,
+};
+use dashmap::DashMap;
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+use tokio_util::sync::CancellationToken;
+
+/// Notifications buffered per subscription before delivery starts dropping.
+///
+/// Only used for the transports that need a channel of their own (stdio); over
+/// HTTP the subscription writes into the `POST` response sink, which is sized
+/// by `sse_log_queue_capacity`.
+pub(crate) const DEFAULT_SUBSCRIPTION_CAPACITY: usize = 64;
+
+/// One live subscription.
+#[derive(Debug)]
+struct Subscription {
+    /// The subset of the requested filter the server agreed to honor.
+    accepted: SubscriptionFilter,
+
+    /// Where this subscription's notifications go: over HTTP the `POST`
+    /// response sink, over stdio a channel pumped into the transport sender.
+    sink: Sender<Message>,
+
+    /// Cancels this subscription alone, leaving the request's own cancellation
+    /// token untouched -- the `subscriptions/listen` request must still be able
+    /// to answer with its graceful-close result.
+    token: CancellationToken,
+}
+
+/// Registry of live `subscriptions/listen` streams, keyed by the JSON-RPC id of
+/// the request that opened each one.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct SubscriptionRegistry {
+    entries: Arc<DashMap<RequestId, Subscription>>,
+}
+
+/// Removes a subscription from the registry when the `subscriptions/listen`
+/// handler ends, whatever ends it: cancellation, disconnect or a panic.
+#[derive(Debug)]
+pub(crate) struct SubscriptionGuard {
+    id: RequestId,
+    registry: SubscriptionRegistry,
+}
+
+impl Drop for SubscriptionGuard {
+    fn drop(&mut self) {
+        self.registry.entries.remove(&self.id);
+    }
+}
+
+impl SubscriptionRegistry {
+    /// Registers a subscription and returns its cancellation token together
+    /// with the guard that deregisters it.
+    pub(crate) fn register(
+        &self,
+        id: RequestId,
+        accepted: SubscriptionFilter,
+        sink: Sender<Message>,
+    ) -> (CancellationToken, SubscriptionGuard) {
+        let token = CancellationToken::new();
+        self.entries.insert(
+            id.clone(),
+            Subscription {
+                accepted,
+                sink,
+                token: token.clone(),
+            },
+        );
+        (
+            token,
+            SubscriptionGuard {
+                id,
+                registry: self.clone(),
+            },
+        )
+    }
+
+    /// Cancels the subscription opened by `id`, if there is one.
+    ///
+    /// Returns whether a subscription was found -- the caller uses that to tell
+    /// a `notifications/cancelled` aimed at a subscription apart from one aimed
+    /// at an ordinary in-flight request.
+    pub(crate) fn cancel(&self, id: &RequestId) -> bool {
+        match self.entries.get(id) {
+            Some(entry) => {
+                entry.token.cancel();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Returns whether any live subscription is watching `uri`.
+    pub(crate) fn is_resource_subscribed(&self, uri: &Uri) -> bool {
+        self.entries
+            .iter()
+            .any(|e| e.accepted.resource_subscriptions.contains(uri))
+    }
+
+    /// Fans `method` out to every subscription whose filter admits it, tagging
+    /// each copy with its own subscription id.
+    ///
+    /// Returns whether `method` is a subscription-delivered notification type
+    /// at all, so the caller can tell "nobody is listening" from "this
+    /// notification never travels on a subscription" (progress, task status and
+    /// elicitation notifications stay request-scoped).
+    ///
+    /// Delivery is best-effort: a subscription whose buffer is full drops the
+    /// notification rather than blocking the request that produced it, exactly
+    /// like the request-scoped notification sink.
+    pub(crate) fn broadcast(&self, method: &str, params: Option<&serde_json::Value>) -> bool {
+        if !is_subscribable(method) {
+            return false;
+        }
+
+        let uri = params
+            .and_then(|p| p.get("uri"))
+            .and_then(|u| u.as_str())
+            .map(Uri::from);
+
+        for entry in self.entries.iter() {
+            if !entry.accepted.matches(method, uri.as_ref()) {
+                continue;
+            }
+            let notification = Notification::new(method, Some(tag(params, entry.key().clone())));
+            if entry
+                .sink
+                .try_send(Message::Notification(notification))
+                .is_err()
+            {
+                #[cfg(feature = "tracing")]
+                tracing::warn!(
+                    logger = "neva",
+                    method,
+                    subscription = %entry.key(),
+                    "dropped a notification: the subscription stream is full or closed"
+                );
+            }
+        }
+        true
+    }
+}
+
+/// Whether `method` is one of the notification types a `subscriptions/listen`
+/// filter can opt in to.
+fn is_subscribable(method: &str) -> bool {
+    use crate::types::{prompt, resource, tool};
+
+    matches!(
+        method,
+        tool::commands::LIST_CHANGED
+            | prompt::commands::LIST_CHANGED
+            | resource::commands::LIST_CHANGED
+            | resource::commands::UPDATED
+    )
+}
+
+/// Stamps `_meta.io.modelcontextprotocol/subscriptionId` onto a copy of
+/// `params`, which is what lets a client demultiplex several subscriptions
+/// sharing one channel (stdio always does).
+fn tag(params: Option<&serde_json::Value>, id: RequestId) -> serde_json::Value {
+    let mut value = params.cloned().unwrap_or_else(|| serde_json::json!({}));
+    let meta =
+        serde_json::to_value(SubscriptionMeta::new(id)).unwrap_or_else(|_| serde_json::json!({}));
+
+    match value.as_object_mut() {
+        Some(obj) => {
+            obj.insert("_meta".to_owned(), meta);
+            value
+        }
+        // Params that are not an object cannot carry `_meta`; the tag matters
+        // more than the payload shape, so rebuild around it.
+        None => serde_json::json!({ "_meta": meta }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{prompt, resource, subscription::SUBSCRIPTION_ID_KEY, tool};
+    use tokio::sync::mpsc::channel;
+
+    fn registry_with(
+        id: RequestId,
+        accepted: SubscriptionFilter,
+    ) -> (
+        SubscriptionRegistry,
+        tokio::sync::mpsc::Receiver<Message>,
+        SubscriptionGuard,
+    ) {
+        let registry = SubscriptionRegistry::default();
+        let (tx, rx) = channel::<Message>(8);
+        let (_token, guard) = registry.register(id, accepted, tx);
+        (registry, rx, guard)
+    }
+
+    fn method_of(msg: &Message) -> String {
+        serde_json::to_value(msg).unwrap()["method"]
+            .as_str()
+            .unwrap()
+            .to_owned()
+    }
+
+    #[tokio::test]
+    async fn it_delivers_only_subscribed_types() {
+        let (registry, mut rx, _guard) = registry_with(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+        );
+
+        assert!(registry.broadcast(prompt::commands::LIST_CHANGED, None));
+        assert!(registry.broadcast(tool::commands::LIST_CHANGED, None));
+
+        let msg = rx.try_recv().expect("the tools notification is subscribed");
+        assert_eq!(method_of(&msg), tool::commands::LIST_CHANGED);
+        assert!(
+            rx.try_recv().is_err(),
+            "a type the client never requested must not be delivered"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_tags_every_notification_with_its_subscription_id() {
+        let (registry, mut rx, _guard) = registry_with(
+            RequestId::String("sub-1".into()),
+            SubscriptionFilter::new().with_tools_changed(),
+        );
+
+        registry.broadcast(tool::commands::LIST_CHANGED, None);
+
+        let msg = rx.try_recv().unwrap();
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["params"]["_meta"][SUBSCRIPTION_ID_KEY], "sub-1");
+    }
+
+    #[tokio::test]
+    async fn it_keeps_resource_update_params_alongside_the_tag() {
+        let (registry, mut rx, _guard) = registry_with(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_resource("res://a"),
+        );
+
+        let params = serde_json::json!({ "uri": "res://a" });
+        registry.broadcast(resource::commands::UPDATED, Some(&params));
+
+        let json = serde_json::to_value(rx.try_recv().unwrap()).unwrap();
+        assert_eq!(json["params"]["uri"], "res://a");
+        assert_eq!(json["params"]["_meta"][SUBSCRIPTION_ID_KEY], 1);
+    }
+
+    #[tokio::test]
+    async fn it_routes_resource_updates_by_uri() {
+        let (registry, mut rx, _guard) = registry_with(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_resource("res://a"),
+        );
+
+        let other = serde_json::json!({ "uri": "res://b" });
+        registry.broadcast(resource::commands::UPDATED, Some(&other));
+
+        assert!(
+            rx.try_recv().is_err(),
+            "an update for an unsubscribed URI must not be delivered"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_reports_non_subscribable_methods() {
+        let registry = SubscriptionRegistry::default();
+        assert!(!registry.broadcast("notifications/progress", None));
+        assert!(!registry.broadcast("notifications/tasks/status", None));
+    }
+
+    #[tokio::test]
+    async fn it_fans_out_to_concurrent_subscriptions() {
+        let registry = SubscriptionRegistry::default();
+        let (tx1, mut rx1) = channel::<Message>(8);
+        let (tx2, mut rx2) = channel::<Message>(8);
+
+        let (_t1, _g1) = registry.register(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+            tx1,
+        );
+        let (_t2, _g2) = registry.register(
+            RequestId::Number(2),
+            SubscriptionFilter::new().with_prompts_changed(),
+            tx2,
+        );
+
+        registry.broadcast(tool::commands::LIST_CHANGED, None);
+
+        let json = serde_json::to_value(rx1.try_recv().unwrap()).unwrap();
+        assert_eq!(json["params"]["_meta"][SUBSCRIPTION_ID_KEY], 1);
+        assert!(rx2.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn it_cancels_only_the_named_subscription() {
+        let registry = SubscriptionRegistry::default();
+        let (tx1, _rx1) = channel::<Message>(8);
+        let (tx2, _rx2) = channel::<Message>(8);
+
+        let (token1, _g1) = registry.register(RequestId::Number(1), SubscriptionFilter::new(), tx1);
+        let (token2, _g2) = registry.register(RequestId::Number(2), SubscriptionFilter::new(), tx2);
+
+        assert!(registry.cancel(&RequestId::Number(1)));
+        assert!(token1.is_cancelled());
+        assert!(!token2.is_cancelled());
+        assert!(!registry.cancel(&RequestId::Number(3)));
+    }
+
+    #[tokio::test]
+    async fn it_deregisters_on_guard_drop() {
+        let registry = SubscriptionRegistry::default();
+        let (tx, mut rx) = channel::<Message>(8);
+        let (_token, guard) = registry.register(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+            tx,
+        );
+
+        drop(guard);
+
+        registry.broadcast(tool::commands::LIST_CHANGED, None);
+        assert!(rx.try_recv().is_err());
+        assert!(!registry.cancel(&RequestId::Number(1)));
+    }
+
+    #[tokio::test]
+    async fn it_answers_whether_a_resource_is_watched() {
+        let (registry, _rx, _guard) = registry_with(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_resource("res://a"),
+        );
+
+        assert!(registry.is_resource_subscribed(&Uri::from("res://a")));
+        assert!(!registry.is_resource_subscribed(&Uri::from("res://b")));
+    }
+}

--- a/neva/src/app/subscriptions.rs
+++ b/neva/src/app/subscriptions.rs
@@ -16,7 +16,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
 };
-use tokio::sync::mpsc::{Sender, error::TrySendError};
+use tokio::sync::mpsc::{OwnedPermit, Sender};
 use tokio_util::sync::CancellationToken;
 
 /// Notifications buffered per subscription before delivery starts dropping.
@@ -84,27 +84,6 @@ impl Drop for SubscriptionGuard {
     }
 }
 
-/// Why a subscription could not be opened.
-#[derive(Debug)]
-pub(crate) enum RegisterError {
-    /// The stream is gone -- the client disconnected before the handshake.
-    Closed,
-
-    /// The stream cannot take the acknowledgment. Since it is empty when
-    /// [`SubscriptionRegistry::register`] runs, this means a buffer too small
-    /// to carry a subscription at all.
-    Full,
-}
-
-impl From<TrySendError<Message>> for RegisterError {
-    fn from(err: TrySendError<Message>) -> Self {
-        match err {
-            TrySendError::Closed(_) => Self::Closed,
-            TrySendError::Full(_) => Self::Full,
-        }
-    }
-}
-
 impl SubscriptionRegistry {
     /// Queues `ack` onto the subscription's stream and registers the
     /// subscription, returning its cancellation token together with the guard
@@ -129,10 +108,9 @@ impl SubscriptionRegistry {
     /// mutation in that instant is dropped by a subscription the client has
     /// been told is live.
     ///
-    /// # Errors
-    /// Returns [`RegisterError`] if the stream cannot take the acknowledgment.
-    /// Nothing is registered in that case: a subscription that cannot open is
-    /// not a subscription.
+    /// `ack_slot` is capacity reserved for the acknowledgment before anything
+    /// else could write to the body, so queueing it cannot fail and cannot be
+    /// crowded out by a noisy request.
     pub(crate) fn register(
         &self,
         id: RequestId,
@@ -140,7 +118,8 @@ impl SubscriptionRegistry {
         accepted: SubscriptionFilter,
         sink: Sender<Message>,
         ack: Message,
-    ) -> Result<(CancellationToken, SubscriptionGuard), RegisterError> {
+        ack_slot: OwnedPermit<Message>,
+    ) -> (CancellationToken, SubscriptionGuard) {
         let token = CancellationToken::new();
         let key = self.next_key.fetch_add(1, Ordering::Relaxed);
 
@@ -148,7 +127,7 @@ impl SubscriptionRegistry {
         // what makes the pair below atomic.
         let slot = self.entries.entry(key);
 
-        sink.try_send(ack).map_err(RegisterError::from)?;
+        ack_slot.send(ack);
 
         slot.insert(Subscription {
             id,
@@ -158,13 +137,13 @@ impl SubscriptionRegistry {
             token: token.clone(),
         });
 
-        Ok((
+        (
             token,
             SubscriptionGuard {
                 key,
                 registry: self.clone(),
             },
-        ))
+        )
     }
 
     /// Cancels the subscription a `notifications/cancelled` names, if this
@@ -271,7 +250,7 @@ mod tests {
     use crate::types::{prompt, resource, subscription::SUBSCRIPTION_ID_KEY, tool};
     use tokio::sync::mpsc::channel;
 
-    fn registry_with(
+    async fn registry_with(
         id: RequestId,
         accepted: SubscriptionFilter,
     ) -> (
@@ -281,7 +260,7 @@ mod tests {
     ) {
         let registry = SubscriptionRegistry::default();
         let (tx, mut rx) = channel::<Message>(8);
-        let (_token, guard) = register(&registry, id, None, accepted, tx, &mut rx);
+        let (_token, guard) = register(&registry, id, None, accepted, tx, &mut rx).await;
         (registry, rx, guard)
     }
 
@@ -292,7 +271,7 @@ mod tests {
     /// Asserting on it here is the point: `register` queuing it is the only
     /// thing that makes "acknowledgment first" hold against a broadcast racing
     /// the registration.
-    fn register(
+    async fn register(
         registry: &SubscriptionRegistry,
         id: RequestId,
         session_id: Option<uuid::Uuid>,
@@ -300,9 +279,12 @@ mod tests {
         tx: Sender<Message>,
         rx: &mut tokio::sync::mpsc::Receiver<Message>,
     ) -> (CancellationToken, SubscriptionGuard) {
-        let registered = registry
-            .register(id, session_id, accepted, tx, ack())
-            .expect("the sink must accept the acknowledgment");
+        let slot = tx
+            .clone()
+            .reserve_owned()
+            .await
+            .expect("the test sink must have room for the acknowledgment");
+        let registered = registry.register(id, session_id, accepted, tx, ack(), slot);
 
         let first = rx
             .try_recv()
@@ -335,7 +317,8 @@ mod tests {
         let (registry, mut rx, _guard) = registry_with(
             RequestId::Number(1),
             SubscriptionFilter::new().with_tools_changed(),
-        );
+        )
+        .await;
 
         assert!(registry.broadcast(prompt::commands::LIST_CHANGED, None));
         assert!(registry.broadcast(tool::commands::LIST_CHANGED, None));
@@ -353,7 +336,8 @@ mod tests {
         let (registry, mut rx, _guard) = registry_with(
             RequestId::String("sub-1".into()),
             SubscriptionFilter::new().with_tools_changed(),
-        );
+        )
+        .await;
 
         registry.broadcast(tool::commands::LIST_CHANGED, None);
 
@@ -367,7 +351,8 @@ mod tests {
         let (registry, mut rx, _guard) = registry_with(
             RequestId::Number(1),
             SubscriptionFilter::new().with_resource("res://a"),
-        );
+        )
+        .await;
 
         let params = serde_json::json!({ "uri": "res://a" });
         registry.broadcast(resource::commands::UPDATED, Some(&params));
@@ -382,7 +367,8 @@ mod tests {
         let (registry, mut rx, _guard) = registry_with(
             RequestId::Number(1),
             SubscriptionFilter::new().with_resource("res://a"),
-        );
+        )
+        .await;
 
         let other = serde_json::json!({ "uri": "res://b" });
         registry.broadcast(resource::commands::UPDATED, Some(&other));
@@ -413,7 +399,8 @@ mod tests {
             SubscriptionFilter::new().with_tools_changed(),
             tx1,
             &mut rx1,
-        );
+        )
+        .await;
         let (_t2, _g2) = register(
             &registry,
             RequestId::Number(2),
@@ -421,7 +408,8 @@ mod tests {
             SubscriptionFilter::new().with_prompts_changed(),
             tx2,
             &mut rx2,
-        );
+        )
+        .await;
 
         registry.broadcast(tool::commands::LIST_CHANGED, None);
 
@@ -443,7 +431,8 @@ mod tests {
             SubscriptionFilter::new(),
             tx1,
             &mut rx1,
-        );
+        )
+        .await;
         let (token2, _g2) = register(
             &registry,
             RequestId::Number(2),
@@ -451,7 +440,8 @@ mod tests {
             SubscriptionFilter::new(),
             tx2,
             &mut rx2,
-        );
+        )
+        .await;
 
         assert!(registry.cancel(&RequestId::Number(1)));
         assert!(token1.is_cancelled());
@@ -470,7 +460,8 @@ mod tests {
             SubscriptionFilter::new().with_tools_changed(),
             tx,
             &mut rx,
-        );
+        )
+        .await;
 
         drop(guard);
 
@@ -496,7 +487,8 @@ mod tests {
             SubscriptionFilter::new().with_tools_changed(),
             tx_a,
             &mut rx_a,
-        );
+        )
+        .await;
         let (_tb, _gb) = register(
             &registry,
             RequestId::Number(1),
@@ -504,7 +496,8 @@ mod tests {
             SubscriptionFilter::new().with_tools_changed(),
             tx_b,
             &mut rx_b,
-        );
+        )
+        .await;
 
         registry.broadcast(tool::commands::LIST_CHANGED, None);
 
@@ -530,7 +523,8 @@ mod tests {
             SubscriptionFilter::new().with_tools_changed(),
             tx_a,
             &mut rx_a,
-        );
+        )
+        .await;
         let (_tb, _gb) = register(
             &registry,
             RequestId::Number(1),
@@ -538,7 +532,8 @@ mod tests {
             SubscriptionFilter::new().with_tools_changed(),
             tx_b,
             &mut rx_b,
-        );
+        )
+        .await;
 
         drop(guard_a);
         registry.broadcast(tool::commands::LIST_CHANGED, None);
@@ -566,7 +561,8 @@ mod tests {
             SubscriptionFilter::new(),
             tx_a,
             &mut rx_a,
-        );
+        )
+        .await;
         let (token_b, _gb) = register(
             &registry,
             RequestId::Number(1),
@@ -574,7 +570,8 @@ mod tests {
             SubscriptionFilter::new(),
             tx_b,
             &mut rx_b,
-        );
+        )
+        .await;
 
         assert!(!registry.cancel(&RequestId::Number(1)));
         assert!(!token_a.is_cancelled());
@@ -586,7 +583,8 @@ mod tests {
         let (registry, _rx, _guard) = registry_with(
             RequestId::Number(1),
             SubscriptionFilter::new().with_resource("res://a"),
-        );
+        )
+        .await;
 
         assert!(registry.is_resource_subscribed(&Uri::from("res://a")));
         assert!(!registry.is_resource_subscribed(&Uri::from("res://b")));

--- a/neva/src/app/subscriptions.rs
+++ b/neva/src/app/subscriptions.rs
@@ -131,7 +131,7 @@ impl SubscriptionRegistry {
         let Some(key) = matching.next() else {
             return false;
         };
-        
+
         if matching.next().is_some() {
             #[cfg(feature = "tracing")]
             tracing::warn!(

--- a/neva/src/app/subscriptions.rs
+++ b/neva/src/app/subscriptions.rs
@@ -16,7 +16,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicU64, Ordering},
 };
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{Sender, error::TrySendError};
 use tokio_util::sync::CancellationToken;
 
 /// Notifications buffered per subscription before delivery starts dropping.
@@ -84,37 +84,87 @@ impl Drop for SubscriptionGuard {
     }
 }
 
+/// Why a subscription could not be opened.
+#[derive(Debug)]
+pub(crate) enum RegisterError {
+    /// The stream is gone -- the client disconnected before the handshake.
+    Closed,
+
+    /// The stream cannot take the acknowledgment. Since it is empty when
+    /// [`SubscriptionRegistry::register`] runs, this means a buffer too small
+    /// to carry a subscription at all.
+    Full,
+}
+
+impl From<TrySendError<Message>> for RegisterError {
+    fn from(err: TrySendError<Message>) -> Self {
+        match err {
+            TrySendError::Closed(_) => Self::Closed,
+            TrySendError::Full(_) => Self::Full,
+        }
+    }
+}
+
 impl SubscriptionRegistry {
-    /// Registers a subscription and returns its cancellation token together
-    /// with the guard that deregisters it.
+    /// Queues `ack` onto the subscription's stream and registers the
+    /// subscription, returning its cancellation token together with the guard
+    /// that deregisters it.
+    ///
     /// `session_id` is the transport session the subscription is bound to (the
     /// per-`POST` session id over HTTP, `None` over stdio).
+    ///
+    /// The acknowledgment is queued *here*, not by the caller, because the two
+    /// steps have to be atomic against [`Self::broadcast`] and only this type
+    /// can make them so. Both happen under the entry's write lock, which
+    /// `broadcast` must take to read the map, so every broadcast falls entirely
+    /// on one side or the other: before, when this subscription did not exist
+    /// yet and nothing was owed to it, or after, when its notification queues
+    /// behind an acknowledgment that is already in the stream.
+    ///
+    /// Doing it the obvious way instead -- queue the acknowledgment, then
+    /// register -- leaves a window that no amount of care in the caller closes:
+    /// the sink is drained concurrently (by the `POST` response stream over
+    /// HTTP, by the pump task over stdio), so the client can be reading the
+    /// acknowledgment off the wire while the entry still does not exist, and a
+    /// mutation in that instant is dropped by a subscription the client has
+    /// been told is live.
+    ///
+    /// # Errors
+    /// Returns [`RegisterError`] if the stream cannot take the acknowledgment.
+    /// Nothing is registered in that case: a subscription that cannot open is
+    /// not a subscription.
     pub(crate) fn register(
         &self,
         id: RequestId,
         session_id: Option<uuid::Uuid>,
         accepted: SubscriptionFilter,
         sink: Sender<Message>,
-    ) -> (CancellationToken, SubscriptionGuard) {
+        ack: Message,
+    ) -> Result<(CancellationToken, SubscriptionGuard), RegisterError> {
         let token = CancellationToken::new();
         let key = self.next_key.fetch_add(1, Ordering::Relaxed);
-        self.entries.insert(
-            key,
-            Subscription {
-                id,
-                session_id,
-                accepted,
-                sink,
-                token: token.clone(),
-            },
-        );
-        (
+
+        // Holds the shard's write lock for as long as it is alive, which is
+        // what makes the pair below atomic.
+        let slot = self.entries.entry(key);
+
+        sink.try_send(ack).map_err(RegisterError::from)?;
+
+        slot.insert(Subscription {
+            id,
+            session_id,
+            accepted,
+            sink,
+            token: token.clone(),
+        });
+
+        Ok((
             token,
             SubscriptionGuard {
                 key,
                 registry: self.clone(),
             },
-        )
+        ))
     }
 
     /// Cancels the subscription a `notifications/cancelled` names, if this
@@ -230,9 +280,47 @@ mod tests {
         SubscriptionGuard,
     ) {
         let registry = SubscriptionRegistry::default();
-        let (tx, rx) = channel::<Message>(8);
-        let (_token, guard) = registry.register(id, None, accepted, tx);
+        let (tx, mut rx) = channel::<Message>(8);
+        let (_token, guard) = register(&registry, id, None, accepted, tx, &mut rx);
         (registry, rx, guard)
+    }
+
+    /// Registers the way `Context::listen` does -- with the acknowledgment --
+    /// then takes it off the stream, so each test below is about what the
+    /// subscription carries *after* its handshake.
+    ///
+    /// Asserting on it here is the point: `register` queuing it is the only
+    /// thing that makes "acknowledgment first" hold against a broadcast racing
+    /// the registration.
+    fn register(
+        registry: &SubscriptionRegistry,
+        id: RequestId,
+        session_id: Option<uuid::Uuid>,
+        accepted: SubscriptionFilter,
+        tx: Sender<Message>,
+        rx: &mut tokio::sync::mpsc::Receiver<Message>,
+    ) -> (CancellationToken, SubscriptionGuard) {
+        let registered = registry
+            .register(id, session_id, accepted, tx, ack())
+            .expect("the sink must accept the acknowledgment");
+
+        let first = rx
+            .try_recv()
+            .expect("register must queue the acknowledgment");
+        assert_eq!(
+            method_of(&first),
+            crate::types::subscription::commands::ACKNOWLEDGED,
+            "the acknowledgment must be the first message on the stream"
+        );
+
+        registered
+    }
+
+    fn ack() -> Message {
+        Message::Notification(Notification::new(
+            crate::types::subscription::commands::ACKNOWLEDGED,
+            None,
+        ))
     }
 
     fn method_of(msg: &Message) -> String {
@@ -318,17 +406,21 @@ mod tests {
         let (tx1, mut rx1) = channel::<Message>(8);
         let (tx2, mut rx2) = channel::<Message>(8);
 
-        let (_t1, _g1) = registry.register(
+        let (_t1, _g1) = register(
+            &registry,
             RequestId::Number(1),
             None,
             SubscriptionFilter::new().with_tools_changed(),
             tx1,
+            &mut rx1,
         );
-        let (_t2, _g2) = registry.register(
+        let (_t2, _g2) = register(
+            &registry,
             RequestId::Number(2),
             None,
             SubscriptionFilter::new().with_prompts_changed(),
             tx2,
+            &mut rx2,
         );
 
         registry.broadcast(tool::commands::LIST_CHANGED, None);
@@ -341,13 +433,25 @@ mod tests {
     #[tokio::test]
     async fn it_cancels_only_the_named_subscription() {
         let registry = SubscriptionRegistry::default();
-        let (tx1, _rx1) = channel::<Message>(8);
-        let (tx2, _rx2) = channel::<Message>(8);
+        let (tx1, mut rx1) = channel::<Message>(8);
+        let (tx2, mut rx2) = channel::<Message>(8);
 
-        let (token1, _g1) =
-            registry.register(RequestId::Number(1), None, SubscriptionFilter::new(), tx1);
-        let (token2, _g2) =
-            registry.register(RequestId::Number(2), None, SubscriptionFilter::new(), tx2);
+        let (token1, _g1) = register(
+            &registry,
+            RequestId::Number(1),
+            None,
+            SubscriptionFilter::new(),
+            tx1,
+            &mut rx1,
+        );
+        let (token2, _g2) = register(
+            &registry,
+            RequestId::Number(2),
+            None,
+            SubscriptionFilter::new(),
+            tx2,
+            &mut rx2,
+        );
 
         assert!(registry.cancel(&RequestId::Number(1)));
         assert!(token1.is_cancelled());
@@ -359,11 +463,13 @@ mod tests {
     async fn it_deregisters_on_guard_drop() {
         let registry = SubscriptionRegistry::default();
         let (tx, mut rx) = channel::<Message>(8);
-        let (_token, guard) = registry.register(
+        let (_token, guard) = register(
+            &registry,
             RequestId::Number(1),
             None,
             SubscriptionFilter::new().with_tools_changed(),
             tx,
+            &mut rx,
         );
 
         drop(guard);
@@ -383,17 +489,21 @@ mod tests {
         let (tx_a, mut rx_a) = channel::<Message>(8);
         let (tx_b, mut rx_b) = channel::<Message>(8);
 
-        let (_ta, _ga) = registry.register(
+        let (_ta, _ga) = register(
+            &registry,
             RequestId::Number(1),
             Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new().with_tools_changed(),
             tx_a,
+            &mut rx_a,
         );
-        let (_tb, _gb) = registry.register(
+        let (_tb, _gb) = register(
+            &registry,
             RequestId::Number(1),
             Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new().with_tools_changed(),
             tx_b,
+            &mut rx_b,
         );
 
         registry.broadcast(tool::commands::LIST_CHANGED, None);
@@ -410,20 +520,24 @@ mod tests {
     #[tokio::test]
     async fn it_does_not_deregister_a_colliding_id_on_teardown() {
         let registry = SubscriptionRegistry::default();
-        let (tx_a, _rx_a) = channel::<Message>(8);
+        let (tx_a, mut rx_a) = channel::<Message>(8);
         let (tx_b, mut rx_b) = channel::<Message>(8);
 
-        let (_ta, guard_a) = registry.register(
+        let (_ta, guard_a) = register(
+            &registry,
             RequestId::Number(1),
             Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new().with_tools_changed(),
             tx_a,
+            &mut rx_a,
         );
-        let (_tb, _gb) = registry.register(
+        let (_tb, _gb) = register(
+            &registry,
             RequestId::Number(1),
             Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new().with_tools_changed(),
             tx_b,
+            &mut rx_b,
         );
 
         drop(guard_a);
@@ -442,20 +556,24 @@ mod tests {
     #[tokio::test]
     async fn it_refuses_to_cancel_a_session_bound_subscription() {
         let registry = SubscriptionRegistry::default();
-        let (tx_a, _rx_a) = channel::<Message>(8);
-        let (tx_b, _rx_b) = channel::<Message>(8);
+        let (tx_a, mut rx_a) = channel::<Message>(8);
+        let (tx_b, mut rx_b) = channel::<Message>(8);
 
-        let (token_a, _ga) = registry.register(
+        let (token_a, _ga) = register(
+            &registry,
             RequestId::Number(1),
             Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new(),
             tx_a,
+            &mut rx_a,
         );
-        let (token_b, _gb) = registry.register(
+        let (token_b, _gb) = register(
+            &registry,
             RequestId::Number(1),
             Some(uuid::Uuid::new_v4()),
             SubscriptionFilter::new(),
             tx_b,
+            &mut rx_b,
         );
 
         assert!(!registry.cancel(&RequestId::Number(1)));

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -3390,6 +3390,43 @@ mod listen_rejection_tests {
         );
     }
 
+    /// A cancel that never reached the wire ended nothing -- the connection
+    /// did. Reporting `Cancelled` for it would tell the caller a deliberate
+    /// stop happened where a connection loss did, and reconnect logic keys on
+    /// exactly that difference.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelling_after_a_disconnect_reports_abrupt() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_offside_notification(listener));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+        client.connect().await.expect("connect");
+
+        let mut subscription = client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect("listen");
+
+        client.disconnect().await.expect("disconnect");
+
+        assert!(
+            subscription.cancel().await.is_err(),
+            "a cancel has nowhere to go once the transport is gone"
+        );
+
+        let ended = tokio::time::timeout(std::time::Duration::from_secs(2), subscription.closed())
+            .await
+            .expect("closed() must not hang after a failed cancel");
+        assert!(
+            matches!(ended, crate::client::SubscriptionEnd::Abrupt),
+            "got {ended:?}"
+        );
+    }
+
     /// The same slot must come back when the handle is simply dropped.
     #[tokio::test(flavor = "multi_thread")]
     async fn dropping_the_handle_releases_the_request_slot() {

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1077,22 +1077,27 @@ impl Client {
         let ack = handler.watch_ack(&id, &notifications);
         let sender = handler.sender();
         let release = handler.subscription_release();
-        let listen = handler.send_listen(request).await;
-        let mut response = match listen {
+
+        // Armed before the send, not after it. `watch_ack` has already
+        // registered the waiter and the pending state, `send_listen` takes the
+        // untimed request slot before it awaits the transport, and that await
+        // is a suspension point like any other: a caller who drops this future
+        // (an outer `tokio::time::timeout`, a lost `select!` branch) runs none
+        // of the branches below, and everything registered so far would be left
+        // behind. Nothing between here and `watch_ack` awaits, so there is no
+        // gap left to fall into.
+        let guard =
+            subscription::EstablishmentGuard::new(id.clone(), release.clone(), sender.clone());
+
+        let mut response = match handler.send_listen(request).await {
             Ok(response) => response,
+            // Never reached the wire, so there is no stream to cancel -- only
+            // this client's own bookkeeping to drop.
             Err(err) => {
-                self.abandon_listen(&id).await;
+                guard.forget();
                 return Err(err);
             }
         };
-
-        // The request is on the wire, so from here every exit has to undo it --
-        // including the one with no code of its own: a caller who drops this
-        // future (an outer `tokio::time::timeout`, a lost `select!` branch)
-        // runs none of the branches below, and would leave the waiter, the
-        // filter, the untimed request slot and the peer's stream behind.
-        let guard =
-            subscription::EstablishmentGuard::new(id.clone(), release.clone(), sender.clone());
 
         // Race the acknowledgment against the request's own reply: a peer that
         // rejects the subscription outright -- `MethodNotFound`, an
@@ -1166,23 +1171,6 @@ impl Client {
             sender,
             release,
         ))
-    }
-
-    /// Gives up on a subscription that never got established.
-    ///
-    /// Dropping the local bookkeeping is not enough: the peer may be holding
-    /// the listen response open (that is precisely the case when establishment
-    /// times out), and a stream nobody is waiting for would keep draining --
-    /// its notifications reaching this client's handlers for a subscription
-    /// `listen` reported as failed, with the server-side entry alive for as
-    /// long as the connection is. So this cancels it exactly like
-    /// [`Subscription::cancel`] does.
-    #[cfg(not(feature = "legacy-spec"))]
-    async fn abandon_listen(&mut self, id: &RequestId) {
-        if let Some(handler) = self.handler.as_mut() {
-            handler.forget_listen(id);
-            let _ = handler.send_notification(subscription::cancelled(id)).await;
-        }
     }
 
     /// Subscribes to a resource on the server to receive notifications when it changes.
@@ -3845,10 +3833,11 @@ mod listen_rejection_tests {
 
         let mut client = Client::new().with_options(|opt| {
             opt.with_http(|http| http.bind(addr.to_string()))
-                // Short: the peer never acknowledges, so establishment ends
-                // by timing out, and the test is about what reached the
-                // handlers meanwhile.
-                .with_timeout(std::time::Duration::from_secs(2))
+                // Bounded, because the peer never acknowledges and
+                // establishment has to end by timing out -- but not tight: the
+                // same budget covers the `connect` above, which shares this
+                // client, and a loaded machine makes a short one flake.
+                .with_timeout(std::time::Duration::from_secs(5))
         });
         client.connect().await.expect("connect");
         client.subscribe(crate::types::tool::commands::LIST_CHANGED, move |_| {
@@ -4099,7 +4088,7 @@ mod listen_rejection_tests {
 
         let mut client = Client::new().with_options(|opt| {
             opt.with_http(|http| http.bind(addr.to_string()))
-                .with_timeout(std::time::Duration::from_secs(2))
+                .with_timeout(std::time::Duration::from_secs(30))
         });
         client.connect().await.expect("connect");
         client.subscribe(crate::types::tool::commands::LIST_CHANGED, move |_| {
@@ -4187,6 +4176,20 @@ mod listen_rejection_tests {
                     let _ = stream
                         .write_all(format!("data: {ack}\n\n").as_bytes())
                         .await;
+
+                    // Straight behind it, a notification squarely inside what
+                    // the client *did* ask for. The acknowledgment is on its way
+                    // to being rejected, so this must not reach the handlers
+                    // either -- intersecting the filter alone would let it.
+                    let in_filter = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": crate::types::tool::commands::LIST_CHANGED,
+                        "params": { "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id } }
+                    });
+                    let _ = stream
+                        .write_all(format!("data: {in_filter}\n\n").as_bytes())
+                        .await;
+
                     // Hold the stream open, the way a real subscription would.
                     tokio::time::sleep(std::time::Duration::from_secs(30)).await;
                     return;
@@ -4211,6 +4214,15 @@ mod listen_rejection_tests {
         });
         client.connect().await.expect("connect");
 
+        let tools = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let seen = tools.clone();
+        client.subscribe(crate::types::tool::commands::LIST_CHANGED, move |_| {
+            let seen = seen.clone();
+            async move {
+                seen.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        });
+
         let err = client
             .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
             .await
@@ -4220,6 +4232,15 @@ mod listen_rejection_tests {
         assert!(
             reported.contains("broader"),
             "the rejection must name the cause, got: {reported}"
+        );
+
+        // Nothing may have been delivered on the strength of an acknowledgment
+        // this call refuses -- not even a category it did ask for.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        assert_eq!(
+            tools.load(AtomicOrdering::SeqCst),
+            0,
+            "a subscription `listen` rejects must deliver nothing"
         );
     }
 
@@ -4287,11 +4308,11 @@ mod listen_rejection_tests {
 
         let mut client = Client::new().with_options(|opt| {
             opt.with_http(|http| http.bind(addr.to_string()))
-                // Short enough to keep the test quick, long enough to survive a
-                // loaded CI machine -- this budget covers the `connect` before
-                // the subscription as well, and the assertion below waits
-                // longer still.
-                .with_timeout(std::time::Duration::from_secs(2))
+                // Bounded, because establishment has to give up on its own --
+                // but not tight: this budget covers the `connect` before the
+                // subscription as well, and a loaded machine makes a short one
+                // flake. The assertion below waits longer still.
+                .with_timeout(std::time::Duration::from_secs(5))
         });
         client.connect().await.expect("connect");
 

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1074,8 +1074,9 @@ impl Client {
         // Watch for the acknowledgment before sending: it is the first thing
         // the server puts on the stream, and the receive loop drops one nobody
         // is waiting for.
-        let ack = handler.watch_ack(&id);
+        let ack = handler.watch_ack(&id, &notifications);
         let sender = handler.sender();
+        let release = handler.subscription_release();
         let listen = handler.send_listen(request).await;
         let mut response = match listen {
             Ok(response) => response,
@@ -1147,6 +1148,7 @@ impl Client {
             acknowledged,
             response,
             sender,
+            release,
         ))
     }
 
@@ -3347,6 +3349,196 @@ mod listen_rejection_tests {
                 }
             });
         }
+    }
+
+    /// A cancelled subscription is never answered, so nothing completes its
+    /// request slot -- and those slots carry no TTL, because a subscription may
+    /// legitimately stay open for hours. Whoever gives up on one has to release
+    /// it, or a client that opens and cancels subscriptions in a loop grows the
+    /// pending queue by one entry per cycle.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelling_releases_the_request_slot() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_offside_notification(listener));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+        client.connect().await.expect("connect");
+
+        let queued = |client: &Client| client.handler.as_ref().expect("connected").pending().len();
+
+        let idle = queued(&client);
+
+        let mut subscription = client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect("listen");
+        assert_eq!(
+            queued(&client),
+            idle + 1,
+            "the live subscription holds one slot"
+        );
+
+        subscription.cancel().await.expect("cancel");
+        assert_eq!(
+            queued(&client),
+            idle,
+            "cancelling must release the subscription's slot"
+        );
+    }
+
+    /// The same slot must come back when the handle is simply dropped.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dropping_the_handle_releases_the_request_slot() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_offside_notification(listener));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+        client.connect().await.expect("connect");
+
+        let queued = |client: &Client| client.handler.as_ref().expect("connected").pending().len();
+
+        let idle = queued(&client);
+        {
+            let _subscription = client
+                .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+                .await
+                .expect("listen");
+            assert_eq!(queued(&client), idle + 1);
+        }
+
+        assert_eq!(
+            queued(&client),
+            idle,
+            "dropping the handle must release the subscription's slot"
+        );
+    }
+
+    /// Acknowledges exactly what was asked for, then sends a tagged
+    /// notification of a category outside it.
+    async fn serve_offside_notification(listener: TcpListener) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                loop {
+                    let Some((_head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let method = msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default();
+
+                    if method == crate::commands::DISCOVER {
+                        let reply = serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {
+                                "supportedVersions": [crate::LATEST_PROTOCOL_VERSION],
+                                "capabilities": {
+                                    "tools": { "listChanged": true },
+                                    "prompts": { "listChanged": true }
+                                }
+                            }
+                        });
+                        write_json(&mut stream, &reply.to_string()).await;
+                        continue;
+                    }
+
+                    let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\n\r\n";
+                    let _ = stream.write_all(head.as_bytes()).await;
+
+                    // A correct acknowledgment: tools only, exactly as asked.
+                    let ack = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/subscriptions/acknowledged",
+                        "params": {
+                            "notifications": { "toolsListChanged": true },
+                            "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id }
+                        }
+                    });
+                    let _ = stream
+                        .write_all(format!("data: {ack}\n\n").as_bytes())
+                        .await;
+
+                    // ...then a category the filter never selected.
+                    let offside = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": crate::types::prompt::commands::LIST_CHANGED,
+                        "params": { "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id } }
+                    });
+                    let _ = stream
+                        .write_all(format!("data: {offside}\n\n").as_bytes())
+                        .await;
+
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    return;
+                }
+            });
+        }
+    }
+
+    /// A valid acknowledgment is a promise about the whole stream, not just its
+    /// first message. A peer that keeps it and then sends an off-filter
+    /// notification anyway must not reach the client's handlers -- they are
+    /// global and know nothing about which subscription a message came from.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn notifications_outside_the_acknowledged_filter_are_dropped() {
+        use std::sync::atomic::AtomicUsize;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_offside_notification(listener));
+
+        let tools = Arc::new(AtomicUsize::new(0));
+        let prompts = Arc::new(AtomicUsize::new(0));
+        let (tools_seen, prompts_seen) = (tools.clone(), prompts.clone());
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+        client.connect().await.expect("connect");
+        client.subscribe(crate::types::tool::commands::LIST_CHANGED, move |_| {
+            let seen = tools_seen.clone();
+            async move {
+                seen.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        });
+        client.subscribe(crate::types::prompt::commands::LIST_CHANGED, move |_| {
+            let seen = prompts_seen.clone();
+            async move {
+                seen.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        });
+
+        let _subscription = client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect("listen");
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        assert_eq!(
+            prompts.load(AtomicOrdering::SeqCst),
+            0,
+            "a notification outside the acknowledged filter must be dropped"
+        );
+        assert_eq!(
+            tools.load(AtomicOrdering::SeqCst),
+            0,
+            "and the in-filter categories are unaffected (none were sent)"
+        );
     }
 
     /// Answers `server/discover` normally, then acknowledges the subscription

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1076,25 +1076,59 @@ impl Client {
         // is waiting for.
         let ack = handler.watch_ack(&id);
         let sender = handler.sender();
-        let response = handler.send_listen(request).await.inspect_err(|_| {
+        let mut response = handler.send_listen(request).await.inspect_err(|_| {
             self.handler
                 .as_ref()
                 .expect("handler was borrowed above")
                 .abandon_listen(&id)
         })?;
 
+        // Race the acknowledgment against the request's own reply: a peer that
+        // rejects the subscription outright -- `MethodNotFound`, an
+        // authorization failure, invalid params -- answers instead of
+        // acknowledging, and waiting only on the acknowledgment would sit out
+        // the whole timeout and report that instead of the server's reason.
         let timeout = self.options.timeout;
-        let acknowledged = match tokio::time::timeout(timeout, ack).await {
+        let established = tokio::select! {
+            biased;
+            acknowledged = ack => Ok(acknowledged),
+            answered = &mut response => Err(match answered {
+                Ok(shared::PendingResponse::Response(resp)) => match resp {
+                    // An error reply is the server's own explanation; surface it.
+                    Response::Err(err) => err.error.into(),
+                    // A success reply this early is the graceful-close result
+                    // for a subscription that never carried anything.
+                    Response::Ok(_) => Error::new(
+                        ErrorCode::InternalError,
+                        "Subscription ended before it was acknowledged",
+                    ),
+                },
+                Ok(shared::PendingResponse::Timeout) | Err(_) => {
+                    Error::new(ErrorCode::Timeout, "Subscription was not acknowledged")
+                }
+            }),
+            _ = tokio::time::sleep(timeout) => Err(Error::new(
+                ErrorCode::Timeout,
+                "Subscription was not acknowledged",
+            )),
+        };
+
+        let acknowledged = match established {
             Ok(Ok(filter)) => filter,
-            _ => {
+            // The waiter's sender was dropped: the receive loop is gone.
+            Ok(Err(_)) => {
                 self.handler
                     .as_ref()
                     .expect("handler was borrowed above")
                     .abandon_listen(&id);
-                return Err(Error::new(
-                    ErrorCode::Timeout,
-                    "Subscription was not acknowledged",
-                ));
+                return Err(Error::new(ErrorCode::InternalError, "Connection closed"));
+            }
+            Err(err) => {
+                self.handler
+                    .as_ref()
+                    .expect("handler was borrowed above")
+                    .abandon_listen(&id);
+                return Err(err);
             }
         };
 
@@ -3189,5 +3223,137 @@ mod fallback_tasks_capability_tests {
     fn no_tasks_capability_resolves_to_none() {
         let client = client_with_capabilities(json!({ "tools": {} }));
         assert!(!client.is_server_supports_tasks());
+    }
+}
+
+/// Establishing a subscription against a peer that answers instead of
+/// acknowledging. Driven by a raw-HTTP mock so the reply can be an outright
+/// rejection, which a real neva server -- whose `subscriptions/listen` handler
+/// is always registered -- never produces.
+#[cfg(all(test, feature = "http-client", not(feature = "legacy-spec")))]
+mod listen_rejection_tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    const REASON: &str = "subscriptions are disabled here";
+
+    async fn read_request(stream: &mut TcpStream) -> Option<(String, String)> {
+        let mut buf = Vec::new();
+        let mut tmp = [0u8; 2048];
+        let header_end = loop {
+            let n = stream.read(&mut tmp).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+            if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                break pos + 4;
+            }
+            if buf.len() > 65536 {
+                return None;
+            }
+        };
+        let head = String::from_utf8_lossy(&buf[..header_end]).to_string();
+        let content_length = head
+            .lines()
+            .find_map(|l| {
+                l.to_ascii_lowercase()
+                    .strip_prefix("content-length:")
+                    .map(|v| v.trim().parse::<usize>().ok())
+            })
+            .flatten()
+            .unwrap_or(0);
+        while buf.len() < header_end + content_length {
+            let n = stream.read(&mut tmp).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            buf.extend_from_slice(&tmp[..n]);
+        }
+        let body =
+            String::from_utf8_lossy(&buf[header_end..header_end + content_length]).to_string();
+        Some((head, body))
+    }
+
+    async fn write_json(stream: &mut TcpStream, body: &str) {
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: keep-alive\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = stream.write_all(resp.as_bytes()).await;
+    }
+
+    /// Answers `server/discover` normally, then rejects `subscriptions/listen`
+    /// with a JSON-RPC error and never sends an acknowledgment.
+    async fn serve_rejecting(listener: TcpListener) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                loop {
+                    let Some((_head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let method = msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default();
+
+                    let reply = if method == crate::commands::DISCOVER {
+                        serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {
+                                "supportedVersions": [crate::LATEST_PROTOCOL_VERSION],
+                                "capabilities": { "tools": { "listChanged": true } }
+                            }
+                        })
+                    } else {
+                        serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "error": { "code": -32600, "message": REASON }
+                        })
+                    };
+                    write_json(&mut stream, &reply.to_string()).await;
+                }
+            });
+        }
+    }
+
+    /// A rejected `subscriptions/listen` must surface the server's own error
+    /// immediately. Waiting only on the acknowledgment would sit out the full
+    /// request timeout and report *that* instead -- the peer's reason lost, and
+    /// the caller blocked for no reason.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn listen_surfaces_an_immediate_rejection() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_rejecting(listener));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                // Generous on purpose: a timeout would be unmistakable below.
+                .with_timeout(std::time::Duration::from_secs(30))
+        });
+        client.connect().await.expect("connect");
+
+        let started = tokio::time::Instant::now();
+        let err = client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect_err("a rejected subscription must fail");
+
+        let reported = format!("{err:?}");
+        assert!(
+            reported.contains(REASON),
+            "the server's own error must survive, got: {reported}"
+        );
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(5),
+            "the rejection must not wait out the request timeout"
+        );
     }
 }

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1076,12 +1076,14 @@ impl Client {
         // is waiting for.
         let ack = handler.watch_ack(&id);
         let sender = handler.sender();
-        let mut response = handler.send_listen(request).await.inspect_err(|_| {
-            self.handler
-                .as_ref()
-                .expect("handler was borrowed above")
-                .abandon_listen(&id)
-        })?;
+        let listen = handler.send_listen(request).await;
+        let mut response = match listen {
+            Ok(response) => response,
+            Err(err) => {
+                self.abandon_listen(&id).await;
+                return Err(err);
+            }
+        };
 
         // Race the acknowledgment against the request's own reply: a peer that
         // rejects the subscription outright -- `MethodNotFound`, an
@@ -1117,20 +1119,27 @@ impl Client {
             Ok(Ok(filter)) => filter,
             // The waiter's sender was dropped: the receive loop is gone.
             Ok(Err(_)) => {
-                self.handler
-                    .as_ref()
-                    .expect("handler was borrowed above")
-                    .abandon_listen(&id);
+                self.abandon_listen(&id).await;
                 return Err(Error::new(ErrorCode::InternalError, "Connection closed"));
             }
             Err(err) => {
-                self.handler
-                    .as_ref()
-                    .expect("handler was borrowed above")
-                    .abandon_listen(&id);
+                self.abandon_listen(&id).await;
                 return Err(err);
             }
         };
+
+        // The server may narrow the filter -- that is the whole point of the
+        // acknowledgment -- but it must not widen it. Notifications are
+        // dispatched to the client's own handlers with no per-subscription
+        // filtering, so an acknowledgment claiming a category or URI this call
+        // never asked for would deliver events outside the requested scope.
+        if !acknowledged.is_subset_of(&notifications) {
+            self.abandon_listen(&id).await;
+            return Err(Error::new(
+                ErrorCode::InvalidRequest,
+                "Server acknowledged a subscription broader than the one requested",
+            ));
+        }
 
         Ok(Subscription::new(
             id,
@@ -1139,6 +1148,23 @@ impl Client {
             response,
             sender,
         ))
+    }
+
+    /// Gives up on a subscription that never got established.
+    ///
+    /// Dropping the local bookkeeping is not enough: the peer may be holding
+    /// the listen response open (that is precisely the case when establishment
+    /// times out), and a stream nobody is waiting for would keep draining --
+    /// its notifications reaching this client's handlers for a subscription
+    /// `listen` reported as failed, with the server-side entry alive for as
+    /// long as the connection is. So this cancels it exactly like
+    /// [`Subscription::cancel`] does.
+    #[cfg(not(feature = "legacy-spec"))]
+    async fn abandon_listen(&mut self, id: &RequestId) {
+        if let Some(handler) = self.handler.as_mut() {
+            handler.forget_listen(id);
+            let _ = handler.send_notification(subscription::cancelled(id)).await;
+        }
     }
 
     /// Subscribes to a resource on the server to receive notifications when it changes.
@@ -3226,10 +3252,9 @@ mod fallback_tasks_capability_tests {
     }
 }
 
-/// Establishing a subscription against a peer that answers instead of
-/// acknowledging. Driven by a raw-HTTP mock so the reply can be an outright
-/// rejection, which a real neva server -- whose `subscriptions/listen` handler
-/// is always registered -- never produces.
+/// Establishing a subscription against a peer that misbehaves: answering
+/// instead of acknowledging, or acknowledging more than was asked for. Driven
+/// by a raw-HTTP mock, since a real neva server produces neither.
 #[cfg(all(test, feature = "http-client", not(feature = "legacy-spec")))]
 mod listen_rejection_tests {
     use super::*;
@@ -3321,6 +3346,93 @@ mod listen_rejection_tests {
                 }
             });
         }
+    }
+
+    /// Answers `server/discover` normally, then acknowledges the subscription
+    /// with a *broader* filter than the client asked for.
+    async fn serve_overbroad_ack(listener: TcpListener) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                loop {
+                    let Some((_head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let method = msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default();
+
+                    if method == crate::commands::DISCOVER {
+                        let reply = serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {
+                                "supportedVersions": [crate::LATEST_PROTOCOL_VERSION],
+                                "capabilities": {
+                                    "tools": { "listChanged": true },
+                                    "prompts": { "listChanged": true }
+                                }
+                            }
+                        });
+                        write_json(&mut stream, &reply.to_string()).await;
+                        continue;
+                    }
+
+                    // The client asked for tools only; claim prompts as well.
+                    let ack = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/subscriptions/acknowledged",
+                        "params": {
+                            "notifications": {
+                                "toolsListChanged": true,
+                                "promptsListChanged": true
+                            },
+                            "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id }
+                        }
+                    });
+                    let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\n\r\n";
+                    let _ = stream.write_all(head.as_bytes()).await;
+                    let _ = stream
+                        .write_all(format!("data: {ack}\n\n").as_bytes())
+                        .await;
+                    // Hold the stream open, the way a real subscription would.
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    return;
+                }
+            });
+        }
+    }
+
+    /// An acknowledgment may narrow the requested filter -- that is what it is
+    /// for -- but never widen it. Notifications reach the client's global
+    /// handlers with no per-subscription filtering, so accepting an overbroad
+    /// acknowledgment would deliver events this call never asked for.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn listen_rejects_an_overbroad_acknowledgment() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_overbroad_ack(listener));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+        client.connect().await.expect("connect");
+
+        let err = client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect_err("an overbroad acknowledgment must be rejected");
+
+        let reported = format!("{err:?}");
+        assert!(
+            reported.contains("broader"),
+            "the rejection must name the cause, got: {reported}"
+        );
     }
 
     /// A rejected `subscriptions/listen` must surface the server's own error

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -3258,6 +3258,7 @@ mod fallback_tasks_capability_tests {
 #[cfg(all(test, feature = "http-client", not(feature = "legacy-spec")))]
 mod listen_rejection_tests {
     use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::{TcpListener, TcpStream};
 
@@ -3432,6 +3433,93 @@ mod listen_rejection_tests {
         assert!(
             reported.contains("broader"),
             "the rejection must name the cause, got: {reported}"
+        );
+    }
+
+    /// Answers `server/discover` normally, then accepts the listen `POST` and
+    /// never replies at all -- headers included. Records whether that
+    /// connection was closed by the peer.
+    async fn serve_stalled_listen(listener: TcpListener, closed: Arc<AtomicBool>) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let closed = closed.clone();
+            tokio::spawn(async move {
+                loop {
+                    let Some((_head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let method = msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default();
+
+                    if method == crate::commands::DISCOVER {
+                        let reply = serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {
+                                "supportedVersions": [crate::LATEST_PROTOCOL_VERSION],
+                                "capabilities": { "tools": { "listChanged": true } }
+                            }
+                        });
+                        write_json(&mut stream, &reply.to_string()).await;
+                        continue;
+                    }
+
+                    // Sit on the request without sending so much as a status
+                    // line, and watch for the client hanging up.
+                    let mut probe = [0u8; 1];
+                    let hung_up = tokio::time::timeout(
+                        std::time::Duration::from_secs(10),
+                        stream.read(&mut probe),
+                    )
+                    .await
+                    .is_ok_and(|read| matches!(read, Ok(0)));
+                    if hung_up {
+                        closed.store(true, AtomicOrdering::SeqCst);
+                    }
+                    return;
+                }
+            });
+        }
+    }
+
+    /// A subscription can be cancelled while the peer is still sitting on the
+    /// response headers -- establishment timing out is exactly that. The abort
+    /// handle has to exist by then, or the cancel finds nothing to close and the
+    /// task starts draining an orphaned stream once the headers finally arrive.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn listen_closes_a_stalled_request_on_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let closed = Arc::new(AtomicBool::new(false));
+        tokio::spawn(serve_stalled_listen(listener, closed.clone()));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                // Short enough to keep the test quick, long enough to survive a
+                // loaded CI machine -- the assertion below waits far longer.
+                .with_timeout(std::time::Duration::from_secs(1))
+        });
+        client.connect().await.expect("connect");
+
+        client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect_err("a stalled subscription must not establish");
+
+        // Giving up has to reach the wire: the peer sees the connection go away
+        // instead of holding a request nobody is waiting for.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !closed.load(AtomicOrdering::SeqCst) && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            closed.load(AtomicOrdering::SeqCst),
+            "abandoning an unacknowledged subscription must close its request"
         );
     }
 

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1086,6 +1086,14 @@ impl Client {
             }
         };
 
+        // The request is on the wire, so from here every exit has to undo it --
+        // including the one with no code of its own: a caller who drops this
+        // future (an outer `tokio::time::timeout`, a lost `select!` branch)
+        // runs none of the branches below, and would leave the waiter, the
+        // filter, the untimed request slot and the peer's stream behind.
+        let guard =
+            subscription::EstablishmentGuard::new(id.clone(), release.clone(), sender.clone());
+
         // Race the acknowledgment against the request's own reply: a peer that
         // rejects the subscription outright -- `MethodNotFound`, an
         // authorization failure, invalid params -- answers instead of
@@ -1125,11 +1133,11 @@ impl Client {
             Ok(Ok(filter)) => filter,
             // The waiter's sender was dropped: the receive loop is gone.
             Ok(Err(_)) => {
-                self.abandon_listen(&id).await;
+                guard.abandon().await;
                 return Err(Error::new(ErrorCode::InternalError, "Connection closed"));
             }
             Err(err) => {
-                self.abandon_listen(&id).await;
+                guard.abandon().await;
                 return Err(err);
             }
         };
@@ -1140,12 +1148,15 @@ impl Client {
         // filtering, so an acknowledgment claiming a category or URI this call
         // never asked for would deliver events outside the requested scope.
         if !acknowledged.is_subset_of(&notifications) {
-            self.abandon_listen(&id).await;
+            guard.abandon().await;
             return Err(Error::new(
                 ErrorCode::InvalidRequest,
                 "Server acknowledged a subscription broader than the one requested",
             ));
         }
+
+        // The handle takes over from here.
+        guard.disarm();
 
         Ok(Subscription::new(
             id,
@@ -3392,6 +3403,57 @@ mod listen_rejection_tests {
             queued(&client),
             idle,
             "cancelling must release the subscription's slot"
+        );
+    }
+
+    /// A caller who drops the `listen` future -- an outer `timeout`, a lost
+    /// `select!` branch -- runs none of the error paths inside it, so the
+    /// bookkeeping and the peer's stream would be left behind by an
+    /// establishment that never returned anything to end them with.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dropping_the_listen_future_abandons_the_subscription() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let closed = Arc::new(AtomicBool::new(false));
+        tokio::spawn(serve_stalled_listen(listener, closed.clone()));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                // Far longer than this test waits: the establishment must be
+                // ended by the dropped future, not by `listen`'s own timeout.
+                .with_timeout(std::time::Duration::from_secs(30))
+        });
+        client.connect().await.expect("connect");
+
+        let queued = |client: &Client| client.handler.as_ref().expect("connected").pending().len();
+        let idle = queued(&client);
+
+        // The caller gives up on its own schedule and never sees a result.
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(300),
+                client.listen(crate::types::SubscriptionFilter::new().with_tools_changed()),
+            )
+            .await
+            .is_err(),
+            "the peer never acknowledges, so the outer timeout must fire"
+        );
+
+        assert_eq!(
+            queued(&client),
+            idle,
+            "a dropped establishment must release its request slot"
+        );
+
+        // And it has to reach the wire too: the peer is still holding the
+        // listen request open, waiting for someone who is no longer there.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while !closed.load(AtomicOrdering::SeqCst) && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            closed.load(AtomicOrdering::SeqCst),
+            "a dropped establishment must close the stream it opened"
         );
     }
 

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -3541,6 +3541,132 @@ mod listen_rejection_tests {
         );
     }
 
+    /// Answers `server/discover` normally, then delivers the whole
+    /// subscription -- acknowledgment, an in-filter notification and an
+    /// off-filter one -- inside a single JSON-RPC batch.
+    async fn serve_batched_frames(listener: TcpListener) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+
+            tokio::spawn(async move {
+                loop {
+                    let Some((_head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let method = msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default();
+
+                    if method == crate::commands::DISCOVER {
+                        let reply = serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {
+                                "supportedVersions": [crate::LATEST_PROTOCOL_VERSION],
+                                "capabilities": {
+                                    "tools": { "listChanged": true },
+                                    "prompts": { "listChanged": true }
+                                }
+                            }
+                        });
+
+                        write_json(&mut stream, &reply.to_string()).await;
+                        continue;
+                    }
+
+                    let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\n\r\n";
+                    let _ = stream.write_all(head.as_bytes()).await;
+
+                    let batch = serde_json::json!([
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "notifications/subscriptions/acknowledged",
+                            "params": {
+                                "notifications": { "toolsListChanged": true },
+                                "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id }
+                            }
+                        },
+                        {
+                            "jsonrpc": "2.0",
+                            "method": crate::types::tool::commands::LIST_CHANGED,
+                            "params": { "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id } }
+                        },
+                        {
+                            "jsonrpc": "2.0",
+                            "method": crate::types::prompt::commands::LIST_CHANGED,
+                            "params": { "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id } }
+                        }
+                    ]);
+                    let _ = stream
+                        .write_all(format!("data: {batch}\n\n").as_bytes())
+                        .await;
+
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    return;
+                }
+            });
+        }
+    }
+
+    /// Batching is a framing choice of the peer's. An acknowledgment sent that
+    /// way still has to establish the subscription, and a tagged notification
+    /// sent that way still has to face the filter it was accepted under.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn batched_subscription_frames_go_through_the_same_gate() {
+        use std::sync::atomic::AtomicUsize;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_batched_frames(listener));
+
+        let tools = Arc::new(AtomicUsize::new(0));
+        let prompts = Arc::new(AtomicUsize::new(0));
+        let (tools_seen, prompts_seen) = (tools.clone(), prompts.clone());
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(2))
+        });
+        client.connect().await.expect("connect");
+        client.subscribe(crate::types::tool::commands::LIST_CHANGED, move |_| {
+            let seen = tools_seen.clone();
+            async move {
+                seen.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        });
+        client.subscribe(crate::types::prompt::commands::LIST_CHANGED, move |_| {
+            let seen = prompts_seen.clone();
+            async move {
+                seen.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        });
+
+        // A batched acknowledgment has to resolve `listen`, not leave it
+        // waiting out the establishment timeout.
+        let _subscription = client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect("a batched acknowledgment must establish the subscription");
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        assert_eq!(
+            tools.load(AtomicOrdering::SeqCst),
+            1,
+            "an in-filter batched notification must be delivered"
+        );
+        assert_eq!(
+            prompts.load(AtomicOrdering::SeqCst),
+            0,
+            "an off-filter batched notification must be dropped"
+        );
+    }
+
     /// Answers `server/discover` normally, then acknowledges the subscription
     /// with a *broader* filter than the client asked for.
     async fn serve_overbroad_ack(listener: TcpListener) {

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1022,7 +1022,9 @@ impl Client {
     /// acknowledged the filter. Notifications delivered on the stream are
     /// dispatched to the handlers registered with [`Self::subscribe`] and its
     /// helpers ([`Self::on_tools_changed`] and friends), so those must be in
-    /// place before listening.
+    /// place before listening -- and, for the capability-gated helpers, after
+    /// [`Self::connect`], which is what discovers the capabilities they assert
+    /// on.
     ///
     /// The returned [`Subscription`] carries the accepted filter -- the server
     /// silently drops types it does not advertise -- and ends the stream on
@@ -1035,8 +1037,8 @@ impl Client {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Error> {
     ///     let mut client = Client::new();
-    ///     client.on_tools_changed(|_| async { println!("tools changed"); });
     ///     client.connect().await?;
+    ///     client.on_tools_changed(|_| async { println!("tools changed"); });
     ///
     ///     let subscription = client
     ///         .listen(SubscriptionFilter::new().with_tools_changed())

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -1106,9 +1106,14 @@ impl Client {
                         "Subscription ended before it was acknowledged",
                     ),
                 },
-                Ok(shared::PendingResponse::Timeout) | Err(_) => {
+                Ok(shared::PendingResponse::Timeout) => {
                     Error::new(ErrorCode::Timeout, "Subscription was not acknowledged")
                 }
+                // The slot's sender was dropped: the receive loop released it
+                // on its way out, so the transport is gone. That is a lost
+                // connection, not a peer that would not acknowledge, and
+                // callers act on the two differently.
+                Err(_) => Error::new(ErrorCode::InternalError, "Connection closed"),
             }),
             _ = tokio::time::sleep(timeout) => Err(Error::new(
                 ErrorCode::Timeout,
@@ -3578,6 +3583,146 @@ mod listen_rejection_tests {
         );
     }
 
+    /// Answers `server/discover` normally, acknowledges the subscription, then
+    /// pushes a subscribable notification with no subscription id on it.
+    async fn serve_untagged_notification(listener: TcpListener) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                loop {
+                    let Some((_head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let method = msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default();
+
+                    if method == crate::commands::DISCOVER {
+                        let reply = serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {
+                                "supportedVersions": [crate::LATEST_PROTOCOL_VERSION],
+                                "capabilities": { "tools": { "listChanged": true } }
+                            }
+                        });
+                        write_json(&mut stream, &reply.to_string()).await;
+                        continue;
+                    }
+
+                    let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\n\r\n";
+                    let _ = stream.write_all(head.as_bytes()).await;
+
+                    let ack = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/subscriptions/acknowledged",
+                        "params": {
+                            "notifications": { "toolsListChanged": true },
+                            "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id }
+                        }
+                    });
+                    let _ = stream
+                        .write_all(format!("data: {ack}\n\n").as_bytes())
+                        .await;
+
+                    // In the accepted filter, but with nothing tying it to the
+                    // subscription that accepted it.
+                    let untagged = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": crate::types::tool::commands::LIST_CHANGED
+                    });
+                    let _ = stream
+                        .write_all(format!("data: {untagged}\n\n").as_bytes())
+                        .await;
+
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    return;
+                }
+            });
+        }
+    }
+
+    /// Under MCP 2026-07-28 a subscribable notification travels on a
+    /// subscription and nowhere else. One that arrives without a subscription
+    /// id has nothing to check it against, so it cannot be admitted just
+    /// because the client happens to have asked for that category somewhere.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn untagged_subscribable_notifications_are_dropped() {
+        use std::sync::atomic::AtomicUsize;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_untagged_notification(listener));
+
+        let tools = Arc::new(AtomicUsize::new(0));
+        let seen = tools.clone();
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(5))
+        });
+        client.connect().await.expect("connect");
+        client.subscribe(crate::types::tool::commands::LIST_CHANGED, move |_| {
+            let seen = seen.clone();
+            async move {
+                seen.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        });
+
+        let _subscription = client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect("listen");
+
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+
+        assert_eq!(
+            tools.load(AtomicOrdering::SeqCst),
+            0,
+            "a subscription-only notification with no subscription id must be dropped"
+        );
+    }
+
+    /// A transport that dies while `listen` is still waiting for its
+    /// acknowledgment is a lost connection, not a peer that would not
+    /// acknowledge -- and callers act on those differently.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn listen_reports_a_lost_transport_as_a_connection_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_stalled_listen(
+            listener,
+            Arc::new(AtomicBool::new(false)),
+        ));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                // Long enough that a timeout cannot be what ends the wait.
+                .with_timeout(std::time::Duration::from_secs(30))
+        });
+        client.connect().await.expect("connect");
+
+        let token = client.handler.as_ref().expect("connected").cancellation();
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            token.cancel();
+        });
+
+        let err = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            client.listen(crate::types::SubscriptionFilter::new().with_tools_changed()),
+        )
+        .await
+        .expect("a dead transport must not be waited out")
+        .expect_err("a dead transport cannot establish a subscription");
+
+        assert_eq!(err.code, ErrorCode::InternalError, "got {err:?}");
+    }
+
     /// Answers `server/discover` normally, then delivers the whole
     /// subscription -- acknowledgment, an in-filter notification and an
     /// off-filter one -- inside a single JSON-RPC batch.
@@ -3856,8 +4001,10 @@ mod listen_rejection_tests {
         let mut client = Client::new().with_options(|opt| {
             opt.with_http(|http| http.bind(addr.to_string()))
                 // Short enough to keep the test quick, long enough to survive a
-                // loaded CI machine -- the assertion below waits far longer.
-                .with_timeout(std::time::Duration::from_secs(1))
+                // loaded CI machine -- this budget covers the `connect` before
+                // the subscription as well, and the assertion below waits
+                // longer still.
+                .with_timeout(std::time::Duration::from_secs(2))
         });
         client.connect().await.expect("connect");
 

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -3776,6 +3776,100 @@ mod listen_rejection_tests {
         );
     }
 
+    /// Answers `server/discover` normally, then puts a correctly tagged,
+    /// in-filter notification on the stream *ahead* of the acknowledgment.
+    async fn serve_notification_before_ack(listener: TcpListener) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            tokio::spawn(async move {
+                loop {
+                    let Some((_head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let method = msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default();
+
+                    if method == crate::commands::DISCOVER {
+                        let reply = serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {
+                                "supportedVersions": [crate::LATEST_PROTOCOL_VERSION],
+                                "capabilities": { "tools": { "listChanged": true } }
+                            }
+                        });
+                        write_json(&mut stream, &reply.to_string()).await;
+                        continue;
+                    }
+
+                    let head = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\n\r\n";
+                    let _ = stream.write_all(head.as_bytes()).await;
+
+                    // Correctly tagged, squarely inside what was requested --
+                    // and out of order.
+                    let early = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "method": crate::types::tool::commands::LIST_CHANGED,
+                        "params": { "_meta": { crate::types::SUBSCRIPTION_ID_KEY: id } }
+                    });
+                    let _ = stream
+                        .write_all(format!("data: {early}\n\n").as_bytes())
+                        .await;
+
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    return;
+                }
+            });
+        }
+    }
+
+    /// The acknowledgment comes first or the subscription is not established.
+    /// A peer that streams before acknowledging is streaming from a
+    /// subscription `listen` goes on to report as failed -- its events must not
+    /// have reached the handlers in the meantime.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn notifications_before_the_acknowledgment_are_dropped() {
+        use std::sync::atomic::AtomicUsize;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(serve_notification_before_ack(listener));
+
+        let tools = Arc::new(AtomicUsize::new(0));
+        let seen = tools.clone();
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                // Short: the peer never acknowledges, so establishment ends
+                // by timing out, and the test is about what reached the
+                // handlers meanwhile.
+                .with_timeout(std::time::Duration::from_secs(2))
+        });
+        client.connect().await.expect("connect");
+        client.subscribe(crate::types::tool::commands::LIST_CHANGED, move |_| {
+            let seen = seen.clone();
+            async move {
+                seen.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        });
+
+        client
+            .listen(crate::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect_err("a peer that never acknowledges must not establish");
+
+        assert_eq!(
+            tools.load(AtomicOrdering::SeqCst),
+            0,
+            "a notification sent before the acknowledgment must be dropped"
+        );
+    }
+
     /// Answers `server/discover` normally, acknowledges the subscription, then
     /// pushes a subscribable notification with no subscription id on it.
     async fn serve_untagged_notification(listener: TcpListener) {

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -3406,6 +3406,137 @@ mod listen_rejection_tests {
         );
     }
 
+    /// A cancel written immediately behind a listen -- which is exactly what a
+    /// dropped establishment writes -- has to find the stream it names. The
+    /// abort handle is registered by the connection loop rather than by the
+    /// task it spawns, so the two are ordered by the wire, not by the
+    /// scheduler.
+    ///
+    /// A single worker on purpose: it pins the interleaving this is about.
+    /// Both messages are queued before the connection loop runs, so it reads
+    /// the cancel on the turn right after spawning the listen, while that task
+    /// has had no chance to run. (One worker rather than `current_thread`
+    /// because connecting uses `block_in_place`, which the current-thread
+    /// runtime refuses.)
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_cancel_queued_behind_a_listen_still_closes_the_stream() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let opened = Arc::new(AtomicBool::new(false));
+        let hung_up = Arc::new(AtomicBool::new(false));
+        tokio::spawn(serve_orphan_watch(
+            listener,
+            opened.clone(),
+            hung_up.clone(),
+        ));
+
+        let mut client = Client::new().with_options(|opt| {
+            opt.with_http(|http| http.bind(addr.to_string()))
+                .with_timeout(std::time::Duration::from_secs(30))
+        });
+        client.connect().await.expect("connect");
+
+        use crate::transport::Sender as _;
+
+        let id = RequestId::Number(99);
+        let mut sender = client.handler.as_ref().expect("connected").sender();
+
+        let listen = Request::new(
+            Some(id.clone()),
+            crate::types::subscription::commands::LISTEN,
+            Some(SubscriptionsListenRequestParams::new(
+                crate::types::SubscriptionFilter::new().with_tools_changed(),
+            )),
+        );
+        sender.send(listen.into()).await.expect("send listen");
+        sender
+            .send(subscription::cancelled(&id).into())
+            .await
+            .expect("send cancel");
+
+        // The abort may land before the POST is even written, so what is
+        // asserted is the outcome rather than one particular mechanism: the
+        // peer must not be left holding this listen open. Without the fix the
+        // cancel finds no handle, the request goes out, and the stream drains
+        // for as long as the connection lives.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        while !hung_up.load(AtomicOrdering::SeqCst) && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
+        assert!(
+            !opened.load(AtomicOrdering::SeqCst) || hung_up.load(AtomicOrdering::SeqCst),
+            "a cancel arriving right behind its listen left the peer holding an orphaned stream"
+        );
+    }
+
+    /// Answers `server/discover`, then holds any other request open and reports
+    /// both that it saw one and whether the client ever hung up on it.
+    async fn serve_orphan_watch(
+        listener: TcpListener,
+        opened: Arc<AtomicBool>,
+        hung_up: Arc<AtomicBool>,
+    ) {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let (opened, hung_up) = (opened.clone(), hung_up.clone());
+            tokio::spawn(async move {
+                loop {
+                    let Some((_head, body)) = read_request(&mut stream).await else {
+                        return;
+                    };
+
+                    let msg: serde_json::Value = serde_json::from_str(&body).unwrap_or_default();
+                    let id = msg.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                    let method = msg
+                        .get("method")
+                        .and_then(|m| m.as_str())
+                        .unwrap_or_default();
+
+                    if method == crate::commands::DISCOVER {
+                        let reply = serde_json::json!({
+                            "jsonrpc": "2.0", "id": id,
+                            "result": {
+                                "supportedVersions": [crate::LATEST_PROTOCOL_VERSION],
+                                "capabilities": { "tools": { "listChanged": true } }
+                            }
+                        });
+                        write_json(&mut stream, &reply.to_string()).await;
+                        continue;
+                    }
+
+                    // Anything else -- the cancel notification travels on its
+                    // own `POST` -- is answered and forgotten; only the listen
+                    // is the stream this test is about.
+                    if method != crate::types::subscription::commands::LISTEN {
+                        let _ = stream
+                            .write_all(
+                                b"HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: keep-alive\r\n\r\n",
+                            )
+                            .await;
+                        continue;
+                    }
+
+                    opened.store(true, AtomicOrdering::SeqCst);
+
+                    let mut probe = [0u8; 1];
+                    if let Ok(Ok(0)) = tokio::time::timeout(
+                        std::time::Duration::from_secs(3),
+                        stream.read(&mut probe),
+                    )
+                    .await
+                    {
+                        hung_up.store(true, AtomicOrdering::SeqCst);
+                    }
+
+                    return;
+                }
+            });
+        }
+    }
+
     /// A caller who drops the `listen` future -- an outer `timeout`, a lost
     /// `select!` branch -- runs none of the error paths inside it, so the
     /// bookkeeping and the peer's stream would be left behind by an

--- a/neva/src/client.rs
+++ b/neva/src/client.rs
@@ -18,6 +18,8 @@ use crate::types::{
     resource::{SubscribeRequestParams, UnsubscribeRequestParams},
 };
 use crate::types::{ClientCapabilities, InitializeRequestParams, InitializeResult};
+#[cfg(not(feature = "legacy-spec"))]
+use crate::types::{SubscriptionFilter, SubscriptionsListenRequestParams};
 use handler::RequestHandler;
 use options::McpOptions;
 use serde::Serialize;
@@ -43,10 +45,14 @@ mod handler;
 mod notification_handler;
 pub mod options;
 pub mod subscribe;
+#[cfg(not(feature = "legacy-spec"))]
+pub mod subscription;
 #[cfg(feature = "tasks")]
 pub mod task;
 
 pub use batch::BatchBuilder;
+#[cfg(not(feature = "legacy-spec"))]
+pub use subscription::{Subscription, SubscriptionEnd};
 #[cfg(feature = "tasks")]
 pub use task::TaskBuilder;
 
@@ -1010,8 +1016,112 @@ impl Client {
         self.send_request(request).await?.into_result()
     }
 
+    /// Opens a long-lived notification subscription (MCP 2026-07-28).
+    ///
+    /// Sends `subscriptions/listen` and returns once the server has
+    /// acknowledged the filter. Notifications delivered on the stream are
+    /// dispatched to the handlers registered with [`Self::subscribe`] and its
+    /// helpers ([`Self::on_tools_changed`] and friends), so those must be in
+    /// place before listening.
+    ///
+    /// The returned [`Subscription`] carries the accepted filter -- the server
+    /// silently drops types it does not advertise -- and ends the stream on
+    /// [`Subscription::cancel`].
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::{Client, error::Error, types::SubscriptionFilter};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Error> {
+    ///     let mut client = Client::new();
+    ///     client.on_tools_changed(|_| async { println!("tools changed"); });
+    ///     client.connect().await?;
+    ///
+    ///     let subscription = client
+    ///         .listen(SubscriptionFilter::new().with_tools_changed())
+    ///         .await?;
+    ///
+    ///     println!("accepted: {:?}", subscription.acknowledged());
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(not(feature = "legacy-spec"))]
+    pub async fn listen(
+        &mut self,
+        notifications: SubscriptionFilter,
+    ) -> Result<Subscription, Error> {
+        if self.is_legacy_peer() {
+            return Err(Error::new(
+                ErrorCode::MethodNotFound,
+                "Peer speaks the legacy protocol; use subscribe_to_resource instead",
+            ));
+        }
+
+        let id = self.generate_id()?;
+        let mut request = Request::new(
+            Some(id.clone()),
+            crate::types::subscription::commands::LISTEN,
+            Some(SubscriptionsListenRequestParams::new(notifications.clone())),
+        );
+        self.apply_client_meta(&mut request, None, None);
+
+        let handler = self
+            .handler
+            .as_mut()
+            .ok_or_else(|| Error::new(ErrorCode::InternalError, "Connection closed"))?;
+
+        // Watch for the acknowledgment before sending: it is the first thing
+        // the server puts on the stream, and the receive loop drops one nobody
+        // is waiting for.
+        let ack = handler.watch_ack(&id);
+        let sender = handler.sender();
+        let response = handler.send_listen(request).await.inspect_err(|_| {
+            self.handler
+                .as_ref()
+                .expect("handler was borrowed above")
+                .abandon_listen(&id)
+        })?;
+
+        let timeout = self.options.timeout;
+        let acknowledged = match tokio::time::timeout(timeout, ack).await {
+            Ok(Ok(filter)) => filter,
+            _ => {
+                self.handler
+                    .as_ref()
+                    .expect("handler was borrowed above")
+                    .abandon_listen(&id);
+                return Err(Error::new(
+                    ErrorCode::Timeout,
+                    "Subscription was not acknowledged",
+                ));
+            }
+        };
+
+        Ok(Subscription::new(
+            id,
+            notifications,
+            acknowledged,
+            response,
+            sender,
+        ))
+    }
+
     /// Subscribes to a resource on the server to receive notifications when it changes.
+    ///
+    /// Legacy only in effect: MCP 2026-07-28 folds per-resource subscriptions
+    /// into the `listen` filter, so against a 2026-07-28 peer this fails and
+    /// `listen` with a `resourceSubscriptions` entry is the way. The method
+    /// stays available because the dual-mode fallback still reaches legacy
+    /// peers.
     pub async fn subscribe_to_resource(&mut self, uri: impl Into<Uri>) -> Result<(), Error> {
+        #[cfg(not(feature = "legacy-spec"))]
+        if !self.is_legacy_peer() {
+            return Err(Error::new(
+                ErrorCode::MethodNotFound,
+                "resources/subscribe is legacy-only; use listen with a resource filter",
+            ));
+        }
         if !self.is_resource_subscription_supported() {
             return Err(Error::new(
                 ErrorCode::MethodNotFound,
@@ -1031,7 +1141,18 @@ impl Client {
     }
 
     /// Unsubscribes from a resource on the server to stop receiving notifications about its changes.
+    ///
+    /// Legacy only in effect; see [`Self::subscribe_to_resource`]. Under MCP
+    /// 2026-07-28 a subscription ends with the stream that carries it
+    /// (`Subscription::cancel`).
     pub async fn unsubscribe_from_resource(&mut self, uri: impl Into<Uri>) -> Result<(), Error> {
+        #[cfg(not(feature = "legacy-spec"))]
+        if !self.is_legacy_peer() {
+            return Err(Error::new(
+                ErrorCode::MethodNotFound,
+                "resources/unsubscribe is legacy-only; cancel the subscription instead",
+            ));
+        }
         if !self.is_resource_subscription_supported() {
             return Err(Error::new(
                 ErrorCode::MethodNotFound,

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -298,18 +298,6 @@ impl RequestHandler {
         rx
     }
 
-    /// Drops a pending acknowledgment waiter and its request slot, for a
-    /// subscription that never got off the ground.
-    ///
-    /// Local bookkeeping only -- ending the stream itself is the caller's job
-    /// (see `Client::abandon_listen`).
-    #[cfg(not(feature = "legacy-spec"))]
-    pub(super) fn forget_listen(&self, id: &RequestId) {
-        self.ack_waiters.remove(id);
-        self.subscription_filters.remove(id);
-        let _ = self.pending.pop(id);
-    }
-
     /// Everything a [`Subscription`] needs to release its own bookkeeping once
     /// its stream is over.
     ///
@@ -673,10 +661,19 @@ fn complete_ack(
         return;
     };
 
-    // This is the handshake completing: the subscription stops being pending
-    // and starts admitting what it narrowed to.
-    if let Some(mut entry) = filters.get_mut(&id) {
-        entry.acknowledge(&filter);
+    // The handshake completing -- unless the acknowledgment is one `listen`
+    // will refuse, in which case the subscription stays pending and delivers
+    // nothing while the waiter below carries the acknowledgment on to be
+    // rejected.
+    if let Some(mut entry) = filters.get_mut(&id)
+        && !entry.acknowledge(&filter)
+    {
+        #[cfg(feature = "tracing")]
+        tracing::warn!(
+            logger = "neva",
+            subscription = %id,
+            "not establishing a subscription on an acknowledgment broader than its request"
+        );
     }
 
     if let Some((_, waiter)) = waiters.remove(&id) {
@@ -1355,11 +1352,31 @@ mod tests {
             "nothing may be delivered before the acknowledgment, however well tagged"
         );
 
+        // An acknowledgment broader than the request establishes nothing:
+        // `Client::listen` refuses it, so admitting even the requested
+        // categories would deliver events from a subscription the caller is
+        // told never opened.
+        let overbroad = SubscriptionFilter::new()
+            .with_tools_changed()
+            .with_prompts_changed();
+        assert!(
+            !filters
+                .get_mut(&RequestId::Number(1))
+                .expect("the subscription is tracked")
+                .acknowledge(&overbroad)
+        );
+        assert!(
+            !admitted(&tagged, &filters, &peer),
+            "an acknowledgment `listen` will reject must not establish the subscription"
+        );
+
         // ...and the same notification is admitted once the handshake completes.
-        filters
-            .get_mut(&RequestId::Number(1))
-            .expect("the subscription is tracked")
-            .acknowledge(&requested);
+        assert!(
+            filters
+                .get_mut(&RequestId::Number(1))
+                .expect("the subscription is tracked")
+                .acknowledge(&requested)
+        );
 
         assert!(admitted(&tagged, &filters, &peer));
     }

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -657,7 +657,7 @@ fn admitted(
     let Some(params) = notification.params.as_ref() else {
         return true;
     };
-    
+
     let Some(id) = params
         .get("_meta")
         .and_then(|meta| meta.get(crate::types::SUBSCRIPTION_ID_KEY))

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -91,6 +91,10 @@ pub(super) struct RequestHandler {
     /// Callers waiting for a `subscriptions/listen` acknowledgment.
     #[cfg(not(feature = "legacy-spec"))]
     ack_waiters: crate::client::subscription::AckWaiters,
+
+    /// What each live subscription is allowed to deliver.
+    #[cfg(not(feature = "legacy-spec"))]
+    subscription_filters: crate::client::subscription::SubscriptionFilters,
 }
 
 impl Roots {
@@ -177,6 +181,8 @@ impl RequestHandler {
             peer_mode: options.peer_mode.clone(),
             #[cfg(not(feature = "legacy-spec"))]
             ack_waiters: Default::default(),
+            #[cfg(not(feature = "legacy-spec"))]
+            subscription_filters: Default::default(),
         };
 
         handler.start(rx)
@@ -273,9 +279,17 @@ impl RequestHandler {
     pub(super) fn watch_ack(
         &self,
         id: &RequestId,
+        requested: &crate::types::SubscriptionFilter,
     ) -> tokio::sync::oneshot::Receiver<crate::types::SubscriptionFilter> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.ack_waiters.insert(id.clone(), tx);
+        // Seeded with what was *requested*, before the request goes out: a
+        // notification can arrive between the acknowledgment and `listen`
+        // returning, and it must be checked against something no broader than
+        // the ask. The acknowledgment narrows this the moment it lands.
+        self.subscription_filters
+            .insert(id.clone(), requested.clone());
+
         rx
     }
 
@@ -287,7 +301,21 @@ impl RequestHandler {
     #[cfg(not(feature = "legacy-spec"))]
     pub(super) fn forget_listen(&self, id: &RequestId) {
         self.ack_waiters.remove(id);
+        self.subscription_filters.remove(id);
         let _ = self.pending.pop(id);
+    }
+
+    /// Everything a [`Subscription`] needs to release its own bookkeeping once
+    /// its stream is over.
+    ///
+    /// [`Subscription`]: crate::client::Subscription
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(super) fn subscription_release(&self) -> crate::client::subscription::SubscriptionRelease {
+        crate::client::subscription::SubscriptionRelease::new(
+            self.pending.clone(),
+            self.ack_waiters.clone(),
+            self.subscription_filters.clone(),
+        )
     }
 
     /// Returns a handle on the transport sender, so a [`Subscription`] can
@@ -387,6 +415,8 @@ impl RequestHandler {
         let peer_mode = self.peer_mode.clone();
         #[cfg(not(feature = "legacy-spec"))]
         let ack_waiters = self.ack_waiters.clone();
+        #[cfg(not(feature = "legacy-spec"))]
+        let subscription_filters = self.subscription_filters.clone();
 
         tokio::task::spawn(async move {
             while let Ok(msg) = rx.recv().await {
@@ -408,7 +438,12 @@ impl RequestHandler {
                     }
                     Message::Notification(notification) => {
                         #[cfg(not(feature = "legacy-spec"))]
-                        complete_ack(&notification, &ack_waiters);
+                        {
+                            complete_ack(&notification, &ack_waiters, &subscription_filters);
+                            if !admitted(&notification, &subscription_filters) {
+                                continue;
+                            }
+                        }
                         dispatch_notification(notification, &notification_handler).await;
                     }
                     Message::Batch(batch) => {
@@ -575,7 +610,11 @@ async fn dispatch_request(
 /// event.
 #[inline]
 #[cfg(not(feature = "legacy-spec"))]
-fn complete_ack(notification: &Notification, waiters: &crate::client::subscription::AckWaiters) {
+fn complete_ack(
+    notification: &Notification,
+    waiters: &crate::client::subscription::AckWaiters,
+    filters: &crate::client::subscription::SubscriptionFilters,
+) {
     if notification.method != crate::types::subscription::commands::ACKNOWLEDGED {
         return;
     }
@@ -586,9 +625,73 @@ fn complete_ack(notification: &Notification, waiters: &crate::client::subscripti
         return;
     };
 
+    // Narrow the seeded filter to what was acknowledged. Intersecting rather
+    // than replacing keeps a peer that acknowledges *more* than was asked from
+    // widening what this stream may deliver in the window before `listen`
+    // rejects it outright.
+    if let Some(mut entry) = filters.get_mut(&id) {
+        let narrowed = entry.intersection(&filter);
+        *entry = narrowed;
+    }
+
     if let Some((_, waiter)) = waiters.remove(&id) {
         let _ = waiter.send(filter);
     }
+}
+
+/// Whether a notification tagged with a subscription id is one that
+/// subscription may carry.
+///
+/// The spec forbids a server from sending a type the client did not request,
+/// but nothing downstream would notice if it did: notifications go straight to
+/// the client's global handlers, which know nothing about subscriptions. So the
+/// promise is enforced here, at the one place that can. Untagged notifications
+/// -- request-scoped progress and log messages -- belong to no subscription and
+/// pass through untouched.
+#[cfg(not(feature = "legacy-spec"))]
+#[inline]
+fn admitted(
+    notification: &Notification,
+    filters: &crate::client::subscription::SubscriptionFilters,
+) -> bool {
+    let Some(params) = notification.params.as_ref() else {
+        return true;
+    };
+    
+    let Some(id) = params
+        .get("_meta")
+        .and_then(|meta| meta.get(crate::types::SUBSCRIPTION_ID_KEY))
+        .and_then(|id| serde_json::from_value::<RequestId>(id.clone()).ok())
+    else {
+        return true;
+    };
+
+    // The acknowledgment is the subscription's own handshake, not one of the
+    // categories a filter selects.
+    if notification.method == crate::types::subscription::commands::ACKNOWLEDGED {
+        return true;
+    }
+
+    let uri = params
+        .get("uri")
+        .and_then(|uri| uri.as_str())
+        .map(crate::types::Uri::from);
+
+    let admitted = filters
+        .get(&id)
+        .is_some_and(|filter| filter.matches(&notification.method, uri.as_ref()));
+
+    #[cfg(feature = "tracing")]
+    if !admitted {
+        tracing::warn!(
+            logger = "neva",
+            method = %notification.method,
+            subscription = %id,
+            "dropping a notification outside its subscription's acknowledged filter"
+        );
+    }
+
+    admitted
 }
 
 /// Forwards a [`Notification`] to the registered handler or traces it when

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -87,6 +87,10 @@ pub(super) struct RequestHandler {
     /// is observed by the receive loop.
     #[cfg(not(feature = "legacy-spec"))]
     peer_mode: crate::shared::PeerMode,
+
+    /// Callers waiting for a `subscriptions/listen` acknowledgment.
+    #[cfg(not(feature = "legacy-spec"))]
+    ack_waiters: crate::client::subscription::AckWaiters,
 }
 
 impl Roots {
@@ -171,6 +175,8 @@ impl RequestHandler {
             tasks: Arc::new(TaskTracker::new()),
             #[cfg(not(feature = "legacy-spec"))]
             peer_mode: options.peer_mode.clone(),
+            #[cfg(not(feature = "legacy-spec"))]
+            ack_waiters: Default::default(),
         };
 
         handler.start(rx)
@@ -236,6 +242,59 @@ impl RequestHandler {
                 }
             }
         }
+    }
+
+    /// Sends a `subscriptions/listen` request and returns the slot its final
+    /// response will arrive in.
+    ///
+    /// Unlike [`Self::send_request`] this does not await the reply and -- by
+    /// skipping [`RequestQueue::activate`] -- never starts the request TTL: a
+    /// subscription is answered only when it ends, which may be hours later.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(super) async fn send_listen(
+        &mut self,
+        request: Request,
+    ) -> Result<tokio::sync::oneshot::Receiver<PendingResponse>, Error> {
+        let id = request.id();
+        let receiver = self.pending.push(&id);
+        if let Err(err) = self.sender.send(request.into()).await {
+            let _ = self.pending.pop(&id);
+            return Err(err);
+        }
+        Ok(receiver)
+    }
+
+    /// Registers interest in the acknowledgment of the subscription `id`.
+    ///
+    /// Must be called *before* the `subscriptions/listen` request goes out --
+    /// the acknowledgment is the first message the server sends back, and the
+    /// receive loop drops one it has no waiter for.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(super) fn watch_ack(
+        &self,
+        id: &RequestId,
+    ) -> tokio::sync::oneshot::Receiver<crate::types::SubscriptionFilter> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.ack_waiters.insert(id.clone(), tx);
+        rx
+    }
+
+    /// Drops a pending acknowledgment waiter and its request slot, for a
+    /// subscription that never got off the ground.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(super) fn abandon_listen(&self, id: &RequestId) {
+        self.ack_waiters.remove(id);
+        let _ = self.pending.pop(id);
+    }
+
+    /// Returns a handle on the transport sender, so a [`Subscription`] can
+    /// cancel itself without borrowing the client.
+    ///
+    /// [`Subscription`]: crate::client::Subscription
+    #[cfg(not(feature = "legacy-spec"))]
+    #[inline]
+    pub(super) fn sender(&self) -> TransportProtoSender {
+        self.sender.clone()
     }
 
     /// Sends a batch of messages to the MCP server.
@@ -323,6 +382,8 @@ impl RequestHandler {
         let tasks = self.tasks.clone();
         #[cfg(not(feature = "legacy-spec"))]
         let peer_mode = self.peer_mode.clone();
+        #[cfg(not(feature = "legacy-spec"))]
+        let ack_waiters = self.ack_waiters.clone();
 
         tokio::task::spawn(async move {
             while let Ok(msg) = rx.recv().await {
@@ -343,6 +404,8 @@ impl RequestHandler {
                         send_response_impl(&mut sender, resp).await;
                     }
                     Message::Notification(notification) => {
+                        #[cfg(not(feature = "legacy-spec"))]
+                        complete_ack(&notification, &ack_waiters);
                         dispatch_notification(notification, &notification_handler).await;
                     }
                     Message::Batch(batch) => {
@@ -498,6 +561,30 @@ async fn dispatch_request(
         #[cfg(all(feature = "tasks", feature = "legacy-spec"))]
         crate::types::task::commands::GET => get_task(req, tasks),
         _ => ErrorCode::MethodNotFound.into_response(req_id),
+    }
+}
+
+/// Completes the waiter for a `notifications/subscriptions/acknowledged`.
+///
+/// The acknowledgment is a protocol-level message, but it is still forwarded to
+/// the user's notification handlers afterwards -- a client that wants to watch
+/// its own subscriptions being established can subscribe to it like any other
+/// event.
+#[inline]
+#[cfg(not(feature = "legacy-spec"))]
+fn complete_ack(notification: &Notification, waiters: &crate::client::subscription::AckWaiters) {
+    if notification.method != crate::types::subscription::commands::ACKNOWLEDGED {
+        return;
+    }
+
+    let Ok((id, filter)) = crate::client::subscription::parse_ack(notification) else {
+        #[cfg(feature = "tracing")]
+        tracing::warn!(logger = "neva", "malformed subscription acknowledgment");
+        return;
+    };
+
+    if let Some((_, waiter)) = waiters.remove(&id) {
+        let _ = waiter.send(filter);
     }
 }
 

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -94,7 +94,7 @@ pub(super) struct RequestHandler {
 
     /// What each live subscription is allowed to deliver.
     #[cfg(not(feature = "legacy-spec"))]
-    subscription_filters: crate::client::subscription::SubscriptionFilters,
+    subscription_filters: crate::client::subscription::SubscriptionStates,
 }
 
 impl Roots {
@@ -283,12 +283,17 @@ impl RequestHandler {
     ) -> tokio::sync::oneshot::Receiver<crate::types::SubscriptionFilter> {
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.ack_waiters.insert(id.clone(), tx);
-        // Seeded with what was *requested*, before the request goes out: a
-        // notification can arrive between the acknowledgment and `listen`
-        // returning, and it must be checked against something no broader than
-        // the ask. The acknowledgment narrows this the moment it lands.
-        self.subscription_filters
-            .insert(id.clone(), requested.clone());
+        // Recorded before the request goes out, and recorded as *pending*: the
+        // acknowledgment is required to be the first message on the stream, so
+        // anything tagged with this id that arrives ahead of it is delivered by
+        // a subscription that does not exist yet -- and may never, if the peer
+        // rejects the listen or simply never answers. The requested filter
+        // rides along because the acknowledgment narrows it rather than
+        // replacing it.
+        self.subscription_filters.insert(
+            id.clone(),
+            crate::client::subscription::SubscriptionState::Pending(requested.clone()),
+        );
 
         rx
     }
@@ -656,7 +661,7 @@ async fn dispatch_request(
 fn complete_ack(
     notification: &Notification,
     waiters: &crate::client::subscription::AckWaiters,
-    filters: &crate::client::subscription::SubscriptionFilters,
+    filters: &crate::client::subscription::SubscriptionStates,
 ) {
     if notification.method != crate::types::subscription::commands::ACKNOWLEDGED {
         return;
@@ -668,13 +673,10 @@ fn complete_ack(
         return;
     };
 
-    // Narrow the seeded filter to what was acknowledged. Intersecting rather
-    // than replacing keeps a peer that acknowledges *more* than was asked from
-    // widening what this stream may deliver in the window before `listen`
-    // rejects it outright.
+    // This is the handshake completing: the subscription stops being pending
+    // and starts admitting what it narrowed to.
     if let Some(mut entry) = filters.get_mut(&id) {
-        let narrowed = entry.intersection(&filter);
-        *entry = narrowed;
+        entry.acknowledge(&filter);
     }
 
     if let Some((_, waiter)) = waiters.remove(&id) {
@@ -690,7 +692,11 @@ fn complete_ack(
 /// promise is enforced here, at the one place that can, in two parts.
 ///
 /// A notification carrying a subscription id must be one that subscription
-/// acknowledged. One *without* a usable id must not be a subscribable type at
+/// acknowledged -- which also means there has to *be* an acknowledgment: the
+/// handshake requires it to come first, and a subscription still pending may
+/// yet be rejected, leaving handlers to have seen events from a stream
+/// `Client::listen` reports as never established. One *without* a usable id
+/// must not be a subscribable type at
 /// all: under MCP 2026-07-28 those travel on a subscription and nowhere else,
 /// so an untagged (or unparseably tagged) `tools/list_changed` is a category
 /// nothing in this client asked for, arriving with nothing to check it against.
@@ -702,7 +708,7 @@ fn complete_ack(
 #[inline]
 fn admitted(
     notification: &Notification,
-    filters: &crate::client::subscription::SubscriptionFilters,
+    filters: &crate::client::subscription::SubscriptionStates,
     peer_mode: &crate::shared::PeerMode,
 ) -> bool {
     // The acknowledgment is the subscription's own handshake, not one of the
@@ -738,9 +744,11 @@ fn admitted(
         .and_then(|uri| uri.as_str())
         .map(crate::types::Uri::from);
 
-    let admitted = filters
-        .get(&id)
-        .is_some_and(|filter| filter.matches(&notification.method, uri.as_ref()));
+    let admitted = filters.get(&id).is_some_and(|state| {
+        state
+            .established()
+            .is_some_and(|filter| filter.matches(&notification.method, uri.as_ref()))
+    });
 
     #[cfg(feature = "tracing")]
     if !admitted {
@@ -748,7 +756,7 @@ fn admitted(
             logger = "neva",
             method = %notification.method,
             subscription = %id,
-            "dropping a notification outside its subscription's acknowledged filter"
+            "dropping a notification its subscription has not acknowledged"
         );
     }
 
@@ -1274,10 +1282,14 @@ mod tests {
     fn admitted_requires_a_subscription_id_from_a_2026_07_28_peer() {
         use crate::types::SUBSCRIPTION_ID_KEY;
 
-        let filters = crate::client::subscription::SubscriptionFilters::default();
+        use crate::client::subscription::SubscriptionState;
+
+        let filters = crate::client::subscription::SubscriptionStates::default();
         filters.insert(
             RequestId::Number(1),
-            crate::types::SubscriptionFilter::new().with_tools_changed(),
+            SubscriptionState::Established(
+                crate::types::SubscriptionFilter::new().with_tools_changed(),
+            ),
         );
 
         let tagged = Notification::new(
@@ -1313,6 +1325,43 @@ mod tests {
         // subscriptions, so nothing it pushes is tagged.
         peer.set_legacy();
         assert!(admitted(&untagged, &filters, &peer));
+    }
+
+    /// The acknowledgment is required to be the first message on a
+    /// subscription. Until it lands, the subscription may still be rejected or
+    /// never answered, so anything tagged with its id would be an event from a
+    /// stream `Client::listen` goes on to report as never established.
+    #[test]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn admitted_refuses_a_subscription_that_has_not_acknowledged_yet() {
+        use crate::client::subscription::SubscriptionState;
+        use crate::types::{SUBSCRIPTION_ID_KEY, SubscriptionFilter};
+
+        let requested = SubscriptionFilter::new().with_tools_changed();
+        let filters = crate::client::subscription::SubscriptionStates::default();
+        filters.insert(
+            RequestId::Number(1),
+            SubscriptionState::Pending(requested.clone()),
+        );
+
+        let tagged = Notification::new(
+            crate::types::tool::commands::LIST_CHANGED,
+            Some(serde_json::json!({ "_meta": { SUBSCRIPTION_ID_KEY: 1 } })),
+        );
+        let peer = crate::shared::PeerMode::default();
+
+        assert!(
+            !admitted(&tagged, &filters, &peer),
+            "nothing may be delivered before the acknowledgment, however well tagged"
+        );
+
+        // ...and the same notification is admitted once the handshake completes.
+        filters
+            .get_mut(&RequestId::Number(1))
+            .expect("the subscription is tracked")
+            .acknowledge(&requested);
+
+        assert!(admitted(&tagged, &filters, &peer));
     }
 
     #[test]

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -352,6 +352,8 @@ impl RequestHandler {
         items: Vec<MessageEnvelope>,
     ) -> Result<Vec<(RequestId, tokio::sync::oneshot::Receiver<PendingResponse>)>, Error> {
         validate_batch_ids(&items)?;
+        #[cfg(not(feature = "legacy-spec"))]
+        validate_no_listen(&items)?;
 
         let mut receivers = Vec::new();
         let mut envelopes = Vec::new();
@@ -408,6 +410,7 @@ impl RequestHandler {
         let sampling_handler = self.sampling_handler.clone();
         let elicitation_handler = self.elicitation_handler.clone();
         let notification_handler = self.notification_handler.clone();
+        let token = self.token.clone();
 
         #[cfg(all(feature = "tasks", feature = "legacy-spec"))]
         let tasks = self.tasks.clone();
@@ -419,7 +422,21 @@ impl RequestHandler {
         let subscription_filters = self.subscription_filters.clone();
 
         tokio::task::spawn(async move {
-            while let Ok(msg) = rx.recv().await {
+            loop {
+                // Cancellation is a first-class exit here, not just an EOF the
+                // receiver happens to report: over HTTP the receiver holds a
+                // sender clone of its own channel, so `recv` never ends by
+                // itself and a disconnect would otherwise leave this task
+                // running against a transport that is already gone.
+                let msg = tokio::select! {
+                    biased;
+                    _ = token.cancelled() => break,
+                    msg = rx.recv() => match msg {
+                        Ok(msg) => msg,
+                        Err(_) => break,
+                    },
+                };
+
                 match msg {
                     Message::Response(resp) => pending.complete(resp),
                     Message::Request(req) => {
@@ -460,6 +477,25 @@ impl RequestHandler {
                         for envelope in batch {
                             match envelope {
                                 MessageEnvelope::Response(resp) => pending.complete(resp),
+                                // A batched notification is still a
+                                // notification: an acknowledgment arriving this
+                                // way has to resolve `listen`, and a tagged
+                                // notification has to face the same filter it
+                                // would on its own. Batching is a framing
+                                // choice of the peer's, not a way around the
+                                // subscription's scope.
+                                #[cfg(not(feature = "legacy-spec"))]
+                                MessageEnvelope::Notification(notification) => {
+                                    complete_ack(
+                                        &notification,
+                                        &ack_waiters,
+                                        &subscription_filters,
+                                    );
+
+                                    if admitted(&notification, &subscription_filters) {
+                                        deferred.push(MessageEnvelope::Notification(notification));
+                                    }
+                                }
                                 other => deferred.push(other),
                             }
                         }
@@ -491,6 +527,13 @@ impl RequestHandler {
                     }
                 }
             }
+            // The transport is gone -- a stdio peer exited, or the connection
+            // was cancelled -- so nothing can complete these any more. Left
+            // alone, a `subscriptions/listen` slot would hold its holder
+            // forever: it carries no TTL to expire it, and `Subscription::closed`
+            // awaits exactly this receiver. Dropping the senders resolves them
+            // as `SubscriptionEnd::Abrupt`, which is what happened.
+            pending.abandon_all();
         });
         self
     }
@@ -948,6 +991,32 @@ fn validate_batch_ids(items: &[MessageEnvelope]) -> Result<(), Error> {
     Ok(())
 }
 
+/// Rejects a `subscriptions/listen` placed in a batch.
+///
+/// A batch slot is an ordinary request slot: it activates the TTL and hands
+/// back a plain [`Response`], with no acknowledgment waiter, no accepted
+/// filter, and no [`Subscription`] handle. There would be nothing to cancel the
+/// stream with and nothing to close it on timeout, so the subscription would
+/// outlive the call that opened it, server-side and on the wire both.
+///
+/// [`Subscription`]: crate::client::Subscription
+#[inline]
+#[cfg(not(feature = "legacy-spec"))]
+fn validate_no_listen(items: &[MessageEnvelope]) -> Result<(), Error> {
+    let listens = items.iter().any(|env| {
+        matches!(env, MessageEnvelope::Request(req)
+            if req.method == crate::types::subscription::commands::LISTEN)
+    });
+
+    if listens {
+        return Err(Error::new(
+            ErrorCode::InvalidRequest,
+            "batch contains `subscriptions/listen`; open subscriptions with `Client::listen`",
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1174,6 +1243,23 @@ mod tests {
 
         // Duplicate ID -- should fail
         let err = validate_batch_ids(&[req(1), req(2), req(1)]).unwrap_err();
+        assert_eq!(err.code, ErrorCode::InvalidRequest);
+    }
+
+    #[test]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn validate_no_listen_rejects_a_batched_subscription() {
+        let listen = MessageEnvelope::Request(Request::new(
+            Some(RequestId::Number(1)),
+            crate::types::subscription::commands::LISTEN,
+            None::<()>,
+        ));
+        let ping =
+            MessageEnvelope::Request(Request::new(Some(RequestId::Number(2)), "ping", None::<()>));
+
+        assert!(validate_no_listen(std::slice::from_ref(&ping)).is_ok());
+
+        let err = validate_no_listen(&[ping, listen]).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidRequest);
     }
 

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -281,8 +281,11 @@ impl RequestHandler {
 
     /// Drops a pending acknowledgment waiter and its request slot, for a
     /// subscription that never got off the ground.
+    ///
+    /// Local bookkeeping only -- ending the stream itself is the caller's job
+    /// (see `Client::abandon_listen`).
     #[cfg(not(feature = "legacy-spec"))]
-    pub(super) fn abandon_listen(&self, id: &RequestId) {
+    pub(super) fn forget_listen(&self, id: &RequestId) {
         self.ack_waiters.remove(id);
         let _ = self.pending.pop(id);
     }

--- a/neva/src/client/handler.rs
+++ b/neva/src/client/handler.rs
@@ -457,7 +457,7 @@ impl RequestHandler {
                         #[cfg(not(feature = "legacy-spec"))]
                         {
                             complete_ack(&notification, &ack_waiters, &subscription_filters);
-                            if !admitted(&notification, &subscription_filters) {
+                            if !admitted(&notification, &subscription_filters, &peer_mode) {
                                 continue;
                             }
                         }
@@ -492,7 +492,7 @@ impl RequestHandler {
                                         &subscription_filters,
                                     );
 
-                                    if admitted(&notification, &subscription_filters) {
+                                    if admitted(&notification, &subscription_filters, &peer_mode) {
                                         deferred.push(MessageEnvelope::Notification(notification));
                                     }
                                 }
@@ -682,41 +682,59 @@ fn complete_ack(
     }
 }
 
-/// Whether a notification tagged with a subscription id is one that
-/// subscription may carry.
+/// Whether a notification belongs on this client's stream at all.
 ///
 /// The spec forbids a server from sending a type the client did not request,
 /// but nothing downstream would notice if it did: notifications go straight to
 /// the client's global handlers, which know nothing about subscriptions. So the
-/// promise is enforced here, at the one place that can. Untagged notifications
-/// -- request-scoped progress and log messages -- belong to no subscription and
-/// pass through untouched.
+/// promise is enforced here, at the one place that can, in two parts.
+///
+/// A notification carrying a subscription id must be one that subscription
+/// acknowledged. One *without* a usable id must not be a subscribable type at
+/// all: under MCP 2026-07-28 those travel on a subscription and nowhere else,
+/// so an untagged (or unparseably tagged) `tools/list_changed` is a category
+/// nothing in this client asked for, arriving with nothing to check it against.
+/// Untagged request-scoped notifications -- progress and log messages -- belong
+/// to no subscription and pass through untouched, as do all of them when the
+/// dual-mode fallback has landed on a legacy peer, which pushes list-changed
+/// notifications on its own and has no subscriptions to tag them with.
 #[cfg(not(feature = "legacy-spec"))]
 #[inline]
 fn admitted(
     notification: &Notification,
     filters: &crate::client::subscription::SubscriptionFilters,
+    peer_mode: &crate::shared::PeerMode,
 ) -> bool {
-    let Some(params) = notification.params.as_ref() else {
-        return true;
-    };
-
-    let Some(id) = params
-        .get("_meta")
-        .and_then(|meta| meta.get(crate::types::SUBSCRIPTION_ID_KEY))
-        .and_then(|id| serde_json::from_value::<RequestId>(id.clone()).ok())
-    else {
-        return true;
-    };
-
     // The acknowledgment is the subscription's own handshake, not one of the
     // categories a filter selects.
     if notification.method == crate::types::subscription::commands::ACKNOWLEDGED {
         return true;
     }
 
+    let params = notification.params.as_ref();
+    let tagged = params
+        .and_then(|params| params.get("_meta"))
+        .and_then(|meta| meta.get(crate::types::SUBSCRIPTION_ID_KEY))
+        .and_then(|id| serde_json::from_value::<RequestId>(id.clone()).ok());
+
+    let Some(id) = tagged else {
+        let admitted = peer_mode.is_legacy()
+            || !crate::types::subscription::is_subscribable(&notification.method);
+
+        #[cfg(feature = "tracing")]
+        if !admitted {
+            tracing::warn!(
+                logger = "neva",
+                method = %notification.method,
+                "dropping a subscription-only notification that carries no usable subscription id"
+            );
+        }
+
+        return admitted;
+    };
+
     let uri = params
-        .get("uri")
+        .and_then(|params| params.get("uri"))
         .and_then(|uri| uri.as_str())
         .map(crate::types::Uri::from);
 
@@ -1244,6 +1262,57 @@ mod tests {
         // Duplicate ID -- should fail
         let err = validate_batch_ids(&[req(1), req(2), req(1)]).unwrap_err();
         assert_eq!(err.code, ErrorCode::InvalidRequest);
+    }
+
+    /// Under MCP 2026-07-28 a subscribable notification travels on a
+    /// subscription and nowhere else, so one arriving without a usable id has
+    /// nothing to be checked against and no subscription to belong to. A peer
+    /// reached through the dual-mode fallback is the exception: it pushes
+    /// list-changed notifications on its own and has no ids to tag them with.
+    #[test]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn admitted_requires_a_subscription_id_from_a_2026_07_28_peer() {
+        use crate::types::SUBSCRIPTION_ID_KEY;
+
+        let filters = crate::client::subscription::SubscriptionFilters::default();
+        filters.insert(
+            RequestId::Number(1),
+            crate::types::SubscriptionFilter::new().with_tools_changed(),
+        );
+
+        let tagged = Notification::new(
+            crate::types::tool::commands::LIST_CHANGED,
+            Some(serde_json::json!({ "_meta": { SUBSCRIPTION_ID_KEY: 1 } })),
+        );
+        let untagged = Notification::new(crate::types::tool::commands::LIST_CHANGED, None);
+        let mistagged = Notification::new(
+            crate::types::tool::commands::LIST_CHANGED,
+            Some(serde_json::json!({ "_meta": { SUBSCRIPTION_ID_KEY: { "not": "an id" } } })),
+        );
+        let progress = Notification::new(
+            crate::types::notification::commands::PROGRESS,
+            Some(serde_json::json!({ "progress": 1 })),
+        );
+
+        let peer = crate::shared::PeerMode::default();
+        assert!(admitted(&tagged, &filters, &peer));
+        assert!(
+            !admitted(&untagged, &filters, &peer),
+            "a subscription-only notification must carry a subscription id"
+        );
+        assert!(
+            !admitted(&mistagged, &filters, &peer),
+            "and one that cannot be parsed is no id at all"
+        );
+        assert!(
+            admitted(&progress, &filters, &peer),
+            "request-scoped notifications belong to no subscription"
+        );
+
+        // The dual-mode fallback landed on a legacy peer: it has no
+        // subscriptions, so nothing it pushes is tagged.
+        peer.set_legacy();
+        assert!(admitted(&untagged, &filters, &peer));
     }
 
     #[test]

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -75,7 +75,10 @@ pub struct Subscription {
     acknowledged: SubscriptionFilter,
     response: oneshot::Receiver<PendingResponse>,
     sender: TransportProtoSender,
+    /// This client cancelled it -- what [`Subscription::closed`] reports.
     cancelled: bool,
+    /// Teardown is already done or unnecessary, so [`Drop`] has nothing to do.
+    settled: bool,
 }
 
 impl std::fmt::Debug for Subscription {
@@ -104,6 +107,7 @@ impl Subscription {
             response,
             sender,
             cancelled: false,
+            settled: false,
         }
     }
 
@@ -139,15 +143,17 @@ impl Subscription {
     /// Cancels the subscription.
     ///
     /// Sends `notifications/cancelled` for the `subscriptions/listen` request,
-    /// which ends the stream server-side. Await [`Self::closed`] afterwards to
-    /// see the graceful-close result.
+    /// which ends the subscription server-side -- directly over stdio, and over
+    /// HTTP by way of the transport closing the listen response body. Await
+    /// [`Self::closed`] afterwards to confirm how it ended.
     pub async fn cancel(&mut self) -> Result<(), Error> {
         self.cancelled = true;
+        self.settled = true;
         self.sender.send(cancelled(&self.id).into()).await
     }
 
     /// Waits for the subscription to end and reports how.
-    pub async fn closed(self) -> SubscriptionEnd {
+    pub async fn closed(mut self) -> SubscriptionEnd {
         // A cancel this client issued needs no waiting: over HTTP it closed the
         // stream, so the peer has nowhere to send a final result and awaiting
         // one would hang until the request timeout.
@@ -155,13 +161,47 @@ impl Subscription {
             return SubscriptionEnd::Cancelled;
         }
 
-        match self.response.await {
+        let end = match (&mut self.response).await {
             Ok(PendingResponse::Response(resp)) => match resp.into_result() {
                 Ok(result) => SubscriptionEnd::Graceful(result),
                 Err(_) => SubscriptionEnd::Abrupt,
             },
             _ => SubscriptionEnd::Abrupt,
+        };
+        // However it ended, it ended: the peer is not streaming any more, so
+        // the `Drop` below has nothing left to cancel.
+        self.settled = true;
+        end
+    }
+}
+
+/// Dropping the handle ends the subscription.
+///
+/// Without this, letting a `Subscription` fall out of scope would leave the
+/// peer streaming into a client that has no way left to stop it: over HTTP the
+/// transport task keeps draining the response body, over stdio the server keeps
+/// the entry registered, and either way the notifications go on reaching the
+/// handlers registered with [`Client::subscribe`](crate::Client::subscribe).
+///
+/// Best-effort by necessity -- `Drop` cannot await, so the cancellation is
+/// handed to the runtime. Outside a runtime there is nothing to hand it to and
+/// the subscription ends with the connection instead; call
+/// [`Self::cancel`] when the ending has to be observable.
+impl Drop for Subscription {
+    fn drop(&mut self) {
+        if self.settled {
+            return;
         }
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+
+        let mut sender = self.sender.clone();
+        let notification = cancelled(&self.id);
+
+        runtime.spawn(async move {
+            let _ = sender.send(notification.into()).await;
+        });
     }
 }
 

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -31,6 +31,12 @@ pub enum SubscriptionEnd {
     /// timeout, or a server that died. Subscriptions are not resumable, so a
     /// client that wants to keep listening re-sends `subscriptions/listen`.
     Abrupt,
+
+    /// This client ended it via [`Subscription::cancel`].
+    ///
+    /// Over HTTP that closes the stream, which is the spec's cancellation
+    /// mechanism there -- so no final result comes back, and none is expected.
+    Cancelled,
 }
 
 /// A live `subscriptions/listen` stream.
@@ -69,6 +75,7 @@ pub struct Subscription {
     acknowledged: SubscriptionFilter,
     response: oneshot::Receiver<PendingResponse>,
     sender: TransportProtoSender,
+    cancelled: bool,
 }
 
 impl std::fmt::Debug for Subscription {
@@ -96,6 +103,7 @@ impl Subscription {
             acknowledged,
             response,
             sender,
+            cancelled: false,
         }
     }
 
@@ -134,19 +142,19 @@ impl Subscription {
     /// which ends the stream server-side. Await [`Self::closed`] afterwards to
     /// see the graceful-close result.
     pub async fn cancel(&mut self) -> Result<(), Error> {
-        let params = CancelledNotificationParams {
-            request_id: self.id.clone(),
-            reason: Some("subscription cancelled by the client".into()),
-        };
-        let notification = Notification::new(
-            crate::types::notification::commands::CANCELLED,
-            serde_json::to_value(params).ok(),
-        );
-        self.sender.send(notification.into()).await
+        self.cancelled = true;
+        self.sender.send(cancelled(&self.id).into()).await
     }
 
     /// Waits for the subscription to end and reports how.
     pub async fn closed(self) -> SubscriptionEnd {
+        // A cancel this client issued needs no waiting: over HTTP it closed the
+        // stream, so the peer has nowhere to send a final result and awaiting
+        // one would hang until the request timeout.
+        if self.cancelled {
+            return SubscriptionEnd::Cancelled;
+        }
+
         match self.response.await {
             Ok(PendingResponse::Response(resp)) => match resp.into_result() {
                 Ok(result) => SubscriptionEnd::Graceful(result),
@@ -155,6 +163,24 @@ impl Subscription {
             _ => SubscriptionEnd::Abrupt,
         }
     }
+}
+
+/// Builds the `notifications/cancelled` that ends a subscription.
+///
+/// Over stdio this is the mechanism the spec names. Over HTTP the spec has the
+/// client close the stream instead -- so there the transport reads this same
+/// notification as its cue to drop the listen response body, and the server
+/// learns of the cancellation from the close rather than from the message.
+pub(super) fn cancelled(id: &RequestId) -> Notification {
+    let params = CancelledNotificationParams {
+        request_id: id.clone(),
+        reason: Some("subscription cancelled by the client".into()),
+    };
+
+    Notification::new(
+        crate::types::notification::commands::CANCELLED,
+        serde_json::to_value(params).ok(),
+    )
 }
 
 /// Reads the acknowledged filter and its subscription id out of a

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -20,6 +20,15 @@ use tokio::sync::oneshot;
 /// return once the server has confirmed the filter.
 pub(super) type AckWaiters = Arc<DashMap<RequestId, oneshot::Sender<SubscriptionFilter>>>;
 
+/// The filter each live subscription is allowed to deliver, keyed by its
+/// subscription id.
+///
+/// The acknowledgment is a promise about what the stream will carry, and a
+/// noncompliant peer can break it *after* acknowledging correctly. Notifications
+/// go to the client's global handlers, so nothing downstream would notice; the
+/// receive loop checks each tagged notification against this instead.
+pub(super) type SubscriptionFilters = Arc<DashMap<RequestId, SubscriptionFilter>>;
+
 /// How a subscription stream ended.
 #[derive(Debug)]
 pub enum SubscriptionEnd {
@@ -75,6 +84,8 @@ pub struct Subscription {
     acknowledged: SubscriptionFilter,
     response: oneshot::Receiver<PendingResponse>,
     sender: TransportProtoSender,
+    /// Releases the request slot a cancelled subscription will never answer.
+    release: SubscriptionRelease,
     /// This client cancelled it -- what [`Subscription::closed`] reports.
     cancelled: bool,
     /// Teardown is already done or unnecessary, so [`Drop`] has nothing to do.
@@ -99,6 +110,7 @@ impl Subscription {
         acknowledged: SubscriptionFilter,
         response: oneshot::Receiver<PendingResponse>,
         sender: TransportProtoSender,
+        release: SubscriptionRelease,
     ) -> Self {
         Self {
             id,
@@ -106,6 +118,7 @@ impl Subscription {
             acknowledged,
             response,
             sender,
+            release,
             cancelled: false,
             settled: false,
         }
@@ -149,6 +162,11 @@ impl Subscription {
     pub async fn cancel(&mut self) -> Result<(), Error> {
         self.cancelled = true;
         self.settled = true;
+        // No terminal response is coming for a stream this client closed, so the
+        // request slot has to go now -- otherwise a client that opens and
+        // cancels subscriptions in a loop grows the pending queue by one entry
+        // per cycle, and these slots carry no TTL to expire them.
+        self.release.release(&self.id);
         self.sender.send(cancelled(&self.id).into()).await
     }
 
@@ -171,6 +189,7 @@ impl Subscription {
         // However it ended, it ended: the peer is not streaming any more, so
         // the `Drop` below has nothing left to cancel.
         self.settled = true;
+        self.release.release(&self.id);
         end
     }
 }
@@ -192,6 +211,8 @@ impl Drop for Subscription {
         if self.settled {
             return;
         }
+        self.release.release(&self.id);
+
         let Ok(runtime) = tokio::runtime::Handle::try_current() else {
             return;
         };
@@ -202,6 +223,45 @@ impl Drop for Subscription {
         runtime.spawn(async move {
             let _ = sender.send(notification.into()).await;
         });
+    }
+}
+
+/// Frees the per-subscription bookkeeping a cancelled stream leaves behind: its
+/// request slot, its acknowledgment waiter, and its delivery filter.
+///
+/// Held by the [`Subscription`] so the handle can clean up on cancel or drop
+/// without borrowing the client it came from.
+#[derive(Clone)]
+pub(super) struct SubscriptionRelease {
+    pending: crate::shared::RequestQueue,
+    ack_waiters: AckWaiters,
+    filters: SubscriptionFilters,
+}
+
+impl SubscriptionRelease {
+    pub(super) fn new(
+        pending: crate::shared::RequestQueue,
+        ack_waiters: AckWaiters,
+        filters: SubscriptionFilters,
+    ) -> Self {
+        Self {
+            pending,
+            ack_waiters,
+            filters,
+        }
+    }
+
+    pub(super) fn release(&self, id: &RequestId) {
+        let _ = self.pending.pop(id);
+        self.ack_waiters.remove(id);
+        self.filters.remove(id);
+    }
+}
+
+impl std::fmt::Debug for SubscriptionRelease {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SubscriptionRelease")
+            .finish_non_exhaustive()
     }
 }
 
@@ -242,6 +302,14 @@ pub(super) fn parse_ack(
 mod tests {
     use super::*;
     use crate::types::{Response, SUBSCRIPTION_ID_KEY};
+
+    fn release() -> SubscriptionRelease {
+        SubscriptionRelease::new(
+            crate::shared::RequestQueue::new(std::time::Duration::from_secs(5)),
+            Default::default(),
+            Default::default(),
+        )
+    }
 
     fn ack(id: serde_json::Value, filter: serde_json::Value) -> Notification {
         Notification::new(
@@ -286,6 +354,7 @@ mod tests {
             SubscriptionFilter::new().with_tools_changed(),
             rx,
             TransportProtoSender::None,
+            release(),
         );
 
         let result = serde_json::json!({ "_meta": { SUBSCRIPTION_ID_KEY: 1 } });
@@ -309,6 +378,7 @@ mod tests {
             SubscriptionFilter::new(),
             rx,
             TransportProtoSender::None,
+            release(),
         );
 
         drop(tx);
@@ -330,6 +400,7 @@ mod tests {
             SubscriptionFilter::new().with_tools_changed(),
             rx,
             TransportProtoSender::None,
+            release(),
         );
 
         assert!(!subscription.is_fully_honored());

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -1,0 +1,271 @@
+//! Client-side handle for a live `subscriptions/listen` stream (MCP 2026-07-28).
+
+use crate::error::{Error, ErrorCode};
+use crate::shared::PendingResponse;
+use crate::transport::{Sender as _, TransportProtoSender};
+use crate::types::{
+    RequestId, SubscriptionFilter, SubscriptionsListenResult,
+    notification::{CancelledNotificationParams, Notification},
+};
+use dashmap::DashMap;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+
+/// Waiters for `notifications/subscriptions/acknowledged`, keyed by the id of
+/// the `subscriptions/listen` request each one belongs to.
+///
+/// The acknowledgment is a notification, so it arrives on the receive loop
+/// rather than as the request's reply -- the reply only comes when the
+/// subscription ends. This is what lets [`Client::listen`](crate::Client::listen)
+/// return once the server has confirmed the filter.
+pub(super) type AckWaiters = Arc<DashMap<RequestId, oneshot::Sender<SubscriptionFilter>>>;
+
+/// How a subscription stream ended.
+#[derive(Debug)]
+pub enum SubscriptionEnd {
+    /// The server answered the `subscriptions/listen` request with its
+    /// graceful-close result.
+    Graceful(SubscriptionsListenResult),
+
+    /// The stream went away without a final result -- a dropped connection, a
+    /// timeout, or a server that died. Subscriptions are not resumable, so a
+    /// client that wants to keep listening re-sends `subscriptions/listen`.
+    Abrupt,
+}
+
+/// A live `subscriptions/listen` stream.
+///
+/// Notifications delivered on the stream are dispatched to the handlers
+/// registered with [`Client::subscribe`](crate::Client::subscribe) and its
+/// helpers ([`on_tools_changed`](crate::Client::on_tools_changed) and
+/// friends), so this handle is about the subscription's *lifecycle*: what the
+/// server agreed to send, cancelling it, and observing how it ended.
+///
+/// # Examples
+/// ```no_run
+/// # #[cfg(all(feature = "client", not(feature = "legacy-spec")))] {
+/// use neva::{Client, error::Error, types::SubscriptionFilter};
+///
+/// #[tokio::main]
+/// async fn main() -> Result<(), Error> {
+///     let mut client = Client::new();
+///     client.on_tools_changed(|_| async { println!("tools changed"); });
+///     client.connect().await?;
+///
+///     let mut subscription = client
+///         .listen(SubscriptionFilter::new().with_tools_changed())
+///         .await?;
+///
+///     // ... work ...
+///
+///     subscription.cancel().await?;
+///     Ok(())
+/// }
+/// # }
+/// ```
+pub struct Subscription {
+    id: RequestId,
+    requested: SubscriptionFilter,
+    acknowledged: SubscriptionFilter,
+    response: oneshot::Receiver<PendingResponse>,
+    sender: TransportProtoSender,
+}
+
+impl std::fmt::Debug for Subscription {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Subscription")
+            .field("id", &self.id)
+            .field("requested", &self.requested)
+            .field("acknowledged", &self.acknowledged)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Subscription {
+    /// Creates a handle for an established subscription.
+    pub(super) fn new(
+        id: RequestId,
+        requested: SubscriptionFilter,
+        acknowledged: SubscriptionFilter,
+        response: oneshot::Receiver<PendingResponse>,
+        sender: TransportProtoSender,
+    ) -> Self {
+        Self {
+            id,
+            requested,
+            acknowledged,
+            response,
+            sender,
+        }
+    }
+
+    /// Returns the subscription id -- the JSON-RPC id of the
+    /// `subscriptions/listen` request, which every message on the stream
+    /// carries in `_meta`.
+    #[inline]
+    pub fn id(&self) -> &RequestId {
+        &self.id
+    }
+
+    /// Returns the filter this client asked for.
+    #[inline]
+    pub fn requested(&self) -> &SubscriptionFilter {
+        &self.requested
+    }
+
+    /// Returns the subset the server agreed to honor.
+    ///
+    /// Types the server does not support are omitted, so a client that cares
+    /// should compare this against [`Self::requested`].
+    #[inline]
+    pub fn acknowledged(&self) -> &SubscriptionFilter {
+        &self.acknowledged
+    }
+
+    /// Returns whether the server honored every requested notification type.
+    #[inline]
+    pub fn is_fully_honored(&self) -> bool {
+        self.requested.is_subset_of(&self.acknowledged)
+    }
+
+    /// Cancels the subscription.
+    ///
+    /// Sends `notifications/cancelled` for the `subscriptions/listen` request,
+    /// which ends the stream server-side. Await [`Self::closed`] afterwards to
+    /// see the graceful-close result.
+    pub async fn cancel(&mut self) -> Result<(), Error> {
+        let params = CancelledNotificationParams {
+            request_id: self.id.clone(),
+            reason: Some("subscription cancelled by the client".into()),
+        };
+        let notification = Notification::new(
+            crate::types::notification::commands::CANCELLED,
+            serde_json::to_value(params).ok(),
+        );
+        self.sender.send(notification.into()).await
+    }
+
+    /// Waits for the subscription to end and reports how.
+    pub async fn closed(self) -> SubscriptionEnd {
+        match self.response.await {
+            Ok(PendingResponse::Response(resp)) => match resp.into_result() {
+                Ok(result) => SubscriptionEnd::Graceful(result),
+                Err(_) => SubscriptionEnd::Abrupt,
+            },
+            _ => SubscriptionEnd::Abrupt,
+        }
+    }
+}
+
+/// Reads the acknowledged filter and its subscription id out of a
+/// `notifications/subscriptions/acknowledged` payload.
+pub(super) fn parse_ack(
+    notification: &Notification,
+) -> Result<(RequestId, SubscriptionFilter), Error> {
+    let params = notification
+        .params
+        .clone()
+        .ok_or_else(|| Error::new(ErrorCode::InvalidParams, "Acknowledgment has no params"))?;
+
+    serde_json::from_value::<crate::types::SubscriptionsAcknowledgedNotificationParams>(params)
+        .map(|p| (p.meta.subscription_id, p.notifications))
+        .map_err(|e| Error::new(ErrorCode::InvalidParams, e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Response, SUBSCRIPTION_ID_KEY};
+
+    fn ack(id: serde_json::Value, filter: serde_json::Value) -> Notification {
+        Notification::new(
+            crate::types::subscription::commands::ACKNOWLEDGED,
+            Some(serde_json::json!({
+                "notifications": filter,
+                "_meta": { SUBSCRIPTION_ID_KEY: id },
+            })),
+        )
+    }
+
+    #[test]
+    fn it_parses_an_acknowledgment() {
+        let notification = ack(
+            serde_json::json!(7),
+            serde_json::json!({ "toolsListChanged": true }),
+        );
+
+        let (id, filter) = parse_ack(&notification).unwrap();
+
+        assert_eq!(id, RequestId::Number(7));
+        assert!(filter.tools_list_changed);
+        assert!(!filter.prompts_list_changed);
+    }
+
+    #[test]
+    fn it_rejects_an_acknowledgment_without_a_subscription_id() {
+        let notification = Notification::new(
+            crate::types::subscription::commands::ACKNOWLEDGED,
+            Some(serde_json::json!({ "notifications": {} })),
+        );
+
+        assert!(parse_ack(&notification).is_err());
+    }
+
+    #[tokio::test]
+    async fn it_reports_a_graceful_close() {
+        let (tx, rx) = oneshot::channel();
+        let subscription = Subscription::new(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+            SubscriptionFilter::new().with_tools_changed(),
+            rx,
+            TransportProtoSender::None,
+        );
+
+        let result = serde_json::json!({ "_meta": { SUBSCRIPTION_ID_KEY: 1 } });
+        tx.send(PendingResponse::Response(Response::success(
+            RequestId::Number(1),
+            result,
+        )))
+        .unwrap();
+
+        let end = subscription.closed().await;
+        assert!(matches!(end, SubscriptionEnd::Graceful(r)
+            if r.meta.subscription_id == RequestId::Number(1)));
+    }
+
+    #[tokio::test]
+    async fn it_reports_an_abrupt_close_when_the_stream_drops() {
+        let (tx, rx) = oneshot::channel();
+        let subscription = Subscription::new(
+            RequestId::Number(1),
+            SubscriptionFilter::new(),
+            SubscriptionFilter::new(),
+            rx,
+            TransportProtoSender::None,
+        );
+
+        drop(tx);
+
+        assert!(matches!(
+            subscription.closed().await,
+            SubscriptionEnd::Abrupt
+        ));
+    }
+
+    #[test]
+    fn it_reports_a_narrowed_acknowledgment() {
+        let (_tx, rx) = oneshot::channel();
+        let subscription = Subscription::new(
+            RequestId::Number(1),
+            SubscriptionFilter::new()
+                .with_tools_changed()
+                .with_prompts_changed(),
+            SubscriptionFilter::new().with_tools_changed(),
+            rx,
+            TransportProtoSender::None,
+        );
+
+        assert!(!subscription.is_fully_honored());
+    }
+}

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -58,18 +58,30 @@ impl SubscriptionState {
         }
     }
 
-    /// Narrows the requested filter to what the peer acknowledged, and marks
-    /// the subscription established.
+    /// Establishes the subscription on an acknowledgment the client accepts,
+    /// narrowed to what was actually asked for. Returns whether it did.
     ///
-    /// Intersecting rather than replacing keeps a peer that acknowledges *more*
-    /// than was asked from widening what this stream may deliver in the window
-    /// before `listen` rejects it outright. A second acknowledgment for a
-    /// subscription that already has one changes nothing: the handshake happens
-    /// once.
-    pub(super) fn acknowledge(&mut self, acknowledged: &SubscriptionFilter) {
-        if let Self::Pending(requested) = self {
-            *self = Self::Established(requested.intersection(acknowledged));
+    /// An acknowledgment *broader* than the request is a protocol violation and
+    /// [`Client::listen`](crate::Client::listen) rejects the subscription over
+    /// it -- so this leaves the state pending rather than establishing
+    /// something about to be refused. Merely intersecting the filter would not
+    /// do: it keeps the extra category out, but the requested categories would
+    /// still be delivered in the window before `listen` returns its error, from
+    /// a subscription the caller is then told never opened.
+    ///
+    /// A second acknowledgment for a subscription that already has one changes
+    /// nothing: the handshake happens once.
+    pub(super) fn acknowledge(&mut self, acknowledged: &SubscriptionFilter) -> bool {
+        let Self::Pending(requested) = self else {
+            return false;
+        };
+
+        if !acknowledged.is_subset_of(requested) {
+            return false;
         }
+
+        *self = Self::Established(requested.intersection(acknowledged));
+        true
     }
 }
 
@@ -395,6 +407,13 @@ impl EstablishmentGuard {
     /// The stream is now the returned [`Subscription`]'s to end.
     pub(super) fn disarm(mut self) {
         self.armed = false;
+    }
+
+    /// Drops the bookkeeping without telling the peer anything, for a request
+    /// that never reached the wire.
+    pub(super) fn forget(mut self) {
+        self.armed = false;
+        self.release.release(&self.id);
     }
 
     /// Ends an establishment that failed, awaiting the cancellation rather than

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -20,14 +20,58 @@ use tokio::sync::oneshot;
 /// return once the server has confirmed the filter.
 pub(super) type AckWaiters = Arc<DashMap<RequestId, oneshot::Sender<SubscriptionFilter>>>;
 
-/// The filter each live subscription is allowed to deliver, keyed by its
+/// Where each subscription this client opened stands, keyed by its
 /// subscription id.
 ///
 /// The acknowledgment is a promise about what the stream will carry, and a
-/// noncompliant peer can break it *after* acknowledging correctly. Notifications
-/// go to the client's global handlers, so nothing downstream would notice; the
-/// receive loop checks each tagged notification against this instead.
-pub(super) type SubscriptionFilters = Arc<DashMap<RequestId, SubscriptionFilter>>;
+/// noncompliant peer can break it in either direction: by sending something
+/// outside the accepted filter after acknowledging correctly, or by sending
+/// anything at all before acknowledging. Notifications go to the client's
+/// global handlers, so nothing downstream would notice; the receive loop checks
+/// each tagged notification against this instead.
+pub(super) type SubscriptionStates = Arc<DashMap<RequestId, SubscriptionState>>;
+
+/// How far along a subscription's handshake is, and what it may deliver.
+#[derive(Debug, Clone)]
+pub(super) enum SubscriptionState {
+    /// The `subscriptions/listen` request is out and nothing has come back.
+    ///
+    /// Nothing may be delivered yet: the acknowledgment is required to be the
+    /// first message on the stream, and this subscription may still be
+    /// rejected outright or never acknowledged at all -- in which case
+    /// [`Client::listen`](crate::Client::listen) reports a failure that the
+    /// user's handlers would already have seen events from.
+    ///
+    /// Carries the *requested* filter, which the acknowledgment narrows.
+    Pending(SubscriptionFilter),
+
+    /// Acknowledged: what the subscription is allowed to carry from here on.
+    Established(SubscriptionFilter),
+}
+
+impl SubscriptionState {
+    /// The accepted filter, once there is one.
+    pub(super) fn established(&self) -> Option<&SubscriptionFilter> {
+        match self {
+            Self::Established(filter) => Some(filter),
+            Self::Pending(_) => None,
+        }
+    }
+
+    /// Narrows the requested filter to what the peer acknowledged, and marks
+    /// the subscription established.
+    ///
+    /// Intersecting rather than replacing keeps a peer that acknowledges *more*
+    /// than was asked from widening what this stream may deliver in the window
+    /// before `listen` rejects it outright. A second acknowledgment for a
+    /// subscription that already has one changes nothing: the handshake happens
+    /// once.
+    pub(super) fn acknowledge(&mut self, acknowledged: &SubscriptionFilter) {
+        if let Self::Pending(requested) = self {
+            *self = Self::Established(requested.intersection(acknowledged));
+        }
+    }
+}
 
 /// How a subscription stream ended.
 #[derive(Debug)]
@@ -255,14 +299,14 @@ impl Drop for Subscription {
 pub(super) struct SubscriptionRelease {
     pending: crate::shared::RequestQueue,
     ack_waiters: AckWaiters,
-    filters: SubscriptionFilters,
+    filters: SubscriptionStates,
 }
 
 impl SubscriptionRelease {
     pub(super) fn new(
         pending: crate::shared::RequestQueue,
         ack_waiters: AckWaiters,
-        filters: SubscriptionFilters,
+        filters: SubscriptionStates,
     ) -> Self {
         Self {
             pending,

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -78,6 +78,10 @@ impl SubscriptionState {
 pub enum SubscriptionEnd {
     /// The server answered the `subscriptions/listen` request with its
     /// graceful-close result.
+    ///
+    /// The result names the subscription it closes, and that name is checked
+    /// against this one -- a reply that closes some other subscription is
+    /// reported as [`Self::Abrupt`] rather than passed on.
     Graceful(SubscriptionsListenResult),
 
     /// The stream went away without a final result -- a dropped connection, a
@@ -245,8 +249,14 @@ impl Subscription {
 
         let end = match (&mut self.response).await {
             Ok(PendingResponse::Response(resp)) => match resp.into_result() {
-                Ok(result) => SubscriptionEnd::Graceful(result),
-                Err(_) => SubscriptionEnd::Abrupt,
+                // The result names the subscription it closes, and it has to be
+                // this one. The outer JSON-RPC id already matched -- that is how
+                // the reply reached this slot -- so a different id in the
+                // payload is a peer contradicting itself, and `Graceful` would
+                // hand the caller a closing result belonging to some other
+                // stream.
+                Ok(result) if self.closes_this(&result) => SubscriptionEnd::Graceful(result),
+                _ => SubscriptionEnd::Abrupt,
             },
             _ => SubscriptionEnd::Abrupt,
         };
@@ -255,6 +265,24 @@ impl Subscription {
         self.settled = true;
         self.release.release(&self.id);
         end
+    }
+
+    /// Whether a graceful-close result is this subscription's own.
+    #[inline]
+    fn closes_this(&self, result: &SubscriptionsListenResult) -> bool {
+        let matches = result.meta.subscription_id == self.id;
+
+        #[cfg(feature = "tracing")]
+        if !matches {
+            tracing::warn!(
+                logger = "neva",
+                subscription = %self.id,
+                closed = %result.meta.subscription_id,
+                "the closing result names a different subscription"
+            );
+        }
+
+        matches
     }
 }
 
@@ -513,6 +541,34 @@ mod tests {
         let end = subscription.closed().await;
         assert!(matches!(end, SubscriptionEnd::Graceful(r)
             if r.meta.subscription_id == RequestId::Number(1)));
+    }
+
+    /// The outer JSON-RPC id is how the reply reached this slot, so a different
+    /// id inside the result is the peer contradicting itself -- and `Graceful`
+    /// would hand the caller a result that closes some other stream.
+    #[tokio::test]
+    async fn it_refuses_a_closing_result_for_another_subscription() {
+        let (tx, rx) = oneshot::channel();
+        let subscription = Subscription::new(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+            SubscriptionFilter::new().with_tools_changed(),
+            rx,
+            TransportProtoSender::None,
+            release(),
+        );
+
+        let result = serde_json::json!({ "_meta": { SUBSCRIPTION_ID_KEY: 2 } });
+        tx.send(PendingResponse::Response(Response::success(
+            RequestId::Number(1),
+            result,
+        )))
+        .unwrap();
+
+        assert!(matches!(
+            subscription.closed().await,
+            SubscriptionEnd::Abrupt
+        ));
     }
 
     #[tokio::test]

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -285,6 +285,88 @@ impl std::fmt::Debug for SubscriptionRelease {
     }
 }
 
+/// Undoes a `subscriptions/listen` that was sent but never became a
+/// [`Subscription`].
+///
+/// Between the send and the returned handle there is bookkeeping only an
+/// explicit ending releases -- the acknowledgment waiter, the accepted filter,
+/// and a request slot that carries no TTL -- and a peer already streaming into
+/// it. The error paths in [`Client::listen`](crate::Client::listen) can await
+/// that cleanup, but the caller dropping the whole `listen` future (an outer
+/// `tokio::time::timeout`, a lost `select!` branch) runs none of them: the
+/// future simply stops existing at its next suspension point. This guard is
+/// what still runs then.
+///
+/// Armed from the moment the request goes out until ownership passes to the
+/// handle ([`Self::disarm`]) or the establishment gives up ([`Self::abandon`]).
+pub(super) struct EstablishmentGuard {
+    id: RequestId,
+    release: SubscriptionRelease,
+    sender: TransportProtoSender,
+    armed: bool,
+}
+
+impl EstablishmentGuard {
+    pub(super) fn new(
+        id: RequestId,
+        release: SubscriptionRelease,
+        sender: TransportProtoSender,
+    ) -> Self {
+        Self {
+            id,
+            release,
+            sender,
+            armed: true,
+        }
+    }
+
+    /// The stream is now the returned [`Subscription`]'s to end.
+    pub(super) fn disarm(mut self) {
+        self.armed = false;
+    }
+
+    /// Ends an establishment that failed, awaiting the cancellation rather than
+    /// handing it to the runtime the way [`Drop`] must.
+    pub(super) async fn abandon(mut self) {
+        self.armed = false;
+        self.release.release(&self.id);
+        let _ = self.sender.send(cancelled(&self.id).into()).await;
+    }
+}
+
+/// Best-effort by necessity, exactly as for [`Subscription`]: `Drop` cannot
+/// await, so the cancellation goes to the runtime. Outside a runtime there is
+/// nothing to hand it to and the subscription ends with the connection instead.
+impl Drop for EstablishmentGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+
+        self.release.release(&self.id);
+
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+
+        let mut sender = self.sender.clone();
+        let notification = cancelled(&self.id);
+
+        runtime.spawn(async move {
+            let _ = sender.send(notification.into()).await;
+        });
+    }
+}
+
+impl std::fmt::Debug for EstablishmentGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EstablishmentGuard")
+            .field("id", &self.id)
+            .field("armed", &self.armed)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Builds the `notifications/cancelled` that ends a subscription.
 ///
 /// Over stdio this is the mechanism the spec names. Over HTTP the spec has the

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -159,15 +159,35 @@ impl Subscription {
     /// which ends the subscription server-side -- directly over stdio, and over
     /// HTTP by way of the transport closing the listen response body. Await
     /// [`Self::closed`] afterwards to confirm how it ended.
+    ///
+    /// # Errors
+    /// Returns [`Error`] if the notification cannot be sent -- the transport is
+    /// already gone, most likely because the client disconnected. The
+    /// subscription is over either way, but it ended with the connection rather
+    /// than by this call, and [`Self::closed`] reports
+    /// [`SubscriptionEnd::Abrupt`] accordingly.
     pub async fn cancel(&mut self) -> Result<(), Error> {
-        self.cancelled = true;
+        let sent = self.sender.send(cancelled(&self.id).into()).await;
+
+        // Settled either way: there is no second attempt worth making on a
+        // transport that just refused the first.
         self.settled = true;
+        // Cancelled only if the notification actually went out. A cancel that
+        // never reached the wire ended nothing -- the connection did -- and
+        // reporting `Cancelled` for it would tell callers a deliberate stop
+        // happened where a connection loss did, which is exactly the difference
+        // reconnect logic keys on.
+        self.cancelled = sent.is_ok();
+
         // No terminal response is coming for a stream this client closed, so the
-        // request slot has to go now -- otherwise a client that opens and
-        // cancels subscriptions in a loop grows the pending queue by one entry
-        // per cycle, and these slots carry no TTL to expire them.
+        // request slot has to go -- otherwise a client that opens and cancels
+        // subscriptions in a loop grows the pending queue by one entry per
+        // cycle, and these slots carry no TTL to expire them. Dropping the slot
+        // also closes the receiver `closed()` awaits, which is what resolves it
+        // to `Abrupt` when the send failed.
         self.release.release(&self.id);
-        self.sender.send(cancelled(&self.id).into()).await
+
+        sent
     }
 
     /// Waits for the subscription to end and reports how.

--- a/neva/src/client/subscription.rs
+++ b/neva/src/client/subscription.rs
@@ -124,8 +124,10 @@ pub enum SubscriptionEnd {
 /// #[tokio::main]
 /// async fn main() -> Result<(), Error> {
 ///     let mut client = Client::new();
-///     client.on_tools_changed(|_| async { println!("tools changed"); });
 ///     client.connect().await?;
+///     // After `connect`: this helper asserts on the capabilities discovery
+///     // reports, and there are none until the handshake has run.
+///     client.on_tools_changed(|_| async { println!("tools changed"); });
 ///
 ///     let mut subscription = client
 ///         .listen(SubscriptionFilter::new().with_tools_changed())

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -293,6 +293,8 @@ pub mod prelude {
 
     #[cfg(feature = "client")]
     pub use crate::client::Client;
+    #[cfg(all(feature = "client", not(feature = "legacy-spec")))]
+    pub use crate::client::{Subscription, SubscriptionEnd};
 
     #[cfg(feature = "client-macros")]
     pub use crate::elicitation;

--- a/neva/src/shared/requests_queue.rs
+++ b/neva/src/shared/requests_queue.rs
@@ -226,6 +226,24 @@ impl RequestQueue {
         self.pending.len()
     }
 
+    /// Drops every queued request, closing the receiver each one is awaited on.
+    ///
+    /// For when no response can arrive any more -- the receive loop has stopped
+    /// because the transport is gone. Waiting out the TTL would be pointless
+    /// for ordinary requests and endless for a `subscriptions/listen` slot,
+    /// which has no TTL at all: its holder would await a stream end that is
+    /// never coming.
+    #[inline]
+    // Its only caller is the client's receive loop; a server-only build has no
+    // receive loop to stop.
+    #[cfg_attr(not(feature = "client"), allow(dead_code))]
+    pub(crate) fn abandon_all(&self) {
+        self.pending.clear();
+        if let Ok(mut expirations) = self.expirations.lock() {
+            expirations.clear();
+        }
+    }
+
     /// Takes a [`Response`] and completes the request if it's still pending
     #[inline]
     pub(crate) fn complete(&self, resp: Response) {

--- a/neva/src/shared/requests_queue.rs
+++ b/neva/src/shared/requests_queue.rs
@@ -212,6 +212,20 @@ impl RequestQueue {
         self.pending.remove(id).map(|(_, handle)| handle)
     }
 
+    /// Returns how many requests are currently queued.
+    ///
+    /// Slots for long-lived requests (`subscriptions/listen`) carry no TTL, so
+    /// nothing sweeps them: whoever gives up on one has to release it. This is
+    /// how the tests hold that contract.
+    #[inline]
+    // Its callers are the subscription tests, which the legacy profile compiles
+    // out; the profile that keeps them is the one that needs this.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.pending.len()
+    }
+
     /// Takes a [`Response`] and completes the request if it's still pending
     #[inline]
     pub(crate) fn complete(&self, resp: Response) {

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -317,9 +317,15 @@ async fn send_request(
 
     #[cfg(not(feature = "legacy-spec"))]
     if !abort.is_empty() {
+        // The session token belongs in this race too: `Client::disconnect`
+        // cancels it and the connection loop exits, but a listen POST is the
+        // one request nothing else stops -- it would go on draining its body,
+        // holding the server-side subscription open past the disconnect.
+        let session_token = session.cancellation_token();
         tokio::select! {
             _ = exchange(client, session, req, resp_tx, auth, param_registry) => {}
             _ = wait_for_any(&abort) => {}
+            _ = session_token.cancelled() => {}
         }
         return;
     }
@@ -537,24 +543,18 @@ impl Drop for AbortGuard {
 
 /// Registers abort handles for a request whose reply is a long-lived stream.
 ///
-/// Only `subscriptions/listen` qualifies: every other request is answered and
-/// gone, so tracking one would be bookkeeping nobody reads. Returns no handles
-/// (and a guard with nothing to clean up) for anything else.
+/// Only a standalone `subscriptions/listen` qualifies: every other request is
+/// answered and gone, so tracking one would be bookkeeping nobody reads, and a
+/// batched listen never reaches the transport (`send_batch` rejects it, having
+/// no handle to give it a lifetime). Returns no handles (and a guard with
+/// nothing to clean up) for anything else.
 #[cfg(not(feature = "legacy-spec"))]
 fn track_listen(req: &Message, session: &Arc<McpSession>) -> (Vec<CancellationToken>, AbortGuard) {
-    let is_listen = match req {
-        Message::Request(r) => r.method == crate::types::subscription::commands::LISTEN,
-        Message::Batch(batch) => batch.iter().any(|env| {
-            matches!(env, crate::types::MessageEnvelope::Request(r)
-                if r.method == crate::types::subscription::commands::LISTEN)
-        }),
-        _ => false,
-    };
-
-    let ids = if is_listen {
-        request_ids(req)
-    } else {
-        Vec::new()
+    let ids = match req {
+        Message::Request(r) if r.method == crate::types::subscription::commands::LISTEN => {
+            request_ids(req)
+        }
+        _ => Vec::new(),
     };
 
     let tokens = ids

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -473,8 +473,9 @@ async fn exchange(
     // resolves the pending request on the response.
     if is_event_stream(resp.headers()) {
         let stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
+        let ids = request_ids(&req);
 
-        let answered = drain_post_sse(stream, &resp_tx).await;
+        let answered = drain_post_sse(stream, &resp_tx, &ids).await;
 
         // A truncated stream, an unparseable frame, or EOF before the final
         // response would otherwise leave the originating request sitting in the
@@ -485,7 +486,7 @@ async fn exchange(
         if !answered {
             #[cfg(feature = "tracing")]
             tracing::error!(logger = "neva", STREAM_ENDED_BEFORE_RESPONSE);
-            for id in request_ids(&req) {
+            for id in ids {
                 let resp = crate::types::Response::error(
                     id,
                     Error::new(ErrorCode::InternalError, STREAM_ENDED_BEFORE_RESPONSE),
@@ -851,8 +852,13 @@ async fn handle_sse_connection(
 /// it carries to the receive loop.
 ///
 /// Returns whether the terminal reply arrived, so the caller can fail the
-/// originating request when the stream ends without one.
-async fn drain_post_sse<S>(mut stream: S, resp_tx: &mpsc::Sender<Result<Message, Error>>) -> bool
+/// originating request when the stream ends without one. `ids` are the requests
+/// this `POST` carried -- a reply answers it only by answering one of them.
+async fn drain_post_sse<S>(
+    mut stream: S,
+    resp_tx: &mpsc::Sender<Result<Message, Error>>,
+    ids: &[crate::types::RequestId],
+) -> bool
 where
     S: futures_util::Stream<Item = Result<sse_stream::Sse, sse_stream::Error>> + Unpin,
 {
@@ -860,7 +866,7 @@ where
     while let Some(event) = stream.next().await {
         match event {
             Ok(sse) if is_message_event(&sse) => {
-                if forward_sse_message(sse, resp_tx).await {
+                if forward_sse_message(sse, resp_tx, ids).await {
                     answered = true;
                 }
             }
@@ -944,18 +950,22 @@ async fn handle_msg(
 
 /// Forwards one frame of a request-scoped SSE `POST` reply to the receive loop.
 ///
-/// Returns `true` only for the *terminal* reply -- a response, or a batch that
-/// carries one -- so the caller can tell an orderly stream end from a truncated
-/// one (notifications, and frames that fail to parse, return `false`).
+/// Returns `true` only for the *terminal* reply -- a response to one of `ids`,
+/// the requests this `POST` carried, whether standalone or inside a batch -- so
+/// the caller can tell an orderly stream end from a truncated one
+/// (notifications, and frames that fail to parse, return `false`).
 ///
-/// A batch is not terminal by virtue of being a batch: a subscription stream
-/// may deliver its acknowledgment and its events batched, and treating those as
-/// the answer would make a stream that dies before the real response look
-/// orderly -- leaving a listen slot, which carries no TTL, with nothing to fail
-/// it and `Subscription::closed` waiting on a result that is never coming.
+/// Both halves of that matter. A batch is not terminal by virtue of being a
+/// batch: a subscription stream may deliver its acknowledgment and its events
+/// batched. And a response is not terminal by virtue of being a response: one
+/// carrying an id this `POST` never sent cannot resolve its pending slot. Either
+/// mistake makes a stream that dies before the real response look orderly,
+/// leaving a listen slot -- which carries no TTL -- with nothing to fail it and
+/// `Subscription::closed` waiting on a result that is never coming.
 async fn forward_sse_message(
     event: sse_stream::Sse,
     resp_tx: &mpsc::Sender<Result<Message, Error>>,
+    ids: &[crate::types::RequestId],
 ) -> bool {
     let Some(data) = event.data else {
         return false;
@@ -970,9 +980,12 @@ async fn forward_sse_message(
         }
     };
 
+    let answers = |resp: &crate::types::Response| ids.contains(&resp.full_id());
     let terminal = match &msg {
-        Message::Response(_) => true,
-        Message::Batch(batch) => batch.has_responses(),
+        Message::Response(resp) => answers(resp),
+        Message::Batch(batch) => batch.iter().any(
+            |env| matches!(env, crate::types::MessageEnvelope::Response(resp) if answers(resp)),
+        ),
         _ => false,
     };
 
@@ -1187,7 +1200,12 @@ mod tests {
             Ok(sse_stream::Sse::default().event("message").data(response)),
         ];
         assert!(
-            drain_post_sse(futures_util::stream::iter(frames), &tx).await,
+            drain_post_sse(
+                futures_util::stream::iter(frames),
+                &tx,
+                &[crate::types::RequestId::Number(1)]
+            )
+            .await,
             "the POST stream must count as answered"
         );
         assert!(matches!(rx.try_recv(), Ok(Ok(Message::Notification(_)))));
@@ -1205,7 +1223,14 @@ mod tests {
                 .event("endpoint")
                 .data(r#"{"jsonrpc":"2.0","id":1,"result":{}}"#)),
         ];
-        assert!(!drain_post_sse(futures_util::stream::iter(frames), &tx).await);
+        assert!(
+            !drain_post_sse(
+                futures_util::stream::iter(frames),
+                &tx,
+                &[crate::types::RequestId::Number(1)]
+            )
+            .await
+        );
         assert!(rx.try_recv().is_err(), "no frame should be delivered");
     }
 
@@ -1236,13 +1261,17 @@ mod tests {
                     {"jsonrpc":"2.0","id":1,"result":{}}]"#,
                 true,
             ),
+            // Nor is a response terminal by virtue of being a response: this
+            // `POST` never sent id 9, so nothing here can resolve its slot.
+            (r#"{"jsonrpc":"2.0","id":9,"result":{}}"#, false),
+            (r#"[{"jsonrpc":"2.0","id":9,"result":{}}]"#, false),
         ];
 
         for (frame, terminal) in cases {
             let (tx, mut rx) = mpsc::channel(1);
             let event = sse_stream::Sse::default().data(frame);
             assert_eq!(
-                forward_sse_message(event, &tx).await,
+                forward_sse_message(event, &tx, &[crate::types::RequestId::Number(1)]).await,
                 terminal,
                 "wrong terminal flag for {frame}"
             );
@@ -1254,7 +1283,7 @@ mod tests {
     async fn forward_sse_message_reports_unparseable_frame_as_unanswered() {
         let (tx, mut rx) = mpsc::channel(1);
         let event = sse_stream::Sse::default().data("not json");
-        assert!(!forward_sse_message(event, &tx).await);
+        assert!(!forward_sse_message(event, &tx, &[crate::types::RequestId::Number(1)]).await);
         assert!(
             rx.try_recv().is_err(),
             "a malformed frame must not reach the receive loop"

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -944,9 +944,15 @@ async fn handle_msg(
 
 /// Forwards one frame of a request-scoped SSE `POST` reply to the receive loop.
 ///
-/// Returns `true` only for the *terminal* reply -- a response or a batch
-/// response -- so the caller can tell an orderly stream end from a truncated one
-/// (notifications, and frames that fail to parse, return `false`).
+/// Returns `true` only for the *terminal* reply -- a response, or a batch that
+/// carries one -- so the caller can tell an orderly stream end from a truncated
+/// one (notifications, and frames that fail to parse, return `false`).
+///
+/// A batch is not terminal by virtue of being a batch: a subscription stream
+/// may deliver its acknowledgment and its events batched, and treating those as
+/// the answer would make a stream that dies before the real response look
+/// orderly -- leaving a listen slot, which carries no TTL, with nothing to fail
+/// it and `Subscription::closed` waiting on a result that is never coming.
 async fn forward_sse_message(
     event: sse_stream::Sse,
     resp_tx: &mpsc::Sender<Result<Message, Error>>,
@@ -954,6 +960,7 @@ async fn forward_sse_message(
     let Some(data) = event.data else {
         return false;
     };
+
     let msg = match serde_json::from_str::<Message>(&data) {
         Ok(msg) => msg,
         Err(_err) => {
@@ -962,12 +969,19 @@ async fn forward_sse_message(
             return false;
         }
     };
-    let terminal = matches!(msg, Message::Response(_) | Message::Batch(_));
+
+    let terminal = match &msg {
+        Message::Response(_) => true,
+        Message::Batch(batch) => batch.has_responses(),
+        _ => false,
+    };
+
     if let Err(_err) = resp_tx.send(Ok(msg)).await {
         #[cfg(feature = "tracing")]
         tracing::error!(logger = "neva", "Failed to send response: {}", _err);
         return false;
     }
+
     terminal
 }
 
@@ -1208,6 +1222,20 @@ mod tests {
             ),
             (r#"{"jsonrpc":"2.0","id":1,"result":{}}"#, true),
             (r#"[{"jsonrpc":"2.0","id":1,"result":{}}]"#, true),
+            // A batch is not terminal by virtue of being a batch: a
+            // subscription stream may deliver its acknowledgment and its events
+            // this way, and the response is still to come.
+            (
+                r#"[{"jsonrpc":"2.0","method":"notifications/subscriptions/acknowledged"},
+                    {"jsonrpc":"2.0","method":"notifications/tools/list_changed"}]"#,
+                false,
+            ),
+            // ...but one that carries a response among them is.
+            (
+                r#"[{"jsonrpc":"2.0","method":"notifications/message"},
+                    {"jsonrpc":"2.0","id":1,"result":{}}]"#,
+                true,
+            ),
         ];
 
         for (frame, terminal) in cases {

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -299,8 +299,16 @@ async fn send_request(
     auth: ClientAuth,
     #[cfg(not(feature = "legacy-spec"))] param_registry: crate::shared::param_headers::Registry,
 ) {
+    // Registered *before* the request goes out: a subscription can be cancelled
+    // while the peer is still sitting on the response headers -- establishment
+    // timing out is exactly that case -- and a handle installed only once the
+    // body arrives would leave that cancel with nothing to abort, then start
+    // draining an orphaned stream when the headers finally land.
+    #[cfg(not(feature = "legacy-spec"))]
+    let (abort, _abort_guard) = track_listen(&req, &session);
+
     let bearer = auth.fresh_bearer().await;
-    let resp = match build_post(
+    let request = build_post(
         &client,
         &session,
         &req,
@@ -308,9 +316,19 @@ async fn send_request(
         #[cfg(not(feature = "legacy-spec"))]
         &param_registry,
     )
-    .send()
-    .await
-    {
+    .send();
+
+    #[cfg(not(feature = "legacy-spec"))]
+    let sent = tokio::select! {
+        sent = request => sent,
+        // Cancelled before the peer even replied: nothing to close, and no
+        // reply worth waiting for.
+        _ = wait_for_any(&abort) => return,
+    };
+    #[cfg(feature = "legacy-spec")]
+    let sent = request.await;
+
+    let resp = match sent {
         Ok(resp) => resp,
         Err(_err) => {
             #[cfg(feature = "tracing")]
@@ -414,25 +432,13 @@ async fn send_request(
         let stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
 
         #[cfg(not(feature = "legacy-spec"))]
-        let answered = {
-            let abort = abort_handles(&req, &session);
-            let drained = tokio::select! {
-                answered = drain_post_sse(stream, &resp_tx) => Some(answered),
-                // Cancelled from this side: dropping `stream` closes the body,
-                // which is what tells the server the subscription is over. The
-                // request is deliberately left uncompleted -- the caller that
-                // cancelled already knows how this ended.
-                _ = wait_for_any(&abort) => None,
-            };
-
-            for id in request_ids(&req) {
-                session.untrack_stream(&id);
-            }
-
-            match drained {
-                Some(answered) => answered,
-                None => return,
-            }
+        let answered = tokio::select! {
+            answered = drain_post_sse(stream, &resp_tx) => answered,
+            // Cancelled from this side: dropping `stream` closes the body,
+            // which is what tells the server the subscription is over. The
+            // request is deliberately left uncompleted -- the caller that
+            // cancelled already knows how this ended.
+            _ = wait_for_any(&abort) => return,
         };
         #[cfg(feature = "legacy-spec")]
         let answered = drain_post_sse(stream, &resp_tx).await;
@@ -492,13 +498,57 @@ async fn send_request(
     }
 }
 
-/// Registers an abort handle per request id carried by `req`.
+/// Untracks a request's abort handles however [`send_request`] exits -- a
+/// transport error, a non-streaming reply, a cancel, or a panic.
 #[cfg(not(feature = "legacy-spec"))]
-fn abort_handles(req: &Message, session: &McpSession) -> Vec<CancellationToken> {
-    request_ids(req)
-        .into_iter()
-        .map(|id| session.track_stream(id))
-        .collect()
+struct AbortGuard {
+    session: Arc<McpSession>,
+    ids: Vec<crate::types::RequestId>,
+}
+
+#[cfg(not(feature = "legacy-spec"))]
+impl Drop for AbortGuard {
+    fn drop(&mut self) {
+        for id in &self.ids {
+            self.session.untrack_stream(id);
+        }
+    }
+}
+
+/// Registers abort handles for a request whose reply is a long-lived stream.
+///
+/// Only `subscriptions/listen` qualifies: every other request is answered and
+/// gone, so tracking one would be bookkeeping nobody reads. Returns no handles
+/// (and a guard with nothing to clean up) for anything else.
+#[cfg(not(feature = "legacy-spec"))]
+fn track_listen(req: &Message, session: &Arc<McpSession>) -> (Vec<CancellationToken>, AbortGuard) {
+    let is_listen = match req {
+        Message::Request(r) => r.method == crate::types::subscription::commands::LISTEN,
+        Message::Batch(batch) => batch.iter().any(|env| {
+            matches!(env, crate::types::MessageEnvelope::Request(r)
+                if r.method == crate::types::subscription::commands::LISTEN)
+        }),
+        _ => false,
+    };
+
+    let ids = if is_listen {
+        request_ids(req)
+    } else {
+        Vec::new()
+    };
+
+    let tokens = ids
+        .iter()
+        .map(|id| session.track_stream(id.clone()))
+        .collect();
+
+    (
+        tokens,
+        AbortGuard {
+            session: session.clone(),
+            ids,
+        },
+    )
 }
 
 /// Resolves as soon as any of `tokens` is cancelled, or never when empty.

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -291,6 +291,14 @@ fn build_post(
     resp
 }
 
+/// Sends one message, racing the whole exchange against a cancellation of the
+/// subscription it opens (if it opens one).
+///
+/// The race wraps *everything* rather than individual awaits: a cancel can land
+/// while the token is being refreshed, while an authorization flow runs, while
+/// the peer sits on the response headers, or mid-stream. Dropping the inner
+/// future at any of those points drops the request and its response body, which
+/// is exactly the close the server reads as "this subscription is over".
 async fn send_request(
     client: reqwest::Client,
     session: Arc<McpSession>,
@@ -307,8 +315,39 @@ async fn send_request(
     #[cfg(not(feature = "legacy-spec"))]
     let (abort, _abort_guard) = track_listen(&req, &session);
 
+    #[cfg(not(feature = "legacy-spec"))]
+    if !abort.is_empty() {
+        tokio::select! {
+            _ = exchange(client, session, req, resp_tx, auth, param_registry) => {}
+            _ = wait_for_any(&abort) => {}
+        }
+        return;
+    }
+
+    exchange(
+        client,
+        session,
+        req,
+        resp_tx,
+        auth,
+        #[cfg(not(feature = "legacy-spec"))]
+        param_registry,
+    )
+    .await
+}
+
+/// The exchange itself: send, handle a managed-OAuth retry, then read the reply
+/// (a single body, or a stream drained into the receive loop).
+async fn exchange(
+    client: reqwest::Client,
+    session: Arc<McpSession>,
+    req: Message,
+    resp_tx: mpsc::Sender<Result<Message, Error>>,
+    auth: ClientAuth,
+    #[cfg(not(feature = "legacy-spec"))] param_registry: crate::shared::param_headers::Registry,
+) {
     let bearer = auth.fresh_bearer().await;
-    let request = build_post(
+    let sent = build_post(
         &client,
         &session,
         &req,
@@ -316,17 +355,8 @@ async fn send_request(
         #[cfg(not(feature = "legacy-spec"))]
         &param_registry,
     )
-    .send();
-
-    #[cfg(not(feature = "legacy-spec"))]
-    let sent = tokio::select! {
-        sent = request => sent,
-        // Cancelled before the peer even replied: nothing to close, and no
-        // reply worth waiting for.
-        _ = wait_for_any(&abort) => return,
-    };
-    #[cfg(feature = "legacy-spec")]
-    let sent = request.await;
+    .send()
+    .await;
 
     let resp = match sent {
         Ok(resp) => resp,
@@ -431,16 +461,6 @@ async fn send_request(
     if is_event_stream(resp.headers()) {
         let stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
 
-        #[cfg(not(feature = "legacy-spec"))]
-        let answered = tokio::select! {
-            answered = drain_post_sse(stream, &resp_tx) => answered,
-            // Cancelled from this side: dropping `stream` closes the body,
-            // which is what tells the server the subscription is over. The
-            // request is deliberately left uncompleted -- the caller that
-            // cancelled already knows how this ended.
-            _ = wait_for_any(&abort) => return,
-        };
-        #[cfg(feature = "legacy-spec")]
         let answered = drain_post_sse(stream, &resp_tx).await;
 
         // A truncated stream, an unparseable frame, or EOF before the final

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -222,6 +222,13 @@ async fn handle_connection(
                     tracing::error!(logger = "neva", "Unexpected messaging error");
                     break;
                 };
+                // A cancel naming a request whose reply is a long-lived stream
+                // ends it the way this transport can: by closing the body. The
+                // notification still goes out -- a peer may want the reason --
+                // but the close is what the server acts on.
+                #[cfg(not(feature = "legacy-spec"))]
+                abort_cancelled_stream(&req, &session);
+
                 crate::spawn_fair!(send_request(
                     client.clone(),
                     session.clone(),
@@ -405,6 +412,29 @@ async fn send_request(
     // resolves the pending request on the response.
     if is_event_stream(resp.headers()) {
         let stream = sse_stream::SseStream::from_bytes_stream(resp.bytes_stream());
+
+        #[cfg(not(feature = "legacy-spec"))]
+        let answered = {
+            let abort = abort_handles(&req, &session);
+            let drained = tokio::select! {
+                answered = drain_post_sse(stream, &resp_tx) => Some(answered),
+                // Cancelled from this side: dropping `stream` closes the body,
+                // which is what tells the server the subscription is over. The
+                // request is deliberately left uncompleted -- the caller that
+                // cancelled already knows how this ended.
+                _ = wait_for_any(&abort) => None,
+            };
+
+            for id in request_ids(&req) {
+                session.untrack_stream(&id);
+            }
+
+            match drained {
+                Some(answered) => answered,
+                None => return,
+            }
+        };
+        #[cfg(feature = "legacy-spec")]
         let answered = drain_post_sse(stream, &resp_tx).await;
 
         // A truncated stream, an unparseable frame, or EOF before the final
@@ -459,6 +489,47 @@ async fn send_request(
                 }
             }
         }
+    }
+}
+
+/// Registers an abort handle per request id carried by `req`.
+#[cfg(not(feature = "legacy-spec"))]
+fn abort_handles(req: &Message, session: &McpSession) -> Vec<CancellationToken> {
+    request_ids(req)
+        .into_iter()
+        .map(|id| session.track_stream(id))
+        .collect()
+}
+
+/// Resolves as soon as any of `tokens` is cancelled, or never when empty.
+#[cfg(not(feature = "legacy-spec"))]
+async fn wait_for_any(tokens: &[CancellationToken]) {
+    if tokens.is_empty() {
+        std::future::pending::<()>().await;
+    }
+
+    futures_util::future::select_all(tokens.iter().map(|t| Box::pin(t.cancelled()))).await;
+}
+
+/// Aborts the streamed reply a `notifications/cancelled` names, if this session
+/// is carrying one.
+#[cfg(not(feature = "legacy-spec"))]
+fn abort_cancelled_stream(msg: &Message, session: &McpSession) {
+    let Message::Notification(notification) = msg else {
+        return;
+    };
+
+    if notification.method != crate::types::notification::commands::CANCELLED {
+        return;
+    }
+
+    if let Some(id) = notification
+        .params
+        .as_ref()
+        .and_then(|p| p.get("requestId"))
+        .and_then(|v| serde_json::from_value::<crate::types::RequestId>(v.clone()).ok())
+    {
+        session.abort_stream(&id);
     }
 }
 

--- a/neva/src/transport/http/client.rs
+++ b/neva/src/transport/http/client.rs
@@ -229,6 +229,15 @@ async fn handle_connection(
                 #[cfg(not(feature = "legacy-spec"))]
                 abort_cancelled_stream(&req, &session);
 
+                // Tracked here rather than inside the spawned task, so that a
+                // cancel arriving right behind a listen -- which is exactly
+                // what a dropped `Client::listen` sends -- finds the handle.
+                // Registering it in the task would leave the ordering to the
+                // scheduler; registering it in this loop makes it the order the
+                // messages arrived in.
+                #[cfg(not(feature = "legacy-spec"))]
+                let abort = track_listen(&req, &session);
+
                 crate::spawn_fair!(send_request(
                     client.clone(),
                     session.clone(),
@@ -237,6 +246,8 @@ async fn handle_connection(
                     auth.clone(),
                     #[cfg(not(feature = "legacy-spec"))]
                     param_registry.clone(),
+                    #[cfg(not(feature = "legacy-spec"))]
+                    abort,
                 ));
             }
         }
@@ -299,6 +310,9 @@ fn build_post(
 /// the peer sits on the response headers, or mid-stream. Dropping the inner
 /// future at any of those points drops the request and its response body, which
 /// is exactly the close the server reads as "this subscription is over".
+///
+/// `abort` is handed in already registered -- see [`track_listen`] for why the
+/// registration cannot happen in here.
 async fn send_request(
     client: reqwest::Client,
     session: Arc<McpSession>,
@@ -306,17 +320,10 @@ async fn send_request(
     resp_tx: mpsc::Sender<Result<Message, Error>>,
     auth: ClientAuth,
     #[cfg(not(feature = "legacy-spec"))] param_registry: crate::shared::param_headers::Registry,
+    #[cfg(not(feature = "legacy-spec"))] abort: ListenAbort,
 ) {
-    // Registered *before* the request goes out: a subscription can be cancelled
-    // while the peer is still sitting on the response headers -- establishment
-    // timing out is exactly that case -- and a handle installed only once the
-    // body arrives would leave that cancel with nothing to abort, then start
-    // draining an orphaned stream when the headers finally land.
     #[cfg(not(feature = "legacy-spec"))]
-    let (abort, _abort_guard) = track_listen(&req, &session);
-
-    #[cfg(not(feature = "legacy-spec"))]
-    if !abort.is_empty() {
+    if abort.is_tracked() {
         // The session token belongs in this race too: `Client::disconnect`
         // cancels it and the connection loop exits, but a listen POST is the
         // one request nothing else stops -- it would go on draining its body,
@@ -324,7 +331,7 @@ async fn send_request(
         let session_token = session.cancellation_token();
         tokio::select! {
             _ = exchange(client, session, req, resp_tx, auth, param_registry) => {}
-            _ = wait_for_any(&abort) => {}
+            _ = abort.cancelled() => {}
             _ = session_token.cancelled() => {}
         }
         return;
@@ -524,16 +531,40 @@ async fn exchange(
     }
 }
 
-/// Untracks a request's abort handles however [`send_request`] exits -- a
-/// transport error, a non-streaming reply, a cancel, or a panic.
+/// A request's registered abort handles, and their untracking.
+///
+/// Carried into [`send_request`] rather than made there: registration has to
+/// happen in the connection loop, ahead of the spawn -- see [`track_listen`].
+/// Empty for everything that is not a listen.
 #[cfg(not(feature = "legacy-spec"))]
-struct AbortGuard {
+struct ListenAbort {
+    tokens: Vec<CancellationToken>,
     session: Arc<McpSession>,
     ids: Vec<crate::types::RequestId>,
 }
 
 #[cfg(not(feature = "legacy-spec"))]
-impl Drop for AbortGuard {
+impl ListenAbort {
+    /// Whether this request opens a stream worth aborting at all.
+    fn is_tracked(&self) -> bool {
+        !self.tokens.is_empty()
+    }
+
+    /// Resolves as soon as any of the handles is cancelled, or never when there
+    /// are none.
+    async fn cancelled(&self) {
+        if self.tokens.is_empty() {
+            std::future::pending::<()>().await;
+        }
+
+        futures_util::future::select_all(self.tokens.iter().map(|t| Box::pin(t.cancelled()))).await;
+    }
+}
+
+/// Untracks the handles however [`send_request`] exits -- a transport error, a
+/// non-streaming reply, a cancel, or a panic.
+#[cfg(not(feature = "legacy-spec"))]
+impl Drop for ListenAbort {
     fn drop(&mut self) {
         for id in &self.ids {
             self.session.untrack_stream(id);
@@ -543,13 +574,19 @@ impl Drop for AbortGuard {
 
 /// Registers abort handles for a request whose reply is a long-lived stream.
 ///
+/// Called from the connection loop *before* the request is spawned, not from
+/// the spawned task: a `notifications/cancelled` queued right behind a listen
+/// -- which is what a dropped `Client::listen` sends -- is read by the very
+/// next turn of that loop, and would find nothing to abort if registration were
+/// left to the scheduler. Registering here makes the order the order the
+/// messages were written in.
+///
 /// Only a standalone `subscriptions/listen` qualifies: every other request is
 /// answered and gone, so tracking one would be bookkeeping nobody reads, and a
 /// batched listen never reaches the transport (`send_batch` rejects it, having
-/// no handle to give it a lifetime). Returns no handles (and a guard with
-/// nothing to clean up) for anything else.
+/// no handle to give it a lifetime). Returns nothing tracked for anything else.
 #[cfg(not(feature = "legacy-spec"))]
-fn track_listen(req: &Message, session: &Arc<McpSession>) -> (Vec<CancellationToken>, AbortGuard) {
+fn track_listen(req: &Message, session: &Arc<McpSession>) -> ListenAbort {
     let ids = match req {
         Message::Request(r) if r.method == crate::types::subscription::commands::LISTEN => {
             request_ids(req)
@@ -562,23 +599,11 @@ fn track_listen(req: &Message, session: &Arc<McpSession>) -> (Vec<CancellationTo
         .map(|id| session.track_stream(id.clone()))
         .collect();
 
-    (
+    ListenAbort {
         tokens,
-        AbortGuard {
-            session: session.clone(),
-            ids,
-        },
-    )
-}
-
-/// Resolves as soon as any of `tokens` is cancelled, or never when empty.
-#[cfg(not(feature = "legacy-spec"))]
-async fn wait_for_any(tokens: &[CancellationToken]) {
-    if tokens.is_empty() {
-        std::future::pending::<()>().await;
+        session: session.clone(),
+        ids,
     }
-
-    futures_util::future::select_all(tokens.iter().map(|t| Box::pin(t.cancelled()))).await;
 }
 
 /// Aborts the streamed reply a `notifications/cancelled` names, if this session

--- a/neva/src/transport/http/client/mcp_session.rs
+++ b/neva/src/transport/http/client/mcp_session.rs
@@ -18,6 +18,17 @@ pub(super) struct McpSession {
     session_id: OnceCell<uuid::Uuid>,
     last_event_id: RwLock<Option<String>>,
     cancellation_token: CancellationToken,
+
+    /// Abort handles for in-flight requests whose reply is a long-lived stream
+    /// (`subscriptions/listen`).
+    ///
+    /// A subscription is ended over HTTP by closing its response body -- that
+    /// is the spec's cancellation mechanism on this transport, and the only one
+    /// that works, since a `notifications/cancelled` travels on its own `POST`
+    /// and carries no evidence of which stream it belongs to. Cancelling the
+    /// token here drops the body without disturbing the rest of the session.
+    #[cfg(not(feature = "legacy-spec"))]
+    streams: dashmap::DashMap<crate::types::RequestId, CancellationToken>,
 }
 
 impl McpSession {
@@ -41,6 +52,36 @@ impl McpSession {
             last_event_id: RwLock::new(None),
             cancellation_token: token,
             url: Arc::from(url.to_url()),
+            #[cfg(not(feature = "legacy-spec"))]
+            streams: dashmap::DashMap::new(),
+        }
+    }
+
+    /// Registers an abort handle for the in-flight request `id` and returns it.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(super) fn track_stream(&self, id: crate::types::RequestId) -> CancellationToken {
+        let token = CancellationToken::new();
+        self.streams.insert(id, token.clone());
+        token
+    }
+
+    /// Drops the abort handle for `id`, once its reply has been read.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(super) fn untrack_stream(&self, id: &crate::types::RequestId) {
+        self.streams.remove(id);
+    }
+
+    /// Aborts the in-flight request `id`, closing its response body.
+    ///
+    /// Returns whether there was one to abort.
+    #[cfg(not(feature = "legacy-spec"))]
+    pub(super) fn abort_stream(&self, id: &crate::types::RequestId) -> bool {
+        match self.streams.remove(id) {
+            Some((_, token)) => {
+                token.cancel();
+                true
+            }
+            None => false,
         }
     }
 

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -467,10 +467,13 @@ async fn handle_post_streaming<E: HttpEngine>(
             // Opted in: register the per-request notification sink (keyed by the
             // per-POST session id, which the tracing span carries) before the
             // runtime starts handling, then stream notifications + response.
-            let notif_rx =
-                crate::types::notification::sink::register(id, ctx.sse_log_queue_capacity);
-
             let hold_for_ack = is_subscription_stream(&msg);
+            let notif_rx = crate::types::notification::sink::register(
+                id,
+                ctx.sse_log_queue_capacity,
+                hold_for_ack,
+            )
+            .await;
 
             if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
                 crate::types::notification::sink::unregister(&id);

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -467,8 +467,11 @@ async fn handle_post_streaming<E: HttpEngine>(
             // Opted in: register the per-request notification sink (keyed by the
             // per-POST session id, which the tracing span carries) before the
             // runtime starts handling, then stream notifications + response.
-            let notif_rx =
-                crate::types::notification::sink::register(id, ctx.sse_log_queue_capacity);
+            let notif_rx = crate::types::notification::sink::register(
+                id,
+                ctx.sse_log_queue_capacity,
+                is_subscription_stream(&msg),
+            );
 
             if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
                 crate::types::notification::sink::unregister(&id);
@@ -508,6 +511,18 @@ fn opts_into_notifications(msg: &Message) -> bool {
         ),
         _ => false,
     }
+}
+
+/// Whether this `POST` body *is* a subscription stream rather than a request's
+/// own notification stream.
+///
+/// The distinction decides what may be written to it: a subscription stream
+/// opens with the acknowledgment and carries that subscription's notifications,
+/// so request-scoped log messages stay off it.
+#[cfg(not(feature = "legacy-spec"))]
+fn is_subscription_stream(msg: &Message) -> bool {
+    matches!(msg, Message::Request(r)
+        if r.method == crate::types::subscription::commands::LISTEN)
 }
 
 /// Whether a single request needs the streaming reply: `subscriptions/listen`

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -73,13 +73,13 @@ pub async fn dispatch_post<E: HttpEngine>(
     ctx: &HttpContext,
 ) -> Result<StreamResponse<impl Stream<Item = E::SseEvent> + Send + 'static>, Error> {
     let neutral = E::adapt_request(req).await?;
-    #[cfg(all(not(feature = "legacy-spec"), feature = "tracing"))]
+    #[cfg(not(feature = "legacy-spec"))]
     {
         Ok(handle_post_streaming::<E>(neutral, ctx).await)
     }
-    // Under `legacy-spec` (or without tracing to source the notifications)
-    // every POST reply is a single body; the Stream arm is never produced.
-    #[cfg(not(all(not(feature = "legacy-spec"), feature = "tracing")))]
+    // Under `legacy-spec` every POST reply is a single body; the Stream arm is
+    // never produced.
+    #[cfg(feature = "legacy-spec")]
     {
         let resp = handle_post(neutral, ctx).await;
         Ok(StreamResponse::<stream::Empty<E::SseEvent>>::Complete(resp))
@@ -431,7 +431,7 @@ async fn prepare_post(req: HttpRequest, ctx: &HttpContext) -> PostPrep {
 /// flow first (routed via the per-request sink), then the final response closes
 /// the stream. Otherwise the reply is a single JSON object (`Complete`),
 /// exactly as [`handle_post`].
-#[cfg(all(not(feature = "legacy-spec"), feature = "tracing"))]
+#[cfg(not(feature = "legacy-spec"))]
 async fn handle_post_streaming<E: HttpEngine>(
     req: HttpRequest,
     ctx: &HttpContext,
@@ -467,13 +467,11 @@ async fn handle_post_streaming<E: HttpEngine>(
             // Opted in: register the per-request notification sink (keyed by the
             // per-POST session id, which the tracing span carries) before the
             // runtime starts handling, then stream notifications + response.
-            let notif_rx = crate::types::notification::fmt::register_request_sink(
-                id,
-                ctx.sse_log_queue_capacity,
-            );
+            let notif_rx =
+                crate::types::notification::sink::register(id, ctx.sse_log_queue_capacity);
 
             if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
-                crate::types::notification::fmt::unregister_request_sink(&id);
+                crate::types::notification::sink::unregister(&id);
                 ctx.pending.remove(&full_id);
                 return StreamResponse::Complete(status_response(
                     http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -493,15 +491,15 @@ async fn handle_post_streaming<E: HttpEngine>(
     }
 }
 
-/// Whether a message opts into request-scoped notifications: a request -- or,
-/// for a batch, *any* contained request -- carrying `logLevel` or
-/// `progressToken` in `_meta`.
+/// Whether a message opts into notifications on its own `POST` response
+/// stream: a `subscriptions/listen`, or a request -- or, for a batch, *any*
+/// contained request -- carrying `logLevel` or `progressToken` in `_meta`.
 ///
 /// Batches count because a client (e.g. via `Client::apply_client_meta_to_batch`)
 /// stamps the configured level onto every batched request; the inner requests
 /// share this POST's session id (copied in `execute_batch`), so their
 /// notifications route to the one sink and stream on this single response.
-#[cfg(all(not(feature = "legacy-spec"), feature = "tracing"))]
+#[cfg(not(feature = "legacy-spec"))]
 fn opts_into_notifications(msg: &Message) -> bool {
     match msg {
         Message::Request(r) => request_opts_in(r),
@@ -512,9 +510,14 @@ fn opts_into_notifications(msg: &Message) -> bool {
     }
 }
 
-/// Whether a single request carries `logLevel` or `progressToken` in `_meta`.
-#[cfg(all(not(feature = "legacy-spec"), feature = "tracing"))]
+/// Whether a single request needs the streaming reply: `subscriptions/listen`
+/// (whose whole point is a long-lived notification stream), or a request
+/// carrying `logLevel` or `progressToken` in `_meta`.
+#[cfg(not(feature = "legacy-spec"))]
 fn request_opts_in(req: &crate::types::Request) -> bool {
+    if req.method == crate::types::subscription::commands::LISTEN {
+        return true;
+    }
     req.params
         .as_ref()
         .and_then(|p| p.get("_meta"))
@@ -537,7 +540,7 @@ fn request_opts_in(req: &crate::types::Request) -> bool {
 ///
 /// Dropping the stream (end of body or client disconnect) unregisters the
 /// per-request sink and clears the pending entry.
-#[cfg(all(not(feature = "legacy-spec"), feature = "tracing"))]
+#[cfg(not(feature = "legacy-spec"))]
 fn post_notification_stream(
     id: uuid::Uuid,
     full_id: RequestId,
@@ -552,7 +555,7 @@ fn post_notification_stream(
     }
     impl Drop for Cleanup {
         fn drop(&mut self) {
-            crate::types::notification::fmt::unregister_request_sink(&self.id);
+            crate::types::notification::sink::unregister(&self.id);
             self.pending.remove(&self.full_id);
         }
     }

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -519,10 +519,24 @@ fn opts_into_notifications(msg: &Message) -> bool {
 /// The distinction decides what may be written to it: a subscription stream
 /// opens with the acknowledgment and carries that subscription's notifications,
 /// so request-scoped log messages stay off it.
+///
+/// A batch counts if it contains a listen at all. neva's own client refuses to
+/// batch one -- a batch slot has no handle to end the subscription with -- but
+/// this server accepts what any peer sends, and a batched listen streams on
+/// this same body with the same ordering requirement.
 #[cfg(not(feature = "legacy-spec"))]
 fn is_subscription_stream(msg: &Message) -> bool {
-    matches!(msg, Message::Request(r)
-        if r.method == crate::types::subscription::commands::LISTEN)
+    fn is_listen(req: &crate::types::Request) -> bool {
+        req.method == crate::types::subscription::commands::LISTEN
+    }
+
+    match msg {
+        Message::Request(r) => is_listen(r),
+        Message::Batch(batch) => batch
+            .iter()
+            .any(|env| matches!(env, crate::types::MessageEnvelope::Request(r) if is_listen(r))),
+        _ => false,
+    }
 }
 
 /// Whether a single request needs the streaming reply: `subscriptions/listen`

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -467,11 +467,10 @@ async fn handle_post_streaming<E: HttpEngine>(
             // Opted in: register the per-request notification sink (keyed by the
             // per-POST session id, which the tracing span carries) before the
             // runtime starts handling, then stream notifications + response.
-            let notif_rx = crate::types::notification::sink::register(
-                id,
-                ctx.sse_log_queue_capacity,
-                is_subscription_stream(&msg),
-            );
+            let notif_rx =
+                crate::types::notification::sink::register(id, ctx.sse_log_queue_capacity);
+
+            let hold_for_ack = is_subscription_stream(&msg);
 
             if ctx.inbound_tx.send(Ok(msg)).await.is_err() {
                 crate::types::notification::sink::unregister(&id);
@@ -482,9 +481,16 @@ async fn handle_post_streaming<E: HttpEngine>(
                 ));
             }
 
-            let stream =
-                post_notification_stream(id, full_id, ctx.pending.clone(), notif_rx, resp_rx)
-                    .map(|msg| E::ephemeral_event(&msg));
+            let stream = post_notification_stream(
+                id,
+                full_id,
+                ctx.pending.clone(),
+                notif_rx,
+                resp_rx,
+                hold_for_ack,
+                ctx.sse_log_queue_capacity,
+            )
+            .map(|msg| E::ephemeral_event(&msg));
 
             StreamResponse::Stream {
                 headers: HeaderMap::new(),
@@ -569,6 +575,15 @@ fn request_opts_in(req: &crate::types::Request) -> bool {
 ///
 /// Dropping the stream (end of body or client disconnect) unregisters the
 /// per-request sink and clears the pending entry.
+///
+/// `hold_for_ack` marks a body that carries a `subscriptions/listen`: there the
+/// acknowledgment MUST be the first message, and middleware logging ahead of
+/// `next(ctx)` is queued before `Context::listen` ever runs. Anything arriving
+/// before the acknowledgment is therefore held back and released right after
+/// it -- ordering the stream rather than dropping the messages, which matters
+/// because a mixed batch's other requests log here too, and their logs were
+/// explicitly asked for. `hold_limit` bounds that buffer at what the sink
+/// itself would have held, so a peer that never acknowledges cannot grow it.
 #[cfg(not(feature = "legacy-spec"))]
 fn post_notification_stream(
     id: uuid::Uuid,
@@ -576,6 +591,8 @@ fn post_notification_stream(
     pending: super::context::RequestMap,
     notif_rx: tokio::sync::mpsc::Receiver<Message>,
     resp_rx: tokio::sync::oneshot::Receiver<Message>,
+    hold_for_ack: bool,
+    hold_limit: usize,
 ) -> impl Stream<Item = Message> + Send {
     struct Cleanup {
         id: uuid::Uuid,
@@ -599,6 +616,21 @@ fn post_notification_stream(
         notifs_open: bool,
         /// Holds the cleanup guard until the stream is fully consumed.
         _cleanup: Cleanup,
+        /// Whether this is a subscription body whose acknowledgment has not
+        /// gone out yet.
+        awaiting_ack: bool,
+        /// Messages that arrived before the acknowledgment, in order.
+        held: std::collections::VecDeque<Message>,
+        /// How many of those to hold before giving up on ordering.
+        hold_limit: usize,
+        /// Ready to emit, ahead of the channels.
+        out: std::collections::VecDeque<Message>,
+    }
+
+    /// Whether a message is the acknowledgment that opens a subscription.
+    fn is_ack(msg: &Message) -> bool {
+        matches!(msg, Message::Notification(n)
+            if n.method == crate::types::subscription::commands::ACKNOWLEDGED)
     }
 
     /// What one poll of the two channels produced.
@@ -618,9 +650,18 @@ fn post_notification_stream(
             full_id,
             pending,
         },
+        awaiting_ack: hold_for_ack,
+        held: std::collections::VecDeque::new(),
+        hold_limit,
+        out: std::collections::VecDeque::new(),
     };
 
     stream::unfold(state, |mut state| async move {
+        // Anything already released goes out before either channel is polled.
+        if let Some(msg) = state.out.pop_front() {
+            return Some((msg, state));
+        }
+
         while state.notifs_open {
             // Split the borrows so both channels can be polled in one `select!`.
             let step = {
@@ -645,12 +686,40 @@ fn post_notification_stream(
             };
 
             match step {
+                Step::Notification(n) if state.awaiting_ack => {
+                    if is_ack(&n) {
+                        // The stream is open: the acknowledgment goes out now,
+                        // and what was waiting on it follows.
+                        state.awaiting_ack = false;
+                        state.out.append(&mut state.held);
+                        return Some((n, state));
+                    }
+                    state.held.push_back(n);
+                    // A peer that never acknowledges must not make this grow
+                    // without end. Past the sink's own capacity the ordering is
+                    // lost anyway, so stop trying and let the messages through.
+                    if state.held.len() >= state.hold_limit {
+                        state.awaiting_ack = false;
+                        state.out.append(&mut state.held);
+                        if let Some(msg) = state.out.pop_front() {
+                            return Some((msg, state));
+                        }
+                    }
+                }
                 Step::Notification(n) => return Some((n, state)),
-                Step::NotificationsClosed => state.notifs_open = false,
+                Step::NotificationsClosed => {
+                    state.notifs_open = false;
+                    state.awaiting_ack = false;
+                }
                 Step::Response(Some(resp)) => {
                     // Buffer it and keep draining until the pipeline is done.
                     state.response = Some(resp);
                     state.resp_rx = None;
+                    // The listen was answered without ever acknowledging --
+                    // rejected, most likely. Nothing is waiting on an
+                    // acknowledgment that is not coming.
+                    state.awaiting_ack = false;
+                    state.out.append(&mut state.held);
                 }
                 // The response channel was dropped: the runtime will never
                 // answer, so stop waiting on notifications and end the body
@@ -658,8 +727,16 @@ fn post_notification_stream(
                 Step::Response(None) => {
                     state.resp_rx = None;
                     state.notifs_open = false;
+                    state.awaiting_ack = false;
                 }
             }
+        }
+
+        // Whatever was still held has nowhere left to wait: release it ahead of
+        // the response.
+        state.out.append(&mut state.held);
+        if let Some(msg) = state.out.pop_front() {
+            return Some((msg, state));
         }
 
         // Pipeline finished and every notification is drained; close with the

--- a/neva/src/transport/http/core/handlers.rs
+++ b/neva/src/transport/http/core/handlers.rs
@@ -583,7 +583,9 @@ fn request_opts_in(req: &crate::types::Request) -> bool {
 /// it -- ordering the stream rather than dropping the messages, which matters
 /// because a mixed batch's other requests log here too, and their logs were
 /// explicitly asked for. `hold_limit` bounds that buffer at what the sink
-/// itself would have held, so a peer that never acknowledges cannot grow it.
+/// itself would have held; overflow past it is dropped rather than released,
+/// because the acknowledgment coming first is the requirement and the logs
+/// riding along are the accommodation.
 #[cfg(not(feature = "legacy-spec"))]
 fn post_notification_stream(
     id: uuid::Uuid,
@@ -694,16 +696,22 @@ fn post_notification_stream(
                         state.out.append(&mut state.held);
                         return Some((n, state));
                     }
-                    state.held.push_back(n);
-                    // A peer that never acknowledges must not make this grow
-                    // without end. Past the sink's own capacity the ordering is
-                    // lost anyway, so stop trying and let the messages through.
-                    if state.held.len() >= state.hold_limit {
-                        state.awaiting_ack = false;
-                        state.out.append(&mut state.held);
-                        if let Some(msg) = state.out.pop_front() {
-                            return Some((msg, state));
-                        }
+                    // Bounded, so a handler that logs without end cannot grow
+                    // this: past the sink's own capacity the overflow is
+                    // dropped, exactly as the sink would have dropped it had
+                    // nothing been draining it. Releasing it instead would put
+                    // these messages ahead of the acknowledgment, and the
+                    // acknowledgment coming first is the requirement -- the
+                    // logs riding along are the accommodation.
+                    if state.held.len() < state.hold_limit {
+                        state.held.push_back(n);
+                    } else {
+                        #[cfg(feature = "tracing")]
+                        tracing::warn!(
+                            logger = "neva",
+                            "dropped a notification queued before the subscription \
+                             acknowledgment: the pre-acknowledgment buffer is full"
+                        );
                     }
                 }
                 Step::Notification(n) => return Some((n, state)),

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -372,6 +372,21 @@ impl MessageBatch {
             .iter()
             .any(|e| matches!(e, MessageEnvelope::Response(Response::Err(_))))
     }
+
+    /// Returns `true` if the batch contains at least one
+    /// [`MessageEnvelope::Response`].
+    ///
+    /// Used by the HTTP client to tell a batch that *answers* a request from
+    /// one that merely carries notifications -- a subscription stream may
+    /// deliver its acknowledgment and its events batched, and mistaking those
+    /// for the terminal reply would make a truncated stream look orderly.
+    #[inline]
+    #[cfg(feature = "http-client")]
+    pub(crate) fn has_responses(&self) -> bool {
+        self.items
+            .iter()
+            .any(|e| matches!(e, MessageEnvelope::Response(_)))
+    }
 }
 
 impl IntoIterator for MessageBatch {

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -372,21 +372,6 @@ impl MessageBatch {
             .iter()
             .any(|e| matches!(e, MessageEnvelope::Response(Response::Err(_))))
     }
-
-    /// Returns `true` if the batch contains at least one
-    /// [`MessageEnvelope::Response`].
-    ///
-    /// Used by the HTTP client to tell a batch that *answers* a request from
-    /// one that merely carries notifications -- a subscription stream may
-    /// deliver its acknowledgment and its events batched, and mistaking those
-    /// for the terminal reply would make a truncated stream look orderly.
-    #[inline]
-    #[cfg(feature = "http-client")]
-    pub(crate) fn has_responses(&self) -> bool {
-        self.items
-            .iter()
-            .any(|e| matches!(e, MessageEnvelope::Response(_)))
-    }
 }
 
 impl IntoIterator for MessageBatch {

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -126,11 +126,13 @@ pub use prompt::{
     GetPromptRequestParams, GetPromptResult, ListPromptsRequestParams, ListPromptsResult, Prompt,
     PromptArgument, PromptMessage,
 };
+#[cfg(any(feature = "legacy-spec", feature = "client"))]
+pub use resource::UnsubscribeRequestParams;
 pub use resource::{
     BlobResourceContents, ListResourceTemplatesRequestParams, ListResourceTemplatesResult,
     ListResourcesRequestParams, ListResourcesResult, ReadResourceRequestParams, ReadResourceResult,
     Resource, ResourceContents, ResourceTemplate, SubscribeRequestParams, TextResourceContents,
-    UnsubscribeRequestParams, Uri,
+    Uri,
 };
 #[cfg(any(feature = "legacy-spec", feature = "client"))]
 pub use sampling::{
@@ -141,6 +143,12 @@ pub use schema::{
     BooleanSchema, LegacyTitledEnumSchema, NumberSchema, Schema, StringFormat, StringSchema,
     TitledMultiSelectEnumSchema, TitledSingleSelectEnumSchema, UntitledMultiSelectEnumSchema,
     UntitledSingleSelectEnumSchema,
+};
+#[cfg(not(feature = "legacy-spec"))]
+pub use subscription::{
+    SUBSCRIPTION_ID_KEY, SubscriptionFilter, SubscriptionMeta,
+    SubscriptionsAcknowledgedNotificationParams, SubscriptionsListenRequestParams,
+    SubscriptionsListenResult,
 };
 
 pub use icon::{Icon, IconSize, IconTheme};
@@ -191,6 +199,8 @@ pub mod root;
 pub mod sampling;
 mod schema;
 pub mod schema_2020;
+#[cfg(not(feature = "legacy-spec"))]
+pub mod subscription;
 #[cfg(feature = "tasks")]
 pub mod task;
 pub mod tool;
@@ -892,10 +902,11 @@ mod tests {
 
     #[cfg(all(feature = "server", not(feature = "legacy-spec")))]
     #[test]
-    fn discover_masks_push_capabilities_under_stateless_transport() {
-        // Even when the server explicitly configures listChanged + subscribe,
-        // the stateless 2026-07-28 transport cannot push, so `DiscoverResult` must not
-        // advertise capabilities clients can never rely on.
+    fn discover_advertises_push_capabilities_backed_by_subscriptions() {
+        // `subscriptions/listen` is how MCP 2026-07-28 delivers these, so a
+        // configured `listChanged` / `subscribe` is a promise the server can
+        // keep and must advertise -- clients narrow their listen filter against
+        // exactly this.
         let options = McpOptions::default()
             .with_tools(|t| t.with_list_changed())
             .with_resources(|r| r.with_subscribe().with_list_changed())
@@ -904,10 +915,10 @@ mod tests {
         let discover = DiscoverResult::new(&options);
         let caps = serde_json::to_value(&discover.capabilities).unwrap();
 
-        assert_eq!(caps["tools"]["listChanged"], serde_json::json!(false));
-        assert_eq!(caps["resources"]["subscribe"], serde_json::json!(false));
-        assert_eq!(caps["resources"]["listChanged"], serde_json::json!(false));
-        assert_eq!(caps["prompts"]["listChanged"], serde_json::json!(false));
+        assert_eq!(caps["tools"]["listChanged"], serde_json::json!(true));
+        assert_eq!(caps["resources"]["subscribe"], serde_json::json!(true));
+        assert_eq!(caps["resources"]["listChanged"], serde_json::json!(true));
+        assert_eq!(caps["prompts"]["listChanged"], serde_json::json!(true));
     }
 
     /// The `logging` capability must be advertised iff the `logging/setLevel`

--- a/neva/src/types/capabilities.rs
+++ b/neva/src/types/capabilities.rs
@@ -162,7 +162,7 @@ pub struct ElicitationUrlCapability {
 /// > These capabilities are advertised to clients during the initialize handshake.
 ///
 /// See the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/) for details
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct ServerCapabilities {
     /// Present if the server offers any tools to call.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/neva/src/types/notification.rs
+++ b/neva/src/types/notification.rs
@@ -30,6 +30,11 @@ pub mod fmt;
 mod formatter;
 mod log_message;
 mod progress;
+#[cfg(all(
+    not(feature = "legacy-spec"),
+    any(feature = "tracing", feature = "http-server")
+))]
+pub(crate) mod sink;
 
 /// List of commands for Notifications
 pub mod commands {

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -147,7 +147,20 @@ where
             if let Some(session_id) = notification.session_id
                 && let Some(sink) = super::sink::REQUEST_NOTIFICATIONS.get(&session_id)
             {
-                let _ = sink.try_send(Message::Notification(notification));
+                // A `subscriptions/listen` body is the subscription's stream:
+                // its first message must be the acknowledgment, and what
+                // follows must belong to the subscription. A log message
+                // emitted by middleware wrapped around the handler would
+                // otherwise be queued before `Context::listen` ever runs, and
+                // arrive ahead of the acknowledgment.
+                if sink.subscription
+                    && notification.method.as_str() == crate::types::notification::commands::MESSAGE
+                {
+                    return;
+                }
+
+                let _ = sink.tx.try_send(Message::Notification(notification));
+
                 return;
             }
 
@@ -418,7 +431,13 @@ mod tests {
 
         let session_id = uuid::Uuid::new_v4();
         let (sink_tx, mut sink_rx) = tokio::sync::mpsc::channel::<Message>(8);
-        super::super::sink::REQUEST_NOTIFICATIONS.insert(session_id, sink_tx);
+        super::super::sink::REQUEST_NOTIFICATIONS.insert(
+            session_id,
+            super::super::sink::RequestSink {
+                tx: sink_tx,
+                subscription: false,
+            },
+        );
 
         let (fallback_tx, mut fallback_rx) = tokio::sync::mpsc::channel::<Notification>(8);
         let subscriber = tracing_subscriber::registry().with(super::MpscLayer {

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -28,39 +28,6 @@ pub(super) const MCP_LOG_LEVEL: &str = "mcp_log_level";
 
 pub(crate) static LOG_REGISTRY: Lazy<MessageRegistry> = Lazy::new(MessageRegistry::new);
 
-/// Per-request notification sinks for the 2026-07-28 stateless HTTP transport, keyed by
-/// the per-`POST` session id (each stateless `POST` mints a fresh one).
-///
-/// The 2026-07-28 transport has no `GET`/SSE stream, so request-scoped notifications
-/// (`notifications/message`, `notifications/progress`) flow on the originating
-/// request's `POST` response stream instead. `handle_post` registers a sink
-/// before dispatch and drains it into that response; the notification layer
-/// routes events fired while handling the request to the matching sink.
-#[cfg(not(feature = "legacy-spec"))]
-pub(crate) static REQUEST_NOTIFICATIONS: Lazy<dashmap::DashMap<uuid::Uuid, Sender<Message>>> =
-    Lazy::new(dashmap::DashMap::new);
-
-/// Registers a per-request notification sink for `id` (the per-`POST` session
-/// id). Returns the receiving end for the `POST` response stream to drain.
-///
-/// Only the HTTP server writes sinks; the layer (which may run client-side too)
-/// merely reads [`REQUEST_NOTIFICATIONS`], so these live behind `http-server`.
-#[cfg(all(not(feature = "legacy-spec"), feature = "http-server"))]
-pub(crate) fn register_request_sink(
-    id: uuid::Uuid,
-    capacity: usize,
-) -> tokio::sync::mpsc::Receiver<Message> {
-    let (tx, rx) = channel::<Message>(capacity);
-    REQUEST_NOTIFICATIONS.insert(id, tx);
-    rx
-}
-
-/// Removes the per-request notification sink for `id`.
-#[cfg(all(not(feature = "legacy-spec"), feature = "http-server"))]
-pub(crate) fn unregister_request_sink(id: &uuid::Uuid) {
-    REQUEST_NOTIFICATIONS.remove(id);
-}
-
 /// Creates a custom tracing layer that delivers messages to MCP Client
 ///
 /// This layer routes notifications to a connected client. On the legacy HTTP
@@ -178,7 +145,7 @@ where
             // id; fall through to the legacy session-SSE path otherwise.
             #[cfg(not(feature = "legacy-spec"))]
             if let Some(session_id) = notification.session_id
-                && let Some(sink) = REQUEST_NOTIFICATIONS.get(&session_id)
+                && let Some(sink) = super::sink::REQUEST_NOTIFICATIONS.get(&session_id)
             {
                 let _ = sink.try_send(Message::Notification(notification));
                 return;
@@ -451,7 +418,7 @@ mod tests {
 
         let session_id = uuid::Uuid::new_v4();
         let (sink_tx, mut sink_rx) = tokio::sync::mpsc::channel::<Message>(8);
-        super::REQUEST_NOTIFICATIONS.insert(session_id, sink_tx);
+        super::super::sink::REQUEST_NOTIFICATIONS.insert(session_id, sink_tx);
 
         let (fallback_tx, mut fallback_rx) = tokio::sync::mpsc::channel::<Notification>(8);
         let subscriber = tracing_subscriber::registry().with(super::MpscLayer {
@@ -470,7 +437,7 @@ mod tests {
             tracing::warn!(logger = "tool", "nested message");
         });
 
-        super::REQUEST_NOTIFICATIONS.remove(&session_id);
+        super::super::sink::REQUEST_NOTIFICATIONS.remove(&session_id);
 
         let msg = sink_rx
             .try_recv()

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -147,19 +147,7 @@ where
             if let Some(session_id) = notification.session_id
                 && let Some(sink) = super::sink::REQUEST_NOTIFICATIONS.get(&session_id)
             {
-                // A `subscriptions/listen` body is the subscription's stream:
-                // its first message must be the acknowledgment, and what
-                // follows must belong to the subscription. A log message
-                // emitted by middleware wrapped around the handler would
-                // otherwise be queued before `Context::listen` ever runs, and
-                // arrive ahead of the acknowledgment.
-                if sink.subscription
-                    && notification.method.as_str() == crate::types::notification::commands::MESSAGE
-                {
-                    return;
-                }
-
-                let _ = sink.tx.try_send(Message::Notification(notification));
+                let _ = sink.try_send(Message::Notification(notification));
 
                 return;
             }
@@ -431,13 +419,7 @@ mod tests {
 
         let session_id = uuid::Uuid::new_v4();
         let (sink_tx, mut sink_rx) = tokio::sync::mpsc::channel::<Message>(8);
-        super::super::sink::REQUEST_NOTIFICATIONS.insert(
-            session_id,
-            super::super::sink::RequestSink {
-                tx: sink_tx,
-                subscription: false,
-            },
-        );
+        super::super::sink::REQUEST_NOTIFICATIONS.insert(session_id, sink_tx);
 
         let (fallback_tx, mut fallback_rx) = tokio::sync::mpsc::channel::<Notification>(8);
         let subscriber = tracing_subscriber::registry().with(super::MpscLayer {

--- a/neva/src/types/notification/fmt.rs
+++ b/neva/src/types/notification/fmt.rs
@@ -414,12 +414,10 @@ mod tests {
     /// child span that carries no MCP fields of its own.
     #[tokio::test]
     async fn routes_events_from_nested_spans_to_the_request_sink() {
-        use crate::types::Message;
         use crate::types::notification::Notification;
 
         let session_id = uuid::Uuid::new_v4();
-        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::channel::<Message>(8);
-        super::super::sink::REQUEST_NOTIFICATIONS.insert(session_id, sink_tx);
+        let mut sink_rx = super::super::sink::register(session_id, 8, false).await;
 
         let (fallback_tx, mut fallback_rx) = tokio::sync::mpsc::channel::<Notification>(8);
         let subscriber = tracing_subscriber::registry().with(super::MpscLayer {
@@ -438,7 +436,7 @@ mod tests {
             tracing::warn!(logger = "tool", "nested message");
         });
 
-        super::super::sink::REQUEST_NOTIFICATIONS.remove(&session_id);
+        super::super::sink::unregister(&session_id);
 
         let msg = sink_rx
             .try_recv()

--- a/neva/src/types/notification/sink.rs
+++ b/neva/src/types/notification/sink.rs
@@ -32,7 +32,7 @@ pub(crate) struct RequestSink {
     /// valid. Reserving the slot up front, before any of that can run, is what
     /// makes the acknowledgment independent of how noisy the request is.
     // Only the HTTP server reserves and hands out this slot; a client-only
-    // build has the map (the layer reads it) but nothing that registers.
+    // build has the map (the layer reads it) but nothing that spends one.
     #[cfg_attr(not(feature = "http-server"), allow(dead_code))]
     ack: Option<OwnedPermit<Message>>,
 }
@@ -63,7 +63,9 @@ impl RequestSink {
 /// slot beyond `capacity`, reserved then and there for the acknowledgment, so
 /// the configured log capacity stays whole and the acknowledgment cannot be
 /// crowded out of it.
-#[cfg(feature = "http-server")]
+// Also compiled for the layer's own tests, which register a sink to route into
+// without an HTTP server to do it for them.
+#[cfg(any(feature = "http-server", all(test, feature = "tracing")))]
 pub(crate) async fn register(
     id: uuid::Uuid,
     capacity: usize,
@@ -89,7 +91,7 @@ pub(crate) fn take_ack_permit(id: &uuid::Uuid) -> Option<OwnedPermit<Message>> {
 }
 
 /// Removes the notification sink for `id`.
-#[cfg(feature = "http-server")]
+#[cfg(any(feature = "http-server", all(test, feature = "tracing")))]
 pub(crate) fn unregister(id: &uuid::Uuid) {
     REQUEST_NOTIFICATIONS.remove(id);
 }

--- a/neva/src/types/notification/sink.rs
+++ b/neva/src/types/notification/sink.rs
@@ -14,23 +14,78 @@
 
 use crate::types::Message;
 use std::sync::LazyLock;
-use tokio::sync::mpsc::Sender;
+use tokio::sync::mpsc::{OwnedPermit, Sender};
+
+/// One registered sink: the `POST` body's writing end, plus the slot held for a
+/// subscription's acknowledgment.
+pub(crate) struct RequestSink {
+    /// Where the body's messages go.
+    tx: Sender<Message>,
+
+    /// A capacity slot reserved for `notifications/subscriptions/acknowledged`,
+    /// taken by the handler when it opens the subscription.
+    ///
+    /// The body is bounded and shared: middleware wrapped around the handler
+    /// logs into it before `Context::listen` ever runs, and enough of that --
+    /// easy with a small `with_sse_log_queue` -- would leave no room for the
+    /// acknowledgment, failing a subscription that is otherwise perfectly
+    /// valid. Reserving the slot up front, before any of that can run, is what
+    /// makes the acknowledgment independent of how noisy the request is.
+    // Only the HTTP server reserves and hands out this slot; a client-only
+    // build has the map (the layer reads it) but nothing that registers.
+    #[cfg_attr(not(feature = "http-server"), allow(dead_code))]
+    ack: Option<OwnedPermit<Message>>,
+}
 
 /// Live per-request notification sinks, keyed by the per-`POST` session id.
 ///
 /// Only the HTTP server registers sinks; the notification layer (which may run
 /// client-side too) merely reads the map, so the writers below are gated on
 /// `http-server` while the map itself is not.
-pub(crate) static REQUEST_NOTIFICATIONS: LazyLock<dashmap::DashMap<uuid::Uuid, Sender<Message>>> =
+pub(crate) static REQUEST_NOTIFICATIONS: LazyLock<dashmap::DashMap<uuid::Uuid, RequestSink>> =
     LazyLock::new(dashmap::DashMap::new);
+
+impl RequestSink {
+    /// Queues a message on the body, dropping it if the buffer is full.
+    // Its only caller is the `tracing` layer; without the feature nothing
+    // produces request-scoped notifications to queue here.
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
+    #[inline]
+    pub(crate) fn try_send(&self, msg: Message) -> Result<(), ()> {
+        self.tx.try_send(msg).map_err(|_| ())
+    }
+}
 
 /// Registers a notification sink for `id` (the per-`POST` session id). Returns
 /// the receiving end for the `POST` response stream to drain.
+///
+/// `reserve_ack` marks a body that carries a `subscriptions/listen`: it gets one
+/// slot beyond `capacity`, reserved then and there for the acknowledgment, so
+/// the configured log capacity stays whole and the acknowledgment cannot be
+/// crowded out of it.
 #[cfg(feature = "http-server")]
-pub(crate) fn register(id: uuid::Uuid, capacity: usize) -> tokio::sync::mpsc::Receiver<Message> {
-    let (tx, rx) = tokio::sync::mpsc::channel::<Message>(capacity);
-    REQUEST_NOTIFICATIONS.insert(id, tx);
+pub(crate) async fn register(
+    id: uuid::Uuid,
+    capacity: usize,
+    reserve_ack: bool,
+) -> tokio::sync::mpsc::Receiver<Message> {
+    let (tx, rx) = tokio::sync::mpsc::channel::<Message>(capacity + usize::from(reserve_ack));
+    // Immediate on a channel nothing has written to yet.
+    let ack = match reserve_ack {
+        true => tx.clone().reserve_owned().await.ok(),
+        false => None,
+    };
+    REQUEST_NOTIFICATIONS.insert(id, RequestSink { tx, ack });
     rx
+}
+
+/// Takes the reserved acknowledgment slot for `id`, if this body has one and
+/// nobody has taken it yet.
+#[cfg(feature = "http-server")]
+pub(crate) fn take_ack_permit(id: &uuid::Uuid) -> Option<OwnedPermit<Message>> {
+    REQUEST_NOTIFICATIONS
+        .get_mut(id)
+        .and_then(|mut s| s.ack.take())
 }
 
 /// Removes the notification sink for `id`.
@@ -47,7 +102,7 @@ pub(crate) fn unregister(id: &uuid::Uuid) {
 /// via [`Sender::closed`] -- how the handler learns the client disconnected.
 #[cfg(feature = "http-server")]
 pub(crate) fn get(id: &uuid::Uuid) -> Option<Sender<Message>> {
-    REQUEST_NOTIFICATIONS.get(id).map(|s| s.clone())
+    REQUEST_NOTIFICATIONS.get(id).map(|s| s.tx.clone())
 }
 
 #[cfg(all(test, feature = "http-server"))]
@@ -58,7 +113,7 @@ mod tests {
     #[tokio::test]
     async fn it_routes_to_a_registered_sink() {
         let id = uuid::Uuid::new_v4();
-        let mut rx = register(id, 4);
+        let mut rx = register(id, 4, false).await;
 
         let sink = get(&id).expect("sink should be registered");
         sink.send(Message::Notification(Notification::new("test", None)))
@@ -75,7 +130,7 @@ mod tests {
         // The disconnect signal a long-lived subscription waits on: the HTTP
         // response stream drops its receiver when the client goes away.
         let id = uuid::Uuid::new_v4();
-        let rx = register(id, 4);
+        let rx = register(id, 4, false).await;
 
         let sink = get(&id).expect("sink should be registered");
         drop(rx);

--- a/neva/src/types/notification/sink.rs
+++ b/neva/src/types/notification/sink.rs
@@ -1,0 +1,86 @@
+//! Per-request notification sinks for the MCP 2026-07-28 transport.
+//!
+//! The 2026-07-28 transport has no session-scoped `GET`/SSE stream, so every
+//! server->client notification travels on a `POST` response body: either the
+//! originating request's own stream (request-scoped `notifications/message` and
+//! `notifications/progress`) or the long-lived `subscriptions/listen` stream.
+//! Both are the same mechanism -- a channel registered before dispatch and
+//! drained into the response body -- keyed by the per-`POST` session id, which
+//! is minted fresh for each `POST` and carried on every message of that request.
+//!
+//! This module deliberately sits outside the `tracing`-gated
+//! [`fmt`](super::fmt) layer: subscriptions must work in a build without
+//! `tracing`, and the layer is only one of the sinks' writers.
+
+use crate::types::Message;
+use std::sync::LazyLock;
+use tokio::sync::mpsc::Sender;
+
+/// Live per-request notification sinks, keyed by the per-`POST` session id.
+///
+/// Only the HTTP server registers sinks; the notification layer (which may run
+/// client-side too) merely reads the map, so the writers below are gated on
+/// `http-server` while the map itself is not.
+pub(crate) static REQUEST_NOTIFICATIONS: LazyLock<dashmap::DashMap<uuid::Uuid, Sender<Message>>> =
+    LazyLock::new(dashmap::DashMap::new);
+
+/// Registers a notification sink for `id` (the per-`POST` session id). Returns
+/// the receiving end for the `POST` response stream to drain.
+#[cfg(feature = "http-server")]
+pub(crate) fn register(id: uuid::Uuid, capacity: usize) -> tokio::sync::mpsc::Receiver<Message> {
+    let (tx, rx) = tokio::sync::mpsc::channel::<Message>(capacity);
+    REQUEST_NOTIFICATIONS.insert(id, tx);
+    rx
+}
+
+/// Removes the notification sink for `id`.
+#[cfg(feature = "http-server")]
+pub(crate) fn unregister(id: &uuid::Uuid) {
+    REQUEST_NOTIFICATIONS.remove(id);
+}
+
+/// Returns a clone of the sink registered for `id`, if the `POST` response
+/// stream is still open.
+///
+/// A `subscriptions/listen` handler holds onto this sender for the life of the
+/// subscription: it is both where the subscription's notifications go and --
+/// via [`Sender::closed`] -- how the handler learns the client disconnected.
+#[cfg(feature = "http-server")]
+pub(crate) fn get(id: &uuid::Uuid) -> Option<Sender<Message>> {
+    REQUEST_NOTIFICATIONS.get(id).map(|s| s.clone())
+}
+
+#[cfg(all(test, feature = "http-server"))]
+mod tests {
+    use super::*;
+    use crate::types::notification::Notification;
+
+    #[tokio::test]
+    async fn it_routes_to_a_registered_sink() {
+        let id = uuid::Uuid::new_v4();
+        let mut rx = register(id, 4);
+
+        let sink = get(&id).expect("sink should be registered");
+        sink.send(Message::Notification(Notification::new("test", None)))
+            .await
+            .unwrap();
+
+        assert!(rx.recv().await.is_some());
+        unregister(&id);
+        assert!(get(&id).is_none());
+    }
+
+    #[tokio::test]
+    async fn it_reports_a_dropped_receiver_as_closed() {
+        // The disconnect signal a long-lived subscription waits on: the HTTP
+        // response stream drops its receiver when the client goes away.
+        let id = uuid::Uuid::new_v4();
+        let rx = register(id, 4);
+
+        let sink = get(&id).expect("sink should be registered");
+        drop(rx);
+
+        sink.closed().await;
+        unregister(&id);
+    }
+}

--- a/neva/src/types/notification/sink.rs
+++ b/neva/src/types/notification/sink.rs
@@ -16,47 +16,20 @@ use crate::types::Message;
 use std::sync::LazyLock;
 use tokio::sync::mpsc::Sender;
 
-/// One registered sink: where the `POST` body's messages go, and what kind of
-/// body it is.
-pub(crate) struct RequestSink {
-    /// The writing end of the response stream.
-    pub(crate) tx: Sender<Message>,
-
-    /// Whether this `POST` body is a `subscriptions/listen` stream.
-    ///
-    /// Such a body belongs to the subscription: its first message must be the
-    /// acknowledgment, and what follows must be that subscription's
-    /// notifications. Request-scoped log messages are not part of it, so they
-    /// are not written here -- see the `notifications/message` branch in
-    /// [`fmt`](super::fmt).
-    // That branch is the only reader, and it is the `tracing` layer: without
-    // the feature there is nothing producing request-scoped log messages to
-    // keep off the stream in the first place.
-    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
-    pub(crate) subscription: bool,
-}
-
 /// Live per-request notification sinks, keyed by the per-`POST` session id.
 ///
 /// Only the HTTP server registers sinks; the notification layer (which may run
 /// client-side too) merely reads the map, so the writers below are gated on
 /// `http-server` while the map itself is not.
-pub(crate) static REQUEST_NOTIFICATIONS: LazyLock<dashmap::DashMap<uuid::Uuid, RequestSink>> =
+pub(crate) static REQUEST_NOTIFICATIONS: LazyLock<dashmap::DashMap<uuid::Uuid, Sender<Message>>> =
     LazyLock::new(dashmap::DashMap::new);
 
 /// Registers a notification sink for `id` (the per-`POST` session id). Returns
 /// the receiving end for the `POST` response stream to drain.
-///
-/// `subscription` marks a `subscriptions/listen` body; see
-/// [`RequestSink::subscription`].
 #[cfg(feature = "http-server")]
-pub(crate) fn register(
-    id: uuid::Uuid,
-    capacity: usize,
-    subscription: bool,
-) -> tokio::sync::mpsc::Receiver<Message> {
+pub(crate) fn register(id: uuid::Uuid, capacity: usize) -> tokio::sync::mpsc::Receiver<Message> {
     let (tx, rx) = tokio::sync::mpsc::channel::<Message>(capacity);
-    REQUEST_NOTIFICATIONS.insert(id, RequestSink { tx, subscription });
+    REQUEST_NOTIFICATIONS.insert(id, tx);
     rx
 }
 
@@ -74,7 +47,7 @@ pub(crate) fn unregister(id: &uuid::Uuid) {
 /// via [`Sender::closed`] -- how the handler learns the client disconnected.
 #[cfg(feature = "http-server")]
 pub(crate) fn get(id: &uuid::Uuid) -> Option<Sender<Message>> {
-    REQUEST_NOTIFICATIONS.get(id).map(|s| s.tx.clone())
+    REQUEST_NOTIFICATIONS.get(id).map(|s| s.clone())
 }
 
 #[cfg(all(test, feature = "http-server"))]
@@ -85,7 +58,7 @@ mod tests {
     #[tokio::test]
     async fn it_routes_to_a_registered_sink() {
         let id = uuid::Uuid::new_v4();
-        let mut rx = register(id, 4, false);
+        let mut rx = register(id, 4);
 
         let sink = get(&id).expect("sink should be registered");
         sink.send(Message::Notification(Notification::new("test", None)))
@@ -102,7 +75,7 @@ mod tests {
         // The disconnect signal a long-lived subscription waits on: the HTTP
         // response stream drops its receiver when the client goes away.
         let id = uuid::Uuid::new_v4();
-        let rx = register(id, 4, false);
+        let rx = register(id, 4);
 
         let sink = get(&id).expect("sink should be registered");
         drop(rx);

--- a/neva/src/types/notification/sink.rs
+++ b/neva/src/types/notification/sink.rs
@@ -16,20 +16,47 @@ use crate::types::Message;
 use std::sync::LazyLock;
 use tokio::sync::mpsc::Sender;
 
+/// One registered sink: where the `POST` body's messages go, and what kind of
+/// body it is.
+pub(crate) struct RequestSink {
+    /// The writing end of the response stream.
+    pub(crate) tx: Sender<Message>,
+
+    /// Whether this `POST` body is a `subscriptions/listen` stream.
+    ///
+    /// Such a body belongs to the subscription: its first message must be the
+    /// acknowledgment, and what follows must be that subscription's
+    /// notifications. Request-scoped log messages are not part of it, so they
+    /// are not written here -- see the `notifications/message` branch in
+    /// [`fmt`](super::fmt).
+    // That branch is the only reader, and it is the `tracing` layer: without
+    // the feature there is nothing producing request-scoped log messages to
+    // keep off the stream in the first place.
+    #[cfg_attr(not(feature = "tracing"), allow(dead_code))]
+    pub(crate) subscription: bool,
+}
+
 /// Live per-request notification sinks, keyed by the per-`POST` session id.
 ///
 /// Only the HTTP server registers sinks; the notification layer (which may run
 /// client-side too) merely reads the map, so the writers below are gated on
 /// `http-server` while the map itself is not.
-pub(crate) static REQUEST_NOTIFICATIONS: LazyLock<dashmap::DashMap<uuid::Uuid, Sender<Message>>> =
+pub(crate) static REQUEST_NOTIFICATIONS: LazyLock<dashmap::DashMap<uuid::Uuid, RequestSink>> =
     LazyLock::new(dashmap::DashMap::new);
 
 /// Registers a notification sink for `id` (the per-`POST` session id). Returns
 /// the receiving end for the `POST` response stream to drain.
+///
+/// `subscription` marks a `subscriptions/listen` body; see
+/// [`RequestSink::subscription`].
 #[cfg(feature = "http-server")]
-pub(crate) fn register(id: uuid::Uuid, capacity: usize) -> tokio::sync::mpsc::Receiver<Message> {
+pub(crate) fn register(
+    id: uuid::Uuid,
+    capacity: usize,
+    subscription: bool,
+) -> tokio::sync::mpsc::Receiver<Message> {
     let (tx, rx) = tokio::sync::mpsc::channel::<Message>(capacity);
-    REQUEST_NOTIFICATIONS.insert(id, tx);
+    REQUEST_NOTIFICATIONS.insert(id, RequestSink { tx, subscription });
     rx
 }
 
@@ -47,7 +74,7 @@ pub(crate) fn unregister(id: &uuid::Uuid) {
 /// via [`Sender::closed`] -- how the handler learns the client disconnected.
 #[cfg(feature = "http-server")]
 pub(crate) fn get(id: &uuid::Uuid) -> Option<Sender<Message>> {
-    REQUEST_NOTIFICATIONS.get(id).map(|s| s.clone())
+    REQUEST_NOTIFICATIONS.get(id).map(|s| s.tx.clone())
 }
 
 #[cfg(all(test, feature = "http-server"))]
@@ -58,7 +85,7 @@ mod tests {
     #[tokio::test]
     async fn it_routes_to_a_registered_sink() {
         let id = uuid::Uuid::new_v4();
-        let mut rx = register(id, 4);
+        let mut rx = register(id, 4, false);
 
         let sink = get(&id).expect("sink should be registered");
         sink.send(Message::Notification(Notification::new("test", None)))
@@ -75,7 +102,7 @@ mod tests {
         // The disconnect signal a long-lived subscription waits on: the HTTP
         // response stream drops its receiver when the client goes away.
         let id = uuid::Uuid::new_v4();
-        let rx = register(id, 4);
+        let rx = register(id, 4, false);
 
         let sink = get(&id).expect("sink should be registered");
         drop(rx);

--- a/neva/src/types/resource.rs
+++ b/neva/src/types/resource.rs
@@ -53,9 +53,21 @@ pub mod commands {
     pub const READ: &str = "resources/read";
 
     /// Command name that subscribes to resource updates.
+    ///
+    /// Legacy only. MCP 2026-07-28 does not delete per-resource subscriptions,
+    /// it folds them into the `subscriptions/listen` filter: a subscription is
+    /// a URI in `SubscriptionFilter::resource_subscriptions`, scoped to that
+    /// stream rather than to server-side state. The constant stays compiled in
+    /// a 2026-07-28 *client* build because the dual-mode fallback still speaks
+    /// to legacy peers.
+    #[cfg(any(feature = "legacy-spec", feature = "client"))]
     pub const SUBSCRIBE: &str = "resources/subscribe";
 
     /// Command name that unsubscribes from resource updates.
+    ///
+    /// Legacy only; see [`SUBSCRIBE`]. Under MCP 2026-07-28 a subscription ends
+    /// with the stream that carries it.
+    #[cfg(any(feature = "legacy-spec", feature = "client"))]
     pub const UNSUBSCRIBE: &str = "resources/unsubscribe";
 
     /// Notification name that indicates that the resource has been updated.
@@ -197,7 +209,10 @@ pub struct SubscribeRequestParams {
 /// Sent from the client to request not receiving updated notifications
 /// from the server whenever a primitive resource changes.
 ///
+/// Legacy only; see [`commands::UNSUBSCRIBE`].
+///
 /// See the [schema](https://github.com/modelcontextprotocol/specification/blob/main/schema/) for details
+#[cfg(any(feature = "legacy-spec", feature = "client"))]
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UnsubscribeRequestParams {
     /// The URI of the resource to unsubscribe from.
@@ -212,6 +227,7 @@ impl<T: Into<Uri>> From<T> for SubscribeRequestParams {
     }
 }
 
+#[cfg(any(feature = "legacy-spec", feature = "client"))]
 impl<T: Into<Uri>> From<T> for UnsubscribeRequestParams {
     #[inline]
     fn from(uri: T) -> Self {
@@ -296,7 +312,7 @@ impl FromHandlerParams for SubscribeRequestParams {
     }
 }
 
-#[cfg(feature = "server")]
+#[cfg(all(feature = "server", any(feature = "legacy-spec", feature = "client")))]
 impl FromHandlerParams for UnsubscribeRequestParams {
     #[inline]
     fn from_params(params: &HandlerParams) -> Result<Self, Error> {

--- a/neva/src/types/subscription.rs
+++ b/neva/src/types/subscription.rs
@@ -1,0 +1,734 @@
+//! Long-lived notification subscriptions (MCP 2026-07-28).
+//!
+//! `subscriptions/listen` opens a stream the server keeps open, delivering only
+//! the notification categories the client opted in to. It replaces both the
+//! legacy HTTP `GET` stream and the `resources/subscribe` /
+//! `resources/unsubscribe` RPC pair -- per-resource subscriptions are now the
+//! [`SubscriptionFilter::resource_subscriptions`] field of the listen filter.
+//!
+//! See the [specification](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/subscriptions)
+//! for details.
+
+use crate::types::{RequestId, RequestParamsMeta, Uri};
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "server")]
+use crate::app::handler::{FromHandlerParams, HandlerParams};
+#[cfg(feature = "server")]
+use crate::error::Error;
+#[cfg(feature = "server")]
+use crate::types::{IntoResponse, Request, Response, request::FromRequest};
+
+/// `_meta` key that tags every message belonging to a subscription with the
+/// id of the `subscriptions/listen` request that opened it.
+pub const SUBSCRIPTION_ID_KEY: &str = "io.modelcontextprotocol/subscriptionId";
+
+/// List of commands for subscriptions
+pub mod commands {
+    /// Command name that opens a long-lived notification subscription.
+    pub const LISTEN: &str = "subscriptions/listen";
+
+    /// Notification name that reports the accepted subset of a subscription
+    /// filter. Always the first message on a subscription.
+    pub const ACKNOWLEDGED: &str = "notifications/subscriptions/acknowledged";
+}
+
+#[inline]
+fn is_false(flag: &bool) -> bool {
+    !*flag
+}
+
+/// Notification categories a client opts in to on a `subscriptions/listen`
+/// stream.
+///
+/// Every category is opt-in: a server **MUST NOT** deliver a notification type
+/// the client did not request. An omitted field is exactly "not subscribed",
+/// which is why unset categories are skipped on the wire rather than sent as
+/// `false`.
+///
+/// # Examples
+/// ```
+/// use neva::types::SubscriptionFilter;
+///
+/// let filter = SubscriptionFilter::new()
+///     .with_tools_changed()
+///     .with_resource("file:///project/config.json");
+///
+/// assert!(filter.tools_list_changed);
+/// assert!(!filter.prompts_list_changed);
+/// ```
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionFilter {
+    /// Receive `notifications/tools/list_changed` when the tool list changes.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub tools_list_changed: bool,
+
+    /// Receive `notifications/prompts/list_changed` when the prompt list changes.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub prompts_list_changed: bool,
+
+    /// Receive `notifications/resources/list_changed` when the resource list changes.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub resources_list_changed: bool,
+
+    /// Receive `notifications/resources/updated` for these resource URIs.
+    ///
+    /// This is where the removed `resources/subscribe` RPC went: a per-resource
+    /// subscription is a URI in this set, scoped to the lifetime of the stream.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resource_subscriptions: Vec<Uri>,
+}
+
+impl SubscriptionFilter {
+    /// Creates an empty filter that opts in to nothing.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// assert!(SubscriptionFilter::new().is_empty());
+    /// ```
+    #[inline]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Opts in to `notifications/tools/list_changed`.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// let filter = SubscriptionFilter::new().with_tools_changed();
+    /// assert!(filter.tools_list_changed);
+    /// ```
+    #[inline]
+    pub fn with_tools_changed(mut self) -> Self {
+        self.tools_list_changed = true;
+        self
+    }
+
+    /// Opts in to `notifications/prompts/list_changed`.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// let filter = SubscriptionFilter::new().with_prompts_changed();
+    /// assert!(filter.prompts_list_changed);
+    /// ```
+    #[inline]
+    pub fn with_prompts_changed(mut self) -> Self {
+        self.prompts_list_changed = true;
+        self
+    }
+
+    /// Opts in to `notifications/resources/list_changed`.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// let filter = SubscriptionFilter::new().with_resources_changed();
+    /// assert!(filter.resources_list_changed);
+    /// ```
+    #[inline]
+    pub fn with_resources_changed(mut self) -> Self {
+        self.resources_list_changed = true;
+        self
+    }
+
+    /// Opts in to `notifications/resources/updated` for a single resource.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// let filter = SubscriptionFilter::new().with_resource("res://config");
+    /// assert_eq!(filter.resource_subscriptions.len(), 1);
+    /// ```
+    #[inline]
+    pub fn with_resource(mut self, uri: impl Into<Uri>) -> Self {
+        let uri = uri.into();
+        if !self.resource_subscriptions.contains(&uri) {
+            self.resource_subscriptions.push(uri);
+        }
+        self
+    }
+
+    /// Opts in to `notifications/resources/updated` for every supplied resource.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// let filter = SubscriptionFilter::new()
+    ///     .with_resources(["res://a", "res://b"]);
+    ///
+    /// assert_eq!(filter.resource_subscriptions.len(), 2);
+    /// ```
+    #[inline]
+    pub fn with_resources<U: Into<Uri>>(mut self, uris: impl IntoIterator<Item = U>) -> Self {
+        for uri in uris {
+            self = self.with_resource(uri);
+        }
+        self
+    }
+
+    /// Returns `true` when nothing at all is subscribed.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// assert!(SubscriptionFilter::new().is_empty());
+    /// assert!(!SubscriptionFilter::new().with_tools_changed().is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        !self.tools_list_changed
+            && !self.prompts_list_changed
+            && !self.resources_list_changed
+            && self.resource_subscriptions.is_empty()
+    }
+
+    /// Returns the subset present in both filters.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// let requested = SubscriptionFilter::new()
+    ///     .with_tools_changed()
+    ///     .with_prompts_changed();
+    /// let offered = SubscriptionFilter::new().with_tools_changed();
+    ///
+    /// let accepted = requested.intersection(&offered);
+    ///
+    /// assert!(accepted.tools_list_changed);
+    /// assert!(!accepted.prompts_list_changed);
+    /// ```
+    pub fn intersection(&self, other: &Self) -> Self {
+        Self {
+            tools_list_changed: self.tools_list_changed && other.tools_list_changed,
+            prompts_list_changed: self.prompts_list_changed && other.prompts_list_changed,
+            resources_list_changed: self.resources_list_changed && other.resources_list_changed,
+            resource_subscriptions: self
+                .resource_subscriptions
+                .iter()
+                .filter(|uri| other.resource_subscriptions.contains(uri))
+                .cloned()
+                .collect(),
+        }
+    }
+
+    /// Returns whether this filter admits only what `other` requested.
+    ///
+    /// This is the client-side check behind "the server **MUST NOT** send a
+    /// notification type the client has not explicitly requested": an
+    /// acknowledgment that is not a subset of the request is a protocol
+    /// violation.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// let requested = SubscriptionFilter::new().with_tools_changed();
+    /// let acknowledged = SubscriptionFilter::new().with_tools_changed();
+    ///
+    /// assert!(acknowledged.is_subset_of(&requested));
+    /// assert!(!requested.with_prompts_changed().is_subset_of(&acknowledged));
+    /// ```
+    pub fn is_subset_of(&self, other: &Self) -> bool {
+        (!self.tools_list_changed || other.tools_list_changed)
+            && (!self.prompts_list_changed || other.prompts_list_changed)
+            && (!self.resources_list_changed || other.resources_list_changed)
+            && self
+                .resource_subscriptions
+                .iter()
+                .all(|uri| other.resource_subscriptions.contains(uri))
+    }
+
+    /// Narrows this filter to what `capabilities` actually advertise.
+    ///
+    /// A server answers a `subscriptions/listen` with the subset it agrees to
+    /// honor; categories it never announced are dropped rather than refused.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::{ServerCapabilities, SubscriptionFilter, ToolsCapability};
+    ///
+    /// let caps = ServerCapabilities {
+    ///     tools: Some(ToolsCapability { list_changed: true }),
+    ///     ..Default::default()
+    /// };
+    ///
+    /// let accepted = SubscriptionFilter::new()
+    ///     .with_tools_changed()
+    ///     .with_prompts_changed()
+    ///     .supported_by(&caps);
+    ///
+    /// assert!(accepted.tools_list_changed);
+    /// assert!(!accepted.prompts_list_changed);
+    /// ```
+    pub fn supported_by(&self, capabilities: &crate::types::ServerCapabilities) -> Self {
+        let resources_subscribe = capabilities
+            .resources
+            .as_ref()
+            .is_some_and(|res| res.subscribe);
+
+        Self {
+            tools_list_changed: self.tools_list_changed
+                && capabilities
+                    .tools
+                    .as_ref()
+                    .is_some_and(|tools| tools.list_changed),
+            prompts_list_changed: self.prompts_list_changed
+                && capabilities
+                    .prompts
+                    .as_ref()
+                    .is_some_and(|prompts| prompts.list_changed),
+            resources_list_changed: self.resources_list_changed
+                && capabilities
+                    .resources
+                    .as_ref()
+                    .is_some_and(|res| res.list_changed),
+            resource_subscriptions: if resources_subscribe {
+                self.resource_subscriptions.clone()
+            } else {
+                Vec::new()
+            },
+        }
+    }
+
+    /// Returns whether a notification belongs on a stream carrying this filter.
+    ///
+    /// `uri` is the updated resource for `notifications/resources/updated` and
+    /// `None` for every other method.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::SubscriptionFilter;
+    ///
+    /// let filter = SubscriptionFilter::new().with_tools_changed();
+    ///
+    /// assert!(filter.matches("notifications/tools/list_changed", None));
+    /// assert!(!filter.matches("notifications/prompts/list_changed", None));
+    /// ```
+    pub fn matches(&self, method: &str, uri: Option<&Uri>) -> bool {
+        use crate::types::{prompt, resource, tool};
+
+        match method {
+            tool::commands::LIST_CHANGED => self.tools_list_changed,
+            prompt::commands::LIST_CHANGED => self.prompts_list_changed,
+            resource::commands::LIST_CHANGED => self.resources_list_changed,
+            resource::commands::UPDATED => {
+                uri.is_some_and(|uri| self.resource_subscriptions.contains(uri))
+            }
+            _ => false,
+        }
+    }
+}
+
+/// `_meta` carried by every message on a subscription stream.
+///
+/// The value is the JSON-RPC id of the `subscriptions/listen` request that
+/// opened the stream, so a client sharing one channel between several
+/// subscriptions -- stdio always does -- can demultiplex them.
+///
+/// # Examples
+/// ```
+/// use neva::types::{RequestId, SubscriptionMeta};
+///
+/// let meta = SubscriptionMeta::new(RequestId::Number(1));
+/// let json = serde_json::to_value(&meta).unwrap();
+///
+/// assert_eq!(json["io.modelcontextprotocol/subscriptionId"], 1);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubscriptionMeta {
+    /// The id of the `subscriptions/listen` request this message belongs to.
+    #[serde(rename = "io.modelcontextprotocol/subscriptionId")]
+    pub subscription_id: RequestId,
+}
+
+impl SubscriptionMeta {
+    /// Creates a new [`SubscriptionMeta`] for `subscription_id`.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::{RequestId, SubscriptionMeta};
+    ///
+    /// let meta = SubscriptionMeta::new(RequestId::Number(7));
+    /// assert_eq!(meta.subscription_id, RequestId::Number(7));
+    /// ```
+    #[inline]
+    pub fn new(subscription_id: RequestId) -> Self {
+        Self { subscription_id }
+    }
+}
+
+impl From<RequestId> for SubscriptionMeta {
+    #[inline]
+    fn from(subscription_id: RequestId) -> Self {
+        Self::new(subscription_id)
+    }
+}
+
+/// Parameters of a `subscriptions/listen` request.
+///
+/// # Examples
+/// ```
+/// use neva::types::{SubscriptionFilter, SubscriptionsListenRequestParams};
+///
+/// let params = SubscriptionsListenRequestParams::new(
+///     SubscriptionFilter::new().with_tools_changed(),
+/// );
+///
+/// assert!(params.notifications.tools_list_changed);
+/// ```
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct SubscriptionsListenRequestParams {
+    /// The notification categories the client opts in to.
+    pub notifications: SubscriptionFilter,
+
+    /// Metadata reserved by MCP for protocol-level metadata.
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestParamsMeta>,
+}
+
+impl SubscriptionsListenRequestParams {
+    /// Creates new params opting in to `notifications`.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::{SubscriptionFilter, SubscriptionsListenRequestParams};
+    ///
+    /// let params = SubscriptionsListenRequestParams::new(SubscriptionFilter::new());
+    /// assert!(params.notifications.is_empty());
+    /// ```
+    #[inline]
+    pub fn new(notifications: SubscriptionFilter) -> Self {
+        Self {
+            notifications,
+            meta: None,
+        }
+    }
+}
+
+impl From<SubscriptionFilter> for SubscriptionsListenRequestParams {
+    #[inline]
+    fn from(notifications: SubscriptionFilter) -> Self {
+        Self::new(notifications)
+    }
+}
+
+/// Parameters of a `notifications/subscriptions/acknowledged` notification.
+///
+/// Sent as the first message on a subscription, reporting the subset of the
+/// requested filter the server agreed to honor.
+///
+/// # Examples
+/// ```
+/// use neva::types::{
+///     RequestId, SubscriptionFilter, SubscriptionsAcknowledgedNotificationParams,
+/// };
+///
+/// let params = SubscriptionsAcknowledgedNotificationParams::new(
+///     RequestId::Number(1),
+///     SubscriptionFilter::new().with_tools_changed(),
+/// );
+///
+/// assert!(params.notifications.tools_list_changed);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionsAcknowledgedNotificationParams {
+    /// The subset of the requested filter the server honors.
+    pub notifications: SubscriptionFilter,
+
+    /// Carries the subscription id (see [`SubscriptionMeta`]).
+    #[serde(rename = "_meta")]
+    pub meta: SubscriptionMeta,
+}
+
+impl SubscriptionsAcknowledgedNotificationParams {
+    /// Creates acknowledgment params for `subscription_id`.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::{
+    ///     RequestId, SubscriptionFilter, SubscriptionsAcknowledgedNotificationParams,
+    /// };
+    ///
+    /// let params = SubscriptionsAcknowledgedNotificationParams::new(
+    ///     RequestId::Number(1),
+    ///     SubscriptionFilter::new(),
+    /// );
+    ///
+    /// assert_eq!(params.meta.subscription_id, RequestId::Number(1));
+    /// ```
+    #[inline]
+    pub fn new(subscription_id: RequestId, notifications: SubscriptionFilter) -> Self {
+        Self {
+            notifications,
+            meta: SubscriptionMeta::new(subscription_id),
+        }
+    }
+}
+
+/// Final result of a `subscriptions/listen` request: the subscription ended
+/// gracefully.
+///
+/// A stream that closes without this result was dropped abruptly, which a
+/// client **MAY** treat as a reason to reconnect and re-subscribe.
+///
+/// # Examples
+/// ```
+/// use neva::types::{RequestId, SubscriptionsListenResult};
+///
+/// let result = SubscriptionsListenResult::new(RequestId::Number(1));
+/// assert_eq!(result.meta.subscription_id, RequestId::Number(1));
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionsListenResult {
+    /// Carries the subscription id (see [`SubscriptionMeta`]).
+    #[serde(rename = "_meta")]
+    pub meta: SubscriptionMeta,
+}
+
+impl SubscriptionsListenResult {
+    /// Creates the graceful-close result for `subscription_id`.
+    ///
+    /// # Examples
+    /// ```
+    /// use neva::types::{RequestId, SubscriptionsListenResult};
+    ///
+    /// let result = SubscriptionsListenResult::new(RequestId::Number(1));
+    /// assert_eq!(result.meta.subscription_id, RequestId::Number(1));
+    /// ```
+    #[inline]
+    pub fn new(subscription_id: RequestId) -> Self {
+        Self {
+            meta: SubscriptionMeta::new(subscription_id),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl FromHandlerParams for SubscriptionsListenRequestParams {
+    #[inline]
+    fn from_params(params: &HandlerParams) -> Result<Self, Error> {
+        let req = Request::from_params(params)?;
+        Self::from_request(req)
+    }
+}
+
+#[cfg(feature = "server")]
+impl IntoResponse for SubscriptionsListenResult {
+    #[inline]
+    fn into_response(self, req_id: RequestId) -> Response {
+        match serde_json::to_value(self) {
+            Ok(v) => Response::success(req_id, v),
+            Err(err) => Response::error(req_id, err.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{
+        PromptsCapability, ResourcesCapability, ServerCapabilities, ToolsCapability,
+    };
+
+    fn caps(
+        tools: bool,
+        prompts: bool,
+        resources_list: bool,
+        subscribe: bool,
+    ) -> ServerCapabilities {
+        ServerCapabilities {
+            tools: Some(ToolsCapability {
+                list_changed: tools,
+            }),
+            prompts: Some(PromptsCapability {
+                list_changed: prompts,
+            }),
+            resources: Some(ResourcesCapability {
+                list_changed: resources_list,
+                subscribe,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn it_omits_unset_categories_on_the_wire() {
+        // "Omitting a field is equivalent to not subscribing to that
+        // notification type" -- an unset category must not travel as `false`,
+        // so an acknowledgment can drop what the server does not honor.
+        let filter = SubscriptionFilter::new().with_tools_changed();
+        let json = serde_json::to_value(&filter).unwrap();
+
+        assert_eq!(json["toolsListChanged"], serde_json::json!(true));
+        assert!(json.get("promptsListChanged").is_none());
+        assert!(json.get("resourcesListChanged").is_none());
+        assert!(json.get("resourceSubscriptions").is_none());
+    }
+
+    #[test]
+    fn it_roundtrips_filter() {
+        let filter = SubscriptionFilter::new()
+            .with_tools_changed()
+            .with_prompts_changed()
+            .with_resources_changed()
+            .with_resources(["res://a", "res://b"]);
+
+        let json = serde_json::to_string(&filter).unwrap();
+        let back: SubscriptionFilter = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(filter, back);
+    }
+
+    #[test]
+    fn it_deserializes_absent_fields_as_unsubscribed() {
+        let filter: SubscriptionFilter = serde_json::from_str("{}").unwrap();
+        assert!(filter.is_empty());
+    }
+
+    #[test]
+    fn it_deduplicates_resource_uris() {
+        let filter = SubscriptionFilter::new().with_resources(["res://a", "res://a"]);
+        assert_eq!(filter.resource_subscriptions.len(), 1);
+    }
+
+    #[test]
+    fn it_intersects_filters() {
+        let requested = SubscriptionFilter::new()
+            .with_tools_changed()
+            .with_prompts_changed()
+            .with_resources(["res://a", "res://b"]);
+        let offered = SubscriptionFilter::new()
+            .with_prompts_changed()
+            .with_resources_changed()
+            .with_resources(["res://b", "res://c"]);
+
+        let accepted = requested.intersection(&offered);
+
+        assert!(!accepted.tools_list_changed);
+        assert!(accepted.prompts_list_changed);
+        assert!(!accepted.resources_list_changed);
+        assert_eq!(accepted.resource_subscriptions, [Uri::from("res://b")]);
+    }
+
+    #[test]
+    fn it_checks_subset() {
+        let requested = SubscriptionFilter::new()
+            .with_tools_changed()
+            .with_resource("res://a");
+
+        assert!(requested.is_subset_of(&requested));
+        assert!(
+            SubscriptionFilter::new()
+                .with_tools_changed()
+                .is_subset_of(&requested)
+        );
+        assert!(SubscriptionFilter::new().is_subset_of(&requested));
+        assert!(
+            !SubscriptionFilter::new()
+                .with_prompts_changed()
+                .is_subset_of(&requested)
+        );
+        assert!(
+            !SubscriptionFilter::new()
+                .with_resource("res://b")
+                .is_subset_of(&requested)
+        );
+    }
+
+    #[test]
+    fn it_narrows_to_advertised_capabilities() {
+        let requested = SubscriptionFilter::new()
+            .with_tools_changed()
+            .with_prompts_changed()
+            .with_resources_changed()
+            .with_resource("res://a");
+
+        let accepted = requested.supported_by(&caps(true, false, true, false));
+
+        assert!(accepted.tools_list_changed);
+        assert!(!accepted.prompts_list_changed);
+        assert!(accepted.resources_list_changed);
+        assert!(accepted.resource_subscriptions.is_empty());
+    }
+
+    #[test]
+    fn it_narrows_to_nothing_without_capabilities() {
+        let requested = SubscriptionFilter::new()
+            .with_tools_changed()
+            .with_resource("res://a");
+
+        let accepted = requested.supported_by(&ServerCapabilities::default());
+
+        assert!(accepted.is_empty());
+    }
+
+    #[test]
+    fn it_keeps_resource_subscriptions_when_subscribe_is_advertised() {
+        let requested = SubscriptionFilter::new().with_resource("res://a");
+        let accepted = requested.supported_by(&caps(false, false, false, true));
+
+        assert_eq!(accepted.resource_subscriptions, [Uri::from("res://a")]);
+    }
+
+    #[test]
+    fn it_matches_only_subscribed_methods() {
+        use crate::types::{prompt, resource, tool};
+
+        let filter = SubscriptionFilter::new()
+            .with_tools_changed()
+            .with_resource("res://a");
+
+        assert!(filter.matches(tool::commands::LIST_CHANGED, None));
+        assert!(!filter.matches(prompt::commands::LIST_CHANGED, None));
+        assert!(!filter.matches(resource::commands::LIST_CHANGED, None));
+        assert!(filter.matches(resource::commands::UPDATED, Some(&Uri::from("res://a"))));
+        assert!(!filter.matches(resource::commands::UPDATED, Some(&Uri::from("res://b"))));
+        assert!(!filter.matches(resource::commands::UPDATED, None));
+        assert!(!filter.matches("notifications/progress", None));
+    }
+
+    #[test]
+    fn it_serializes_subscription_id_meta() {
+        let params = SubscriptionsAcknowledgedNotificationParams::new(
+            RequestId::Number(1),
+            SubscriptionFilter::new().with_tools_changed(),
+        );
+        let json = serde_json::to_value(&params).unwrap();
+
+        assert_eq!(json["_meta"][SUBSCRIPTION_ID_KEY], serde_json::json!(1));
+        assert_eq!(json["notifications"]["toolsListChanged"], true);
+    }
+
+    #[test]
+    fn it_serializes_graceful_close_result() {
+        let result = SubscriptionsListenResult::new(RequestId::String("sub-1".into()));
+        let json = serde_json::to_value(&result).unwrap();
+
+        assert_eq!(json["_meta"][SUBSCRIPTION_ID_KEY], "sub-1");
+    }
+
+    #[test]
+    fn it_parses_listen_params() {
+        let json = r#"{"notifications":{"toolsListChanged":true,
+            "resourceSubscriptions":["file:///project/config.json"]}}"#;
+        let params: SubscriptionsListenRequestParams = serde_json::from_str(json).unwrap();
+
+        assert!(params.notifications.tools_list_changed);
+        assert_eq!(
+            params.notifications.resource_subscriptions,
+            [Uri::from("file:///project/config.json")]
+        );
+    }
+}

--- a/neva/src/types/subscription.rs
+++ b/neva/src/types/subscription.rs
@@ -38,6 +38,27 @@ fn is_false(flag: &bool) -> bool {
     !*flag
 }
 
+/// Whether `method` is one of the notification types a [`SubscriptionFilter`]
+/// can opt in to.
+///
+/// Shared by both ends of the wire, and for opposite reasons: the server uses
+/// it to tell "nobody is listening" from "this never travels on a
+/// subscription" (progress, task status and elicitation notifications stay
+/// request-scoped), the client to tell which arrivals are required to carry a
+/// subscription id.
+#[inline]
+pub(crate) fn is_subscribable(method: &str) -> bool {
+    use crate::types::{prompt, resource, tool};
+
+    matches!(
+        method,
+        tool::commands::LIST_CHANGED
+            | prompt::commands::LIST_CHANGED
+            | resource::commands::LIST_CHANGED
+            | resource::commands::UPDATED
+    )
+}
+
 /// Notification categories a client opts in to on a `subscriptions/listen`
 /// stream.
 ///

--- a/neva/tests/subscription_logging.rs
+++ b/neva/tests/subscription_logging.rs
@@ -277,6 +277,70 @@ async fn a_flood_before_the_acknowledgment_never_displaces_it() {
     handle.abort();
 }
 
+/// The acknowledgment's room on the body is reserved before any middleware can
+/// run, so a burst that fills the sink outright cannot cost the subscription
+/// its handshake -- it only costs the logs that did not fit, which is what a
+/// bounded sink does anyway.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_burst_that_fills_the_sink_still_opens_the_subscription() {
+    install_subscriber();
+
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app = App::new()
+        .with_options(|opt| {
+            opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp").with_sse_log_queue(1))
+                .with_tools(|t| t.with_list_changed())
+        })
+        // Synchronous, so nothing drains between them: with a capacity of one,
+        // the channel is full by the time the listen handler runs.
+        .wrap(|ctx, next| async move {
+            for i in 0..16 {
+                tracing::warn!(logger = "mw", "{MARKER}-{i}");
+            }
+            next(ctx).await
+        });
+    app.map_tool("ping", || async { "pong" });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
+    let url = format!("http://{addr}/mcp");
+
+    let listen = serde_json::json!({
+        "jsonrpc": "2.0", "id": "sub-1", "method": "subscriptions/listen",
+        "params": {
+            "notifications": { "toolsListChanged": true },
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/logLevel": "info"
+            }
+        }
+    });
+    let mut stream = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "subscriptions/listen")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&listen)
+        .send()
+        .await
+        .expect("listen failed");
+
+    let mut body = String::new();
+    let first = next_message(&mut stream, &mut body).await;
+    assert_eq!(
+        first["method"], "notifications/subscriptions/acknowledged",
+        "a full sink must not cost the subscription its acknowledgment, got {first}"
+    );
+
+    handle.abort();
+}
+
 /// The notification layer is the process-wide subscriber, so whichever test
 /// gets there first installs it -- both want the same one.
 fn install_subscriber() {

--- a/neva/tests/subscription_logging.rs
+++ b/neva/tests/subscription_logging.rs
@@ -26,10 +26,7 @@ const MARKER: &str = "logged-before-next";
 
 #[tokio::test(flavor = "multi_thread")]
 async fn a_listen_stream_opens_with_its_acknowledgment() {
-    tracing_subscriber::registry()
-        .with(tracing::level_filters::LevelFilter::WARN)
-        .with(notification::fmt::layer())
-        .init();
+    install_subscriber();
 
     let addr = format!("127.0.0.1:{}", pick_free_port());
     let mut app = App::new()
@@ -163,6 +160,130 @@ async fn a_listen_stream_opens_with_its_acknowledgment() {
     );
 
     handle.abort();
+}
+
+/// The acknowledgment coming first is a MUST; the held logs riding along after
+/// it are an accommodation. A handler that floods the body before the listen
+/// handler runs must therefore lose the overflow, not the ordering.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_flood_before_the_acknowledgment_never_displaces_it() {
+    const HELD: usize = 2;
+    const FLOOD: usize = 8;
+
+    install_subscriber();
+
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app = App::new()
+        .with_options(|opt| {
+            opt.with_http(|http| {
+                http.bind(&addr)
+                    .with_endpoint("/mcp")
+                    .with_sse_log_queue(HELD)
+            })
+            .with_tools(|t| t.with_list_changed())
+        })
+        // Paced, not bursted: the stream drains each message into the hold
+        // buffer before the next arrives, so the buffer outgrows the channel
+        // while the channel itself never fills -- which is the only way to
+        // reach the limit with the acknowledgment still able to get through.
+        .wrap(|ctx, next| async move {
+            for i in 0..FLOOD {
+                tracing::warn!(logger = "mw", "{MARKER}-{i}");
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+            next(ctx).await
+        });
+    app.map_tool("grow", |mut ctx: neva::Context| async move {
+        ctx.add_tool(neva::types::Tool::new(
+            format!("grown-{}", uuid::Uuid::new_v4()),
+            || async { "ok" },
+        ))
+        .await?;
+        Ok::<_, neva::error::Error>("grown".to_string())
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
+    let url = format!("http://{addr}/mcp");
+
+    let listen = serde_json::json!({
+        "jsonrpc": "2.0", "id": "sub-1", "method": "subscriptions/listen",
+        "params": {
+            "notifications": { "toolsListChanged": true },
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/logLevel": "info"
+            }
+        }
+    });
+    let mut stream = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "subscriptions/listen")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&listen)
+        .send()
+        .await
+        .expect("listen failed");
+
+    let mut body = String::new();
+    let first = next_message(&mut stream, &mut body).await;
+    assert_eq!(
+        first["method"], "notifications/subscriptions/acknowledged",
+        "a flood before the acknowledgment must not displace it, got {first}"
+    );
+
+    // What is released after it is bounded: the buffer holds what the sink
+    // itself would have, and the rest is dropped rather than reordered.
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "grow", "arguments": {}, "_meta": {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {}
+        } }
+    });
+    let resp = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "tools/call")
+        .header("Mcp-Name", "grow")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&call)
+        .send()
+        .await
+        .expect("grow failed");
+    let _ = resp.text().await;
+
+    let mut released = 0;
+    loop {
+        let msg = next_message(&mut stream, &mut body).await;
+        match msg["method"].as_str().unwrap_or_default() {
+            "notifications/message" => released += 1,
+            "notifications/tools/list_changed" => break,
+            other => panic!("unexpected frame on the subscription stream: {other}"),
+        }
+    }
+    assert!(
+        released <= HELD,
+        "the pre-acknowledgment buffer must stay bounded, got {released} of {FLOOD}"
+    );
+
+    handle.abort();
+}
+
+/// The notification layer is the process-wide subscriber, so whichever test
+/// gets there first installs it -- both want the same one.
+fn install_subscriber() {
+    let _ = tracing_subscriber::registry()
+        .with(tracing::level_filters::LevelFilter::WARN)
+        .with(notification::fmt::layer())
+        .try_init();
 }
 
 /// Pulls chunks off a live SSE body until one more complete `data:` frame is

--- a/neva/tests/subscription_logging.rs
+++ b/neva/tests/subscription_logging.rs
@@ -127,6 +127,41 @@ async fn a_listen_stream_opens_with_its_acknowledgment() {
          logging of the call that opened it; got {before:?}"
     );
 
+    // A listen inside a batch streams on the same kind of body under the same
+    // rule. neva's own client refuses to batch one -- there would be no handle
+    // to end the subscription with -- but this server takes what any peer
+    // sends, so the classification has to see through the batch.
+    let batched = serde_json::json!([{
+        "jsonrpc": "2.0", "id": "sub-2", "method": "subscriptions/listen",
+        "params": {
+            "notifications": { "toolsListChanged": true },
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/logLevel": "info"
+            }
+        }
+    }]);
+    let mut batch_stream = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        // No `Mcp-Method`: the server rejects one on a batch, since it cannot
+        // describe several requests at once.
+        .header("Accept", "application/json, text/event-stream")
+        .json(&batched)
+        .send()
+        .await
+        .expect("batched listen failed");
+
+    assert!(batch_stream.status().is_success());
+
+    let mut batch_body = String::new();
+    let first = next_message(&mut batch_stream, &mut batch_body).await;
+    assert_eq!(
+        first["method"], "notifications/subscriptions/acknowledged",
+        "a batched listen streams under the same rule, got {first}"
+    );
+
     handle.abort();
 }
 

--- a/neva/tests/subscription_logging.rs
+++ b/neva/tests/subscription_logging.rs
@@ -1,0 +1,163 @@
+//! What a `subscriptions/listen` response body may carry (MCP 2026-07-28).
+//!
+//! The body of a listen `POST` is the subscription's stream: the
+//! acknowledgment MUST be its first message. Request-scoped
+//! `notifications/message` are a different mechanism on the same transport, and
+//! middleware wrapped around the handler emits them *before* the handler ever
+//! runs -- so they must not be written onto this body at all.
+//!
+//! Its own file because the notification layer is installed as the process-wide
+//! default subscriber.
+#![cfg(all(
+    not(feature = "legacy-spec"),
+    feature = "http-server-volga",
+    feature = "http-client",
+    feature = "tracing"
+))]
+
+use neva::App;
+use neva::types::notification;
+use std::time::Duration;
+use tracing_subscriber::prelude::*;
+
+const MARKER: &str = "logged-before-next";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_listen_stream_opens_with_its_acknowledgment() {
+    tracing_subscriber::registry()
+        .with(tracing::level_filters::LevelFilter::WARN)
+        .with(notification::fmt::layer())
+        .init();
+
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app = App::new()
+        .with_options(|opt| {
+            opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+                .with_tools(|t| t.with_list_changed())
+        })
+        // Logs *before* `next(ctx)`: by the time the listen handler queues its
+        // acknowledgment, this event has already been through the layer. The
+        // per-request sink exists from the moment the transport takes the
+        // request, so nothing but the stream's own rules keeps it off the body.
+        .wrap(|ctx, next| async move {
+            tracing::warn!(logger = "mw", "{MARKER}");
+            next(ctx).await
+        });
+    app.map_tool("grow", |mut ctx: neva::Context| async move {
+        ctx.add_tool(neva::types::Tool::new(
+            format!("grown-{}", uuid::Uuid::new_v4()),
+            || async { "ok" },
+        ))
+        .await?;
+        Ok::<_, neva::error::Error>("grown".to_string())
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
+    let url = format!("http://{addr}/mcp");
+
+    let listen = serde_json::json!({
+        "jsonrpc": "2.0", "id": "sub-1", "method": "subscriptions/listen",
+        "params": {
+            "notifications": { "toolsListChanged": true },
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/logLevel": "info"
+            }
+        }
+    });
+    let mut stream = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "subscriptions/listen")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&listen)
+        .send()
+        .await
+        .expect("listen failed");
+
+    assert!(stream.status().is_success());
+
+    let mut body = String::new();
+    let first = next_message(&mut stream, &mut body).await;
+    assert_eq!(
+        first["method"], "notifications/subscriptions/acknowledged",
+        "the acknowledgment must be the first message on a subscription stream, got {first}"
+    );
+
+    // And the log never appears later either: a subscription stream carries the
+    // subscription, not the request-scoped logging of the call that opened it.
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+        "params": { "name": "grow", "arguments": {}, "_meta": {
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {}
+        } }
+    });
+    let resp = client
+        .post(&url)
+        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "tools/call")
+        .header("Mcp-Name", "grow")
+        .header("Accept", "application/json, text/event-stream")
+        .json(&call)
+        .send()
+        .await
+        .expect("grow failed");
+    let _ = resp.text().await;
+
+    let mut before = Vec::new();
+    loop {
+        let msg = next_message(&mut stream, &mut body).await;
+        let method = msg["method"].as_str().unwrap_or_default().to_owned();
+        if method == "notifications/tools/list_changed" {
+            break;
+        }
+        before.push(method);
+    }
+    assert!(
+        before.is_empty(),
+        "a subscription stream carries the subscription, not the request-scoped \
+         logging of the call that opened it; got {before:?}"
+    );
+
+    handle.abort();
+}
+
+/// Pulls chunks off a live SSE body until one more complete `data:` frame is
+/// available, and returns it parsed.
+async fn next_message(resp: &mut reqwest::Response, body: &mut String) -> serde_json::Value {
+    loop {
+        if let Some(msg) = take_frame(body) {
+            return msg;
+        }
+        let chunk = tokio::time::timeout(Duration::from_secs(5), resp.chunk())
+            .await
+            .expect("timed out waiting for the next subscription message")
+            .expect("stream error")
+            .expect("stream ended before the expected message");
+        body.push_str(&String::from_utf8_lossy(&chunk));
+    }
+}
+
+fn take_frame(body: &mut String) -> Option<serde_json::Value> {
+    let end = body.find("\n\n")?;
+    let frame: String = body.drain(..end + 2).collect();
+    frame
+        .lines()
+        .find_map(|line| line.strip_prefix("data:"))
+        .and_then(|data| serde_json::from_str(data.trim()).ok())
+}
+
+fn pick_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}

--- a/neva/tests/subscription_logging.rs
+++ b/neva/tests/subscription_logging.rs
@@ -2,9 +2,11 @@
 //!
 //! The body of a listen `POST` is the subscription's stream: the
 //! acknowledgment MUST be its first message. Request-scoped
-//! `notifications/message` are a different mechanism on the same transport, and
-//! middleware wrapped around the handler emits them *before* the handler ever
-//! runs -- so they must not be written onto this body at all.
+//! `notifications/message` share the same body, and middleware wrapped around
+//! the handler emits them *before* the handler ever runs -- so they are held
+//! back until the acknowledgment goes out, then released. Held, not dropped:
+//! the client asked for them, and in a mixed batch they may belong to another
+//! request entirely.
 //!
 //! Its own file because the notification layer is installed as the process-wide
 //! default subscriber.
@@ -91,8 +93,15 @@ async fn a_listen_stream_opens_with_its_acknowledgment() {
         "the acknowledgment must be the first message on a subscription stream, got {first}"
     );
 
-    // And the log never appears later either: a subscription stream carries the
-    // subscription, not the request-scoped logging of the call that opened it.
+    // The log that preceded it is not lost -- it follows the acknowledgment
+    // rather than jumping ahead of it.
+    let logged = next_message(&mut stream, &mut body).await;
+    assert_eq!(
+        logged["method"], "notifications/message",
+        "the held log message must be released after the acknowledgment, got {logged}"
+    );
+    assert_eq!(logged["params"]["data"]["message"], MARKER);
+
     let call = serde_json::json!({
         "jsonrpc": "2.0", "id": 2, "method": "tools/call",
         "params": { "name": "grow", "arguments": {}, "_meta": {
@@ -112,19 +121,10 @@ async fn a_listen_stream_opens_with_its_acknowledgment() {
         .expect("grow failed");
     let _ = resp.text().await;
 
-    let mut before = Vec::new();
-    loop {
-        let msg = next_message(&mut stream, &mut body).await;
-        let method = msg["method"].as_str().unwrap_or_default().to_owned();
-        if method == "notifications/tools/list_changed" {
-            break;
-        }
-        before.push(method);
-    }
-    assert!(
-        before.is_empty(),
-        "a subscription stream carries the subscription, not the request-scoped \
-         logging of the call that opened it; got {before:?}"
+    let next = next_message(&mut stream, &mut body).await;
+    assert_eq!(
+        next["method"], "notifications/tools/list_changed",
+        "the subscription's own notification must follow, got {next}"
     );
 
     // A listen inside a batch streams on the same kind of body under the same

--- a/neva/tests/subscriptions.rs
+++ b/neva/tests/subscriptions.rs
@@ -118,7 +118,9 @@ async fn subscription_streams_only_the_requested_notifications() {
     assert_eq!(updated["params"]["uri"], RESOURCE);
     assert_eq!(updated["params"]["_meta"][SUBSCRIPTION_ID_KEY], "sub-1");
 
-    // Cancelling ends the stream with the graceful-close result.
+    // Over HTTP a `notifications/cancelled` naming a bare id must NOT end the
+    // stream: it arrives on its own POST and proves nothing about who opened
+    // the subscription, while ids collide across clients routinely.
     let cancel = serde_json::json!({
         "jsonrpc": "2.0", "method": "notifications/cancelled",
         "params": { "requestId": "sub-1", "reason": "done" }
@@ -130,10 +132,20 @@ async fn subscription_streams_only_the_requested_notifications() {
         .await
         .expect("cancel failed");
 
-    let closed = next_message(&mut stream, &mut body).await;
-    assert_eq!(closed["id"], "sub-1");
-    assert_eq!(closed["result"]["_meta"][SUBSCRIPTION_ID_KEY], "sub-1");
-    assert_eq!(closed["result"]["resultType"], "complete");
+    call_tool(&client, &url, "grow", 5).await;
+    let still_live = next_message(&mut stream, &mut body).await;
+    assert_eq!(
+        still_live["method"], "notifications/tools/list_changed",
+        "a bare cancel must not end a session-bound subscription"
+    );
+
+    // Closing the stream is the mechanism the spec names on this transport.
+    drop(stream);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // The server survives it and keeps serving: the subscription was torn down,
+    // not the runtime.
+    call_tool(&client, &url, "grow", 6).await;
 
     handle.abort();
 }
@@ -243,6 +255,83 @@ async fn client_listen_delivers_to_registered_handlers() {
         seen.load(Ordering::SeqCst),
         1,
         "the registered handler must see the tools list change"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn client_cancel_ends_the_stream_over_http() {
+    // `Subscription::cancel` has to actually end the subscription on this
+    // transport, where the server cannot act on a bare `notifications/cancelled`
+    // -- the client closes its listen response body instead, and the handler
+    // observes that through its sink.
+    use neva::Client;
+    use neva::client::SubscriptionEnd;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app = App::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_tools(|t| t.with_list_changed())
+    });
+    app.map_tool("grow", |mut ctx: neva::Context| async move {
+        ctx.add_tool(Tool::new(
+            format!("grown-{}", uuid::Uuid::new_v4()),
+            || async { "ok" },
+        ))
+        .await?;
+        Ok::<_, neva::error::Error>("grown".to_string())
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    await_reachable(&addr).await;
+
+    let seen = Arc::new(AtomicUsize::new(0));
+    let counter = seen.clone();
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_timeout(Duration::from_secs(5))
+    });
+    client.connect().await.expect("connect");
+    client.on_tools_changed(move |_| {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+
+    let mut subscription = client
+        .listen(neva::types::SubscriptionFilter::new().with_tools_changed())
+        .await
+        .expect("listen");
+
+    client.call_tool("grow", ()).await.expect("first mutation");
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while seen.load(Ordering::SeqCst) == 0 && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(seen.load(Ordering::SeqCst), 1, "the stream must be live");
+
+    subscription.cancel().await.expect("cancel");
+    // Cancelling closes the stream, so no final result comes back -- and
+    // `closed()` must say so instead of waiting one out.
+    let ended = tokio::time::timeout(Duration::from_secs(2), subscription.closed())
+        .await
+        .expect("closed() must not hang after a cancel");
+    assert!(matches!(ended, SubscriptionEnd::Cancelled), "got {ended:?}");
+
+    // Nothing arrives after the cancel.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    client.call_tool("grow", ()).await.expect("second mutation");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        1,
+        "a cancelled subscription must stop delivering"
     );
 
     handle.abort();

--- a/neva/tests/subscriptions.rs
+++ b/neva/tests/subscriptions.rs
@@ -1,0 +1,348 @@
+//! `subscriptions/listen` end-to-end over the 2026-07-28 HTTP transport.
+//!
+//! The listen `POST` stays open as a `text/event-stream`: the acknowledgment
+//! arrives first, then only the notification types the filter opted in to, each
+//! tagged with the subscription id, and finally the graceful-close result once
+//! the client cancels.
+#![cfg(all(
+    not(feature = "legacy-spec"),
+    feature = "http-server-volga",
+    feature = "http-client"
+))]
+
+use neva::App;
+use neva::types::{SUBSCRIPTION_ID_KEY, Tool};
+use std::time::Duration;
+
+const RESOURCE: &str = "res://watched";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn subscription_streams_only_the_requested_notifications() {
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app = App::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_tools(|t| t.with_list_changed())
+            .with_prompts(|p| p.with_list_changed())
+            .with_resources(|r| r.with_list_changed().with_subscribe())
+    });
+    // Mutations a client can trigger, each producing one subscribable
+    // notification.
+    app.map_tool("grow", |mut ctx: neva::Context| async move {
+        ctx.add_tool(Tool::new("grown", || async { "ok" })).await?;
+        Ok::<_, neva::error::Error>("grown".to_string())
+    });
+    app.map_tool("touch", |mut ctx: neva::Context| async move {
+        ctx.resource_updated(RESOURCE).await?;
+        Ok::<_, neva::error::Error>("touched".to_string())
+    });
+    app.map_tool("add_prompt", |mut ctx: neva::Context| async move {
+        ctx.add_prompt(neva::types::Prompt::new("fresh", || async {
+            neva::types::PromptMessage::user().with("hi")
+        }))
+        .await?;
+        Ok::<_, neva::error::Error>("added".to_string())
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
+    let url = format!("http://{addr}/mcp");
+
+    // Open the subscription: tools list changes plus updates for one resource.
+    // Prompts are deliberately left out -- the server must never send them.
+    let listen = serde_json::json!({
+        "jsonrpc": "2.0", "id": "sub-1", "method": "subscriptions/listen",
+        "params": {
+            "notifications": {
+                "toolsListChanged": true,
+                "resourceSubscriptions": [RESOURCE]
+            },
+            "_meta": meta()
+        }
+    });
+    let mut stream = routed(client.post(&url), &listen)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&listen)
+        .send()
+        .await
+        .expect("listen failed");
+
+    assert!(stream.status().is_success());
+    let ctype = content_type(&stream);
+    assert!(
+        ctype.contains("text/event-stream"),
+        "a subscription reply must be a stream, got content-type {ctype:?}"
+    );
+
+    // The acknowledgment MUST be the first message, carrying the accepted
+    // subset and the subscription id.
+    let mut body = String::new();
+    let ack = next_message(&mut stream, &mut body).await;
+    assert_eq!(ack["method"], "notifications/subscriptions/acknowledged");
+    assert_eq!(ack["params"]["_meta"][SUBSCRIPTION_ID_KEY], "sub-1");
+    assert_eq!(ack["params"]["notifications"]["toolsListChanged"], true);
+    assert_eq!(
+        ack["params"]["notifications"]["resourceSubscriptions"][0],
+        RESOURCE
+    );
+    assert!(
+        ack["params"]["notifications"]
+            .get("promptsListChanged")
+            .is_none(),
+        "the acknowledgment must omit types the client never requested"
+    );
+
+    // A mutation on another request reaches this stream...
+    call_tool(&client, &url, "add_prompt", 2).await;
+    call_tool(&client, &url, "grow", 3).await;
+
+    let notification = next_message(&mut stream, &mut body).await;
+    assert_eq!(
+        notification["method"], "notifications/tools/list_changed",
+        "the prompts notification must not appear: it was never requested"
+    );
+    assert_eq!(
+        notification["params"]["_meta"][SUBSCRIPTION_ID_KEY],
+        "sub-1"
+    );
+
+    // ...and so does an update for a subscribed resource.
+    call_tool(&client, &url, "touch", 4).await;
+
+    let updated = next_message(&mut stream, &mut body).await;
+    assert_eq!(updated["method"], "notifications/resources/updated");
+    assert_eq!(updated["params"]["uri"], RESOURCE);
+    assert_eq!(updated["params"]["_meta"][SUBSCRIPTION_ID_KEY], "sub-1");
+
+    // Cancelling ends the stream with the graceful-close result.
+    let cancel = serde_json::json!({
+        "jsonrpc": "2.0", "method": "notifications/cancelled",
+        "params": { "requestId": "sub-1", "reason": "done" }
+    });
+    routed(client.post(&url), &cancel)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&cancel)
+        .send()
+        .await
+        .expect("cancel failed");
+
+    let closed = next_message(&mut stream, &mut body).await;
+    assert_eq!(closed["id"], "sub-1");
+    assert_eq!(closed["result"]["_meta"][SUBSCRIPTION_ID_KEY], "sub-1");
+    assert_eq!(closed["result"]["resultType"], "complete");
+
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn subscription_is_narrowed_to_advertised_capabilities() {
+    // A server that never advertises `listChanged` cannot promise it: the
+    // acknowledgment reports an empty filter rather than refusing the stream.
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app =
+        App::new().with_options(|opt| opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp")));
+    app.map_tool("noop", || async { "ok" });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let client = reqwest::Client::builder()
+        .no_proxy()
+        .build()
+        .expect("test client");
+    let url = format!("http://{addr}/mcp");
+
+    let listen = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "subscriptions/listen",
+        "params": {
+            "notifications": { "toolsListChanged": true, "promptsListChanged": true },
+            "_meta": meta()
+        }
+    });
+    let mut stream = routed(client.post(&url), &listen)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&listen)
+        .send()
+        .await
+        .expect("listen failed");
+
+    let mut body = String::new();
+    let ack = next_message(&mut stream, &mut body).await;
+
+    assert_eq!(ack["method"], "notifications/subscriptions/acknowledged");
+    assert_eq!(ack["params"]["_meta"][SUBSCRIPTION_ID_KEY], 1);
+    assert_eq!(
+        ack["params"]["notifications"],
+        serde_json::json!({}),
+        "an unadvertised type must be dropped from the accepted filter"
+    );
+
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn client_listen_delivers_to_registered_handlers() {
+    // The neva client's half of the same round trip: `listen` returns once the
+    // filter is acknowledged, and notifications land on the handlers registered
+    // with `on_tools_changed` and friends.
+    use neva::Client;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app = App::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_tools(|t| t.with_list_changed())
+    });
+    app.map_tool("grow", |mut ctx: neva::Context| async move {
+        ctx.add_tool(Tool::new("grown", || async { "ok" })).await?;
+        Ok::<_, neva::error::Error>("grown".to_string())
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    await_reachable(&addr).await;
+
+    let seen = Arc::new(AtomicUsize::new(0));
+    let counter = seen.clone();
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_timeout(Duration::from_secs(5))
+    });
+    client.connect().await.expect("connect");
+    // After `connect`: the helper asserts the server advertises `listChanged`,
+    // which is only known once capabilities have been discovered.
+    client.on_tools_changed(move |_| {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+
+    let subscription = client
+        .listen(neva::types::SubscriptionFilter::new().with_tools_changed())
+        .await
+        .expect("listen");
+
+    assert!(subscription.acknowledged().tools_list_changed);
+    assert!(subscription.is_fully_honored());
+
+    client.call_tool("grow", ()).await.expect("tools/call");
+
+    // The notification travels on the listen stream, so it arrives out of band
+    // from the call's own reply.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    while seen.load(Ordering::SeqCst) == 0 && tokio::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        1,
+        "the registered handler must see the tools list change"
+    );
+
+    handle.abort();
+}
+
+async fn await_reachable(addr: &str) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        match tokio::net::TcpStream::connect(addr).await {
+            Ok(_) => break,
+            Err(_) if tokio::time::Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(50)).await
+            }
+            Err(err) => panic!("server never became reachable: {err}"),
+        }
+    }
+}
+
+/// Calls a tool over a plain (non-streaming) POST and waits for its reply, so
+/// the mutation it performs has definitely happened.
+async fn call_tool(client: &reqwest::Client, url: &str, name: &str, id: i64) {
+    let call = serde_json::json!({
+        "jsonrpc": "2.0", "id": id, "method": "tools/call",
+        "params": { "name": name, "arguments": {}, "_meta": meta() }
+    });
+    let resp = routed(client.post(url), &call)
+        .header("Accept", "application/json, text/event-stream")
+        .json(&call)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("{name} call failed: {e}"));
+    assert!(resp.status().is_success(), "{name} call was rejected");
+    let _ = resp.text().await;
+}
+
+/// Pulls chunks off a live SSE body until one more complete `data:` frame is
+/// available, and returns it parsed.
+///
+/// `body` accumulates across calls: an SSE chunk boundary does not have to line
+/// up with a frame boundary, so a partially-read frame must survive to the next
+/// call.
+async fn next_message(resp: &mut reqwest::Response, body: &mut String) -> serde_json::Value {
+    loop {
+        if let Some(msg) = take_frame(body) {
+            return msg;
+        }
+        let chunk = tokio::time::timeout(Duration::from_secs(5), resp.chunk())
+            .await
+            .expect("timed out waiting for the next subscription message")
+            .expect("stream error")
+            .expect("stream ended before the expected message");
+        body.push_str(&String::from_utf8_lossy(&chunk));
+    }
+}
+
+/// Removes and parses the first complete `data:` frame in `body`, if any.
+fn take_frame(body: &mut String) -> Option<serde_json::Value> {
+    let end = body.find("\n\n")?;
+    let frame: String = body.drain(..end + 2).collect();
+    frame
+        .lines()
+        .find_map(|line| line.strip_prefix("data:"))
+        .and_then(|data| serde_json::from_str(data.trim()).ok())
+}
+
+fn content_type(resp: &reqwest::Response) -> String {
+    resp.headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned()
+}
+
+fn pick_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    port
+}
+
+/// The `_meta` MCP 2026-07-28 requires on every request.
+fn meta() -> serde_json::Value {
+    serde_json::json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {}
+    })
+}
+
+/// Attaches the routing headers MCP 2026-07-28 requires on every request.
+fn routed(req: reqwest::RequestBuilder, body: &serde_json::Value) -> reqwest::RequestBuilder {
+    let req = req.header("MCP-Protocol-Version", "2026-07-28");
+    let Some(method) = body["method"].as_str() else {
+        return req;
+    };
+    let req = req.header("Mcp-Method", method);
+    match method {
+        "tools/call" => match body.pointer("/params/name").and_then(|v| v.as_str()) {
+            Some(name) => req.header("Mcp-Name", name),
+            None => req,
+        },
+        _ => req,
+    }
+}

--- a/neva/tests/subscriptions.rs
+++ b/neva/tests/subscriptions.rs
@@ -405,6 +405,84 @@ async fn dropping_the_handle_ends_the_subscription() {
     handle.abort();
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn disconnecting_ends_the_subscription_abruptly() {
+    // Disconnecting takes the transport out from under a live subscription:
+    // client-side its final result can never arrive, so `closed()` has to say
+    // `Abrupt` rather than await one that is not coming; server-side the listen
+    // POST has to close, or the subscription outlives the client that opened it.
+    use neva::Client;
+    use neva::client::SubscriptionEnd;
+
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app = App::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_tools(|t| t.with_list_changed())
+            .with_resources(|r| r.with_list_changed().with_subscribe())
+    });
+    app.map_tool("watched", |ctx: neva::Context| async move {
+        Ok::<_, neva::error::Error>(ctx.is_subscribed(&"res://config".into()).to_string())
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    await_reachable(&addr).await;
+
+    let mut observer = Client::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_timeout(Duration::from_secs(5))
+    });
+    observer.connect().await.expect("observer connect");
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_timeout(Duration::from_secs(5))
+    });
+    client.connect().await.expect("connect");
+
+    let subscription = client
+        .listen(neva::types::SubscriptionFilter::new().with_resource("res://config"))
+        .await
+        .expect("listen");
+    assert_eq!(
+        watched(&mut observer).await,
+        Some("true".into()),
+        "the server must see the subscription while it is live"
+    );
+
+    client.disconnect().await.expect("disconnect");
+
+    let ended = tokio::time::timeout(Duration::from_secs(5), subscription.closed())
+        .await
+        .expect("closed() must not hang once the transport is gone");
+    assert!(matches!(ended, SubscriptionEnd::Abrupt), "got {ended:?}");
+
+    // The listen POST closing is what tells the server the subscription is
+    // over. Without it the entry stays registered and the server goes on
+    // broadcasting into a client that disconnected.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if watched(&mut observer).await.as_deref() == Some("false") {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "the subscription outlived the client that opened it"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    handle.abort();
+}
+
+/// Asks the server whether anything is currently listening for `res://config`.
+async fn watched(client: &mut neva::Client) -> Option<String> {
+    let resp = client.call_tool("watched", ()).await.expect("watched call");
+    resp.content
+        .first()
+        .and_then(|c| c.as_text())
+        .map(|t| t.text.to_string())
+}
+
 async fn await_reachable(addr: &str) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {

--- a/neva/tests/subscriptions.rs
+++ b/neva/tests/subscriptions.rs
@@ -337,6 +337,74 @@ async fn client_cancel_ends_the_stream_over_http() {
     handle.abort();
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn dropping_the_handle_ends_the_subscription() {
+    // A `Subscription` that falls out of scope without `cancel()` must not leave
+    // the peer streaming: there is no handle left to stop it, but its
+    // notifications would still reach the client's registered handlers.
+    use neva::Client;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let addr = format!("127.0.0.1:{}", pick_free_port());
+    let mut app = App::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_tools(|t| t.with_list_changed())
+    });
+    app.map_tool("grow", |mut ctx: neva::Context| async move {
+        ctx.add_tool(Tool::new(
+            format!("grown-{}", uuid::Uuid::new_v4()),
+            || async { "ok" },
+        ))
+        .await?;
+        Ok::<_, neva::error::Error>("grown".to_string())
+    });
+
+    let handle = tokio::spawn(async move { app.run().await });
+    await_reachable(&addr).await;
+
+    let seen = Arc::new(AtomicUsize::new(0));
+    let counter = seen.clone();
+
+    let mut client = Client::new().with_options(|opt| {
+        opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp"))
+            .with_timeout(Duration::from_secs(5))
+    });
+    client.connect().await.expect("connect");
+    client.on_tools_changed(move |_| {
+        let counter = counter.clone();
+        async move {
+            counter.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+
+    {
+        let _subscription = client
+            .listen(neva::types::SubscriptionFilter::new().with_tools_changed())
+            .await
+            .expect("listen");
+
+        client.call_tool("grow", ()).await.expect("first mutation");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while seen.load(Ordering::SeqCst) == 0 && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert_eq!(seen.load(Ordering::SeqCst), 1, "the stream must be live");
+    } // <- handle dropped here, with no cancel() and no closed()
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    client.call_tool("grow", ()).await.expect("second mutation");
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    assert_eq!(
+        seen.load(Ordering::SeqCst),
+        1,
+        "a dropped subscription must stop delivering"
+    );
+
+    handle.abort();
+}
+
 async fn await_reachable(addr: &str) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {


### PR DESCRIPTION
## Summary

The final 2026-07-28 spec replaced the HTTP `GET` stream **and** the `resources/subscribe` / `resources/unsubscribe` RPC pair with a single long-lived request carrying a notification filter. This implements it on both sides and retracts the note neva has carried since 0.4.x that "server-initiated notifications are inert; clients poll instead" — that limitation described the
RC, not the final spec.

Spec: [`basic/patterns/subscriptions`](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/subscriptions).
Reference implementation surveyed: `modelcontextprotocol/rust-sdk` (rmcp).

### Wire surface

```
--> subscriptions/listen  { "notifications": SubscriptionFilter }
<-- notifications/subscriptions/acknowledged  { "notifications": <accepted>, "_meta": { subscriptionId } }
<-- notifications/tools/list_changed          { "_meta": { subscriptionId } }
...
<-- { "id": ..., "result": { "resultType": "complete", "_meta": { subscriptionId } } }
```

### Server

`subscriptions/listen` is handled by neva itself — there is no handler to write. The accepted filter is the requested one narrowed to the advertised capabilities, acknowledged first on the stream, and every message carries `_meta["io.modelcontextprotocol/subscriptionId"]`.

`Context::{add_tool, remove_tool, add_prompt, remove_prompt, add_resource, remove_resource, resource_updated}` fan out to the streams that asked for them — every existing call site is unchanged, because `send_notification` now routes to
the registry and reports whether the method is subscribable at all (progress, task status and elicitation keep their request-scoped behavior). `Context::is_subscribed` answers from the live streams.

The registry lives on the shared `McpOptions`, so any *other* in-flight request's `Context` reaches it. A subscription ends on `notifications/cancelled`, on transport close, or on server shutdown — the last two after a graceful empty result.

**Sink**: HTTP reuses the per-`POST` notification sink already built for request-scoped logging, so notifications land directly on the listen `POST`'s response body and `Sender::closed()` doubles as the disconnect signal — no new
transport plumbing, `core/dispatch.rs` untouched. stdio gets a channel of its own, pumped into the transport sender.

**Cancellation**: each subscription owns a token *separate* from its request's. Sharing the request token would have raced the dispatcher's own `select! { handler, token.cancelled() }` — both branches become ready at once, and the client would get `RequestCancelled` instead of its graceful-close result roughly half the time.

### Client

`Client::listen(SubscriptionFilter)` returns a `Subscription` once the server acknowledges, exposing `id()`, `requested()`, `acknowledged()`, `is_fully_honored()`, `cancel()` and `closed() -> SubscriptionEnd`.

Two details make the long-lived request work: `RequestQueue::push` without `activate` registers the response slot but never starts the request TTL, and the acknowledgment (a *notification*) completes a waiter registered before the send,
then forwards to the user's handlers like any other notification.

Notifications keep flowing to the handlers registered with `Client::subscribe` / `on_tools_changed` / `on_resource_changed`, **so existing client code needs no change** — and why neva does not need rmcp's per-subscription `next()` stream. The HTTP client transport needed nothing: it already drains a `POST` SSE reply
into the receive loop.

### Breaking changes

* **`listChanged` and `resources.subscribe` are advertised again.** Both were masked off in the default build because nothing could deliver them; a listen stream now can. Servers that configure `with_list_changed()` / `with_subscribe()` start seeing those capabilities on the wire.
* **`resources/subscribe` / `resources/unsubscribe` are legacy-only.** The spec does not delete them, it folds them into
  `SubscriptionFilter::resource_subscriptions` — a subscription is now a URI on a stream rather than server-side state.
  * `Context::subscribe_to_resource` / `unsubscribe_from_resource` and `resource::commands::{SUBSCRIBE, UNSUBSCRIBE}` move behind `legacy-spec`; `UnsubscribeRequestParams` behind `any(legacy-spec, client)`.
    `SubscribeRequestParams` stays in both — it is the `{uri}` payload of `notifications/resources/updated`.
  * `Client::subscribe_to_resource` / `unsubscribe_from_resource` stay compiled (the dual-mode fallback still reaches legacy peers) but reject a 2026-07-28 peer with `MethodNotFound`.
  * Migration: `client.subscribe_to_resource(uri)` → `client.listen(SubscriptionFilter::new().with_resource(uri))`, and drop
    `ctx.subscribe_to_resource(..)` from server handlers — the client owns the subscription now.

### Other changes

* **The streaming `POST` reply no longer requires `tracing`.** A subscription stream is not a logging concern, so `dispatch_post` produces the `StreamResponse::Stream` arm in any default-build configuration. The per-`POST`
  notification sink moved out of the `tracing`-gated `notification::fmt` into a new internal `notification::sink`.
* `ServerCapabilities` derives `Default`.
* `Subscription` / `SubscriptionEnd` re-exported from `neva::prelude` alongside `Client`; the filter types arrive there with the rest of `neva::types`.

### Tests

Unit tests inline, per repo convention: filter serde and algebra (`types/subscription.rs`), routing / tagging / fan-out / cancellation / guard teardown (`app/subscriptions.rs`), sink registration and the closed-receiver signal (`types/notification/sink.rs`), acknowledgment parsing and end states (`client/subscription.rs`).

`neva/tests/subscriptions.rs` covers the wire end to end over HTTP:

* the acknowledgment arrives first with the accepted subset;
* a type the client never requested is never delivered;
* tool-list changes and resource updates arrive tagged with the subscription id;
* `notifications/cancelled` closes the stream with the graceful result;
* an unadvertised category is dropped from the acknowledgment;
* neva's own `Client::listen` drives the same round trip into its registered handlers.

`examples/subscriptions/` is the runnable version, verified by hand against a live server.

### Deliberately not done

* **No server-side filter hook.** rmcp lets a handler override `accepted_subscription_filter` and run its own `listen` loop; neva derives the accepted filter from advertised capabilities and needs no user code. Can be added later if a use case appears.
* **No SSE keep-alive emission.** neva's client already tolerates a peer's keep-alives (skips non-`message` frames, still advances `Last-Event-ID`), but the server has never emitted them on any stream — the listen stream inherits exactly what the legacy `GET` stream had. Adding emission belongs to a transport change.
* **Task-status is not a filter category.** The spec routes `notifications/tasks` through a subscription too; that category is not in `SubscriptionFilter` yet.

## Type
- [ ] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [x] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [x] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)
