### PR TITLE
Multiple tool and prompt handler arguments bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   successfully, and this reports them before serving instead of on a peer's
   first request. A schema that composes -- `$ref`, `allOf`, `oneOf`, a
   conditional branch -- may publish an argument the check cannot follow, so it
-  is left alone rather than failed on a guess.
+  is left alone rather than failed on a guess. `Context::add_tool` and
+  `Context::add_prompt` run the same check and refuse the insertion, since a
+  primitive registered while the server runs has no startup left to fail.
 * `ArgNames` and `FromHandlerArgs` in `neva::types`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   * An argument a peer omitted is offered to the handler as `null`, so an
     absent optional argument no longer errors on arrival.
   * `Meta<_>`, `Context` and `Dc<_>` parameters consume no argument slot, so
-    they can sit anywhere in the signature without shifting the rest.
+    they can sit anywhere in the signature without shifting the rest. The
+    `#[tool]` / `#[prompt]` macros classify them from the *resolved* type, so a
+    parameter reaching the signature through a type alias
+    (`type Token = Meta<ProgressToken>`) is recognised too.
+  * Whether an argument may be omitted is decided by its type, never by whether
+    a synthetic `null` happens to deserialize into it -- otherwise a required
+    `serde_json::Value` argument would silently arrive as `Null`.
 * **Tools registered from a closure publish one property per argument.** The
   generated `inputSchema` keyed its properties by *type name*, so
   `|a: i32, b: i32|` advertised a single `number` property and the second
@@ -40,9 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   registers the tool with `name` and `age` and skips metadata parameters.
 * `App::run` fails at startup when a tool's published `inputSchema` and its
   handler disagree about the arguments -- an overridden schema without
-  `with_arg_names`, or a miscounted declaration. Such a tool could never be
-  called successfully, and this reports it before serving instead of on a
-  peer's first call.
+  `with_arg_names`, a miscounted declaration, or declared names the schema does
+  not offer as properties. Such a tool could never be called successfully, and
+  this reports it before serving instead of on a peer's first call. A schema
+  that has no top-level `properties` (assembled from `$ref` or a composition
+  keyword) is left alone rather than failed on a guess.
 * `ArgNames` and `FromHandlerArgs` in `neva::types`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     they can sit anywhere in the signature without shifting the rest. The
     `#[tool]` / `#[prompt]` macros classify them from the *resolved* type, so a
     parameter reaching the signature through a type alias
-    (`type Token = Meta<ProgressToken>`) is recognised too.
+    (`type Token = Meta<ProgressToken>`) is recognised too. The same goes for
+    an argument's published JSON type and whether it is required: a
+    `type MaybeAge = Option<i32>` parameter now publishes exactly what the
+    spelled-out type does.
   * Whether an argument may be omitted is decided by its type, never by whether
     a synthetic `null` happens to deserialize into it -- otherwise a required
     `serde_json::Value` argument would silently arrive as `Null`.
@@ -44,13 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * `map_tool!` / `map_prompt!` read the names off the closure itself:
   `map_tool!(app, "greet", |name: String, age: i32| async move { ... })`
   registers the tool with `name` and `age` and skips metadata parameters.
-* `App::run` fails at startup when a tool's published `inputSchema` and its
-  handler disagree about the arguments -- an overridden schema without
-  `with_arg_names`, a miscounted declaration, or declared names the schema does
-  not offer as properties. Such a tool could never be called successfully, and
-  this reports it before serving instead of on a peer's first call. A schema
-  that has no top-level `properties` (assembled from `$ref` or a composition
-  keyword) is left alone rather than failed on a guess.
+* `App::run` fails at startup when a tool or prompt and its handler disagree
+  about the arguments -- a tool whose schema was overridden without
+  `with_arg_names`, a miscounted `with_arg_names`, declared names the schema
+  does not offer as properties, or a `Prompt::with_args` list that does not
+  cover every argument the handler takes. None of these could ever be called
+  successfully, and this reports them before serving instead of on a peer's
+  first request. A schema that composes -- `$ref`, `allOf`, `oneOf`, a
+  conditional branch -- may publish an argument the check cannot follow, so it
+  is left alone rather than failed on a guess.
 * `ArgNames` and `FromHandlerArgs` in `neva::types`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## Unreleased
+## 0.5.2
 
 ### Fixed
 * **Tool and prompt arguments are extracted by name, not by position.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 * `App::run` fails at startup when a tool or prompt and its handler disagree
   about the arguments -- a tool whose schema was overridden without
   `with_arg_names`, a miscounted `with_arg_names`, declared names the schema
-  does not offer as properties, or a `Prompt::with_args` list that does not
-  cover every argument the handler takes. None of these could ever be called
+  does not offer as properties, a `Prompt::with_args` list that does not cover
+  every argument the handler takes, or the same name given to two arguments.
+  None of these could ever be called
   successfully, and this reports them before serving instead of on a peer's
   first request. A schema that composes -- `$ref`, `allOf`, `oneOf`, a
   conditional branch -- may publish an argument the check cannot follow, so it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+* **Tool and prompt arguments are extracted by name, not by position.**
+  * A failure now names the argument: ``missing required argument `age` `` and
+    ``invalid value for argument `age`: ... `` instead of
+    `Invalid param provided`.
+  * An argument a peer omitted is offered to the handler as `null`, so an
+    absent optional argument no longer errors on arrival.
+  * `Meta<_>`, `Context` and `Dc<_>` parameters consume no argument slot, so
+    they can sit anywhere in the signature without shifting the rest.
+* **Tools registered from a closure publish one property per argument.** The
+  generated `inputSchema` keyed its properties by *type name*, so
+  `|a: i32, b: i32|` advertised a single `number` property and the second
+  argument had nowhere to travel in. Properties are now named per argument and
+  listed in `required`. Prompt arguments likewise no longer publish
+  `std::any::type_name` output.
+
+### Added
+* **`Option<T>` tool and prompt arguments.**
+  * New `ToolArg` (the return type of `ToolHandler::args`) carries the
+    published property together with whether a call must supply it.
+  * New `PromptArgument::named(name, required)`.
+  * A tool whose arguments are all optional now publishes no `required` key
+    rather than an empty array.
+* `Tool::with_arg_names([...])` declares the names of a handler's arguments.
+  Rust does not keep a closure's parameter names, so a tool registered from a
+  bare closure publishes and reads the positional `arg0`, `arg1`, ... names
+  until this is called; it renames the generated schema and the extraction
+  names together, so the two cannot drift.
+* `map_tool!` / `map_prompt!` read the names off the closure itself:
+  `map_tool!(app, "greet", |name: String, age: i32| async move { ... })`
+  registers the tool with `name` and `age` and skips metadata parameters.
+* `App::run` fails at startup when a tool's published `inputSchema` and its
+  handler disagree about the arguments -- an overridden schema without
+  `with_arg_names`, or a miscounted declaration. Such a tool could never be
+  called successfully, and this reports it before serving instead of on a
+  peer's first call.
+* `ArgNames` and `FromHandlerArgs` in `neva::types`.
+
+### Changed
+* **Breaking:** `App::map_tool` / `Tool::new` take
+  `Args: FromHandlerArgs<CallToolRequestParams>` and `App::map_prompt` /
+  `Prompt::new` take `Args: FromHandlerArgs<GetPromptRequestParams>`, replacing
+  the `TryFrom<...Params>` bounds. Handlers themselves are unaffected; a
+  hand-written `impl TryFrom<CallToolRequestParams> for MyArgs` needs porting.
+* **Breaking:** `HandlerParams::Tool` and `HandlerParams::Prompt` carry the
+  primitive's `ArgNames` alongside the params.
+* **Breaking:** `ToolHandler::args` returns `Vec<ToolArg>` instead of
+  `Option<HashMap<String, SchemaProperty>>` -- ordered, so the *n*-th entry is
+  the *n*-th argument slot, and carrying each argument's `required` flag.
+* **Breaking (wire):** a tool registered from a bare closure advertises
+  `arg0`, `arg1`, ... instead of the former type names (`number`, `string`).
+  Tools declared with `#[tool]` are unaffected -- they already published their
+  parameter names, and now read by them.
+* `Prompt::with_args` sets the extraction names along with the published
+  argument list, so the two are one decision. `#[prompt]` needs no change.
+
 ## 0.5.1
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "base64",
+ "base64 0.22.1",
  "bitflags",
  "brotli",
  "bytes",
@@ -367,7 +367,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -398,7 +398,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -414,6 +414,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-set"
@@ -839,7 +845,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "neva",
  "serde_json",
  "tokio",
@@ -852,7 +858,7 @@ name = "example-axum"
 version = "0.1.0"
 dependencies = [
  "axum",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "neva",
  "tokio",
@@ -886,7 +892,7 @@ name = "example-hyper"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -934,7 +940,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -1021,9 +1027,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+checksum = "476de73bddf2ef8490aa4ee8f1cf40b430bf1d56c48c22080e5186952cd580e6"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1232,7 +1238,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1285,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1300,7 +1306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -1311,7 +1317,7 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -1348,7 +1354,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.15",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -1365,7 +1371,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1381,11 +1387,11 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -1653,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.48.5"
+version = "0.49.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
+checksum = "ca4b985be36e5b3d15162b16ca94ac18c2a0514f5598b23b9d769895cb56bc3c"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1684,18 +1690,18 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-regex"
-version = "0.48.5"
+version = "0.49.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
+checksum = "614c05e01260d4532d9ad28d66185fa1d93d015c5d610cde70d4b7143d7fb98f"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "jsonschema-value"
-version = "0.48.5"
+version = "0.49.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+checksum = "8602a6850f24cf05c518f58c9b8d08e32a28b9848115c8e193693db0952353f6"
 dependencies = [
  "ahash",
  "bytecount",
@@ -1712,7 +1718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -1863,15 +1869,15 @@ dependencies = [
 
 [[package]]
 name = "neva"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "bytes",
  "chacha20poly1305",
  "chrono",
  "dashmap",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "inventory",
  "jsonschema",
  "memchr",
@@ -1899,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "neva_macros"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2079,7 +2085,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -2331,9 +2337,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.48.5"
+version = "0.49.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
+checksum = "0753550862a089302b186486dfb843f2d547415257d78c32ae0d169e4d6784d1"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -2360,9 +2366,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2387,14 +2393,14 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.15",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -2570,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2583,14 +2589,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2660,13 +2666,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3108,7 +3114,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
  "tower",
@@ -3365,7 +3371,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecfee2c5c6172647ee547c85306bb1b6447368f31e40df8a5ab0b1a834c32ea0"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -3386,10 +3392,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44491f1b30a7a26e1817aa91bb093a7aa6366a3d7dc44270a450df3a41f96e4d"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-rustls",
@@ -3406,7 +3412,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6b60b2d632db6d120ea10b7764255ae674e1424ac9f8d7211a40322dc1c121"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT"
 edition = "2024"
 rust-version = "1.90.0"
@@ -30,7 +30,7 @@ categories = [
 ]
 
 [workspace.dependencies]
-neva_macros = { path = "neva_macros", version = "0.5.1" }
+neva_macros = { path = "neva_macros", version = "0.5.2" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Blazingly fast and easily configurable [Model Context Protocol (MCP)](https://mo
 With simple configuration and ergonomic APIs, it provides everything you need to quickly build MCP clients and servers, 
 fully aligned with the latest MCP specification.
 
-[![latest](https://img.shields.io/badge/latest-0.5.1-d8eb34)](https://crates.io/crates/neva)
+[![latest](https://img.shields.io/badge/latest-0.5.2-d8eb34)](https://crates.io/crates/neva)
 [![latest](https://img.shields.io/badge/rustc-1.90+-964B00)](https://releases.rs/docs/1.90.0/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-624bd1.svg)](https://github.com/RomanEmreis/neva/blob/main/LICENSE)
 [![CI](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml/badge.svg)](https://github.com/RomanEmreis/neva/actions/workflows/rust.yml)
@@ -30,7 +30,7 @@ fully aligned with the latest MCP specification.
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.5.1", features = ["client-full"] }
+neva = { version = "0.5.2", features = ["client-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -68,7 +68,7 @@ async fn main() -> Result<(), Error> {
 #### Dependencies
 ```toml
 [dependencies]
-neva = { version = "0.5.1", features = ["server-full"] }
+neva = { version = "0.5.2", features = ["server-full"] }
 tokio = { version = "1", features = ["full"] }
 ```
 #### Code

--- a/neva/Cargo.toml
+++ b/neva/Cargo.toml
@@ -17,17 +17,17 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-base64 = "0.22.1"
+base64 = "0.23.1"
 bytes = "1.12.1"
 sha2 = { version = "0.11.0", optional = true }
 chrono = { version = "0.4.45", features = ["serde"] }
 dashmap = "6.2.1"
 futures-util = { version = "0.3.33", default-features = false, features = ["alloc"] }
-http = "1.4.2"
+http = "1.5.0"
 memchr = "2.8.3"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
-schemars = { version = "1.2.1" }
+schemars = { version = "1.2.2" }
 tokio = { version = "1.53.1", features = ["sync", "io-std", "io-util", "rt", "time", "macros"] }
 tokio-util = "0.7.19"
 uuid = { version = "1.24.0", features = ["v4", "serde"] }
@@ -35,7 +35,7 @@ uuid = { version = "1.24.0", features = ["v4", "serde"] }
 # optional
 chacha20poly1305 = { version = "0.11.0", optional = true }
 inventory = { version = "0.3.24", optional = true }
-jsonschema = { version = "0.48.5", optional = true }
+jsonschema = { version = "0.49.7", optional = true }
 once_cell = { version = "1.21.4", features = ["std"], optional = true }
 reqwest = { version = "0.13.4", features = ["stream", "json"], optional = true }
 sse-stream = { version = "0.2.5", optional = true }

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -2080,6 +2080,34 @@ mod tests {
         assert_eq!(names.get(1), "age");
     }
 
+    #[tokio::test]
+    async fn map_prompt_macro_keeps_names_and_optionality() {
+        use crate::types::Role;
+
+        let mut app = App::new();
+        crate::map_prompt!(
+            app,
+            "analyze",
+            |ctx: crate::Context, lang: String, tone: Option<String>| async move {
+                let _ = ctx;
+                (format!("{lang} {tone:?}"), Role::User)
+            }
+        );
+
+        let prompt = app.options.prompts.as_ref().get("analyze").expect("prompt");
+        let args = prompt.args.as_ref().unwrap();
+
+        // `ctx` is served from the request, so it is neither published nor
+        // named; `tone` is published as an argument peers may leave out.
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0].name, "lang");
+        assert_eq!(args[0].required, Some(true));
+        assert_eq!(args[1].name, "tone");
+        assert_eq!(args[1].required, Some(false));
+        assert_eq!(prompt.arg_names.get(0), "lang");
+        assert_eq!(prompt.arg_names.get(1), "tone");
+    }
+
     #[test]
     fn a_bare_closure_publishes_the_names_it_reads() {
         let mut app = App::new();
@@ -2126,6 +2154,50 @@ mod tests {
             format!("{name} is {age}")
         })
         .with_arg_names(["name"]);
+
+        app.validate_tool_arg_names();
+    }
+
+    #[test]
+    #[should_panic(expected = "declares the argument `q` but publishes an inputSchema without it")]
+    fn startup_rejects_names_the_schema_does_not_offer() {
+        let mut app = App::new();
+        app.map_tool("search", |q: String| async move { q })
+            .with_input_schema(|_| {
+                const JSON: &str = r#"{"type":"object","properties":{"query":{"type":"string"}}}"#;
+                #[cfg(feature = "legacy-spec")]
+                {
+                    crate::types::tool::ToolSchema::from_json_str(JSON)
+                }
+                #[cfg(not(feature = "legacy-spec"))]
+                {
+                    crate::types::schema_2020::InputSchema::from_json_str(JSON).unwrap_or_default()
+                }
+            })
+            .with_arg_names(["q"]);
+
+        app.validate_tool_arg_names();
+    }
+
+    /// A schema that describes its arguments through `$ref` or a composition
+    /// keyword has no top-level `properties` to check against, and is left
+    /// alone rather than failed on a guess.
+    #[test]
+    fn startup_accepts_a_schema_without_top_level_properties() {
+        let mut app = App::new();
+        app.map_tool("search", |q: String| async move { q })
+            .with_input_schema(|_| {
+                const JSON: &str = r##"{"$ref": "#/$defs/Args"}"##;
+                #[cfg(feature = "legacy-spec")]
+                {
+                    crate::types::tool::ToolSchema::from_json_str(JSON)
+                }
+                #[cfg(not(feature = "legacy-spec"))]
+                {
+                    crate::types::schema_2020::InputSchema::from_json_str(JSON).unwrap_or_default()
+                }
+            })
+            .with_arg_names(["q"]);
 
         app.validate_tool_arg_names();
     }

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -2222,10 +2222,13 @@ mod tests {
         app.validate_arg_names();
     }
 
-    /// `additionalProperties` left open admits names the map never listed.
+    /// Permitting further names is not the same as naming one. A schema left
+    /// open by `additionalProperties` still tells no peer to send `q`, so the
+    /// tool is as uncallable as with a closed schema and is still reported.
     #[test]
+    #[should_panic(expected = "declares the argument `q` but publishes an inputSchema without it")]
     #[cfg(not(feature = "legacy-spec"))]
-    fn startup_accepts_a_schema_left_open_to_further_properties() {
+    fn startup_checks_a_schema_left_open_to_further_properties() {
         let mut app = App::new();
         app.map_tool("search", |q: String| async move { q })
             .with_input_schema(|_| {
@@ -2239,8 +2242,33 @@ mod tests {
         app.validate_arg_names();
     }
 
-    /// `additionalProperties: false` is the spelling that *closes* the schema,
-    /// so the map really is exhaustive and the check still applies.
+    /// `propertyNames` constrains what names may appear; it declares none. It
+    /// is no reason to stop checking, least of all next to an
+    /// `additionalProperties: false` that closes the schema outright.
+    #[test]
+    #[should_panic(expected = "declares the argument `q` but publishes an inputSchema without it")]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn startup_checks_a_schema_constraining_property_names() {
+        let mut app = App::new();
+        app.map_tool("search", |q: String| async move { q })
+            .with_input_schema(|_| {
+                crate::types::schema_2020::InputSchema::from_json_str(
+                    r#"{
+                        "type": "object",
+                        "properties": { "query": { "type": "string" } },
+                        "propertyNames": { "pattern": "^[a-z]+$" },
+                        "additionalProperties": false
+                    }"#,
+                )
+                .unwrap_or_default()
+            })
+            .with_arg_names(["q"]);
+
+        app.validate_arg_names();
+    }
+
+    /// `additionalProperties: false` closes the schema; the map is exhaustive
+    /// and the check applies as plainly as it does without the keyword.
     #[test]
     #[should_panic(expected = "declares the argument `q` but publishes an inputSchema without it")]
     #[cfg(not(feature = "legacy-spec"))]

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -2176,6 +2176,29 @@ mod tests {
         app.validate_arg_names();
     }
 
+    /// Zero is a count like any other: a name handed to a handler that reads
+    /// none is the same miscount as too few names for one that reads several.
+    #[test]
+    #[should_panic(expected = "declares 1 argument name(s) but its handler takes 0")]
+    fn startup_rejects_a_declaration_on_a_zero_arity_handler() {
+        let mut app = App::new();
+        app.map_tool("ping", || async { "pong" })
+            .with_arg_names(["value"]);
+
+        app.validate_arg_names();
+    }
+
+    /// The counterpart: naming nothing for a handler that reads nothing is a
+    /// declaration that agrees with its handler, and is left alone.
+    #[test]
+    fn startup_accepts_an_empty_declaration_on_a_zero_arity_handler() {
+        let mut app = App::new();
+        app.map_tool("ping", || async { "pong" })
+            .with_arg_names(Vec::<String>::new());
+
+        app.validate_arg_names();
+    }
+
     #[test]
     #[should_panic(expected = "declares the argument `q` but publishes an inputSchema without it")]
     fn startup_rejects_names_the_schema_does_not_offer() {

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -13,12 +13,12 @@ use crate::middleware::{MwContext, Next, make_fn::make_mw};
 use crate::shared;
 use crate::transport::{Receiver, Sender, Transport};
 use crate::types::{
-    CallToolRequestParams, CallToolResponse, CompleteResult, GetPromptRequestParams,
-    GetPromptResult, IntoResponse, ListPromptsRequestParams, ListPromptsResult,
-    ListResourceTemplatesRequestParams, ListResourceTemplatesResult, ListResourcesRequestParams,
-    ListResourcesResult, ListToolsRequestParams, ListToolsResult, Message, MessageBatch,
-    MessageEnvelope, Prompt, PromptHandler, ReadResourceRequestParams, ReadResourceResult, Request,
-    Resource, ResourceTemplate, Response, Tool, ToolHandler, Uri,
+    CallToolRequestParams, CallToolResponse, CompleteResult, FromHandlerArgs,
+    GetPromptRequestParams, GetPromptResult, IntoResponse, ListPromptsRequestParams,
+    ListPromptsResult, ListResourceTemplatesRequestParams, ListResourceTemplatesResult,
+    ListResourcesRequestParams, ListResourcesResult, ListToolsRequestParams, ListToolsResult,
+    Message, MessageBatch, MessageEnvelope, Prompt, PromptHandler, ReadResourceRequestParams,
+    ReadResourceResult, Request, Resource, ResourceTemplate, Response, Tool, ToolHandler, Uri,
     notification::{CancelledNotificationParams, Notification},
     resource::template::ResourceFunc,
 };
@@ -248,6 +248,10 @@ impl App {
     pub async fn run(mut self) {
         #[cfg(feature = "macros")]
         self.register_methods();
+
+        // Must follow register_methods() for the same reason the greeting does:
+        // macro-registered tools are not in the collection before it.
+        self.validate_tool_arg_names();
 
         // ORDERING CONSTRAINT: must execute after register_methods() so macro-registered
         // tools/prompts are present; must execute before self.options.transport() consumes
@@ -580,8 +584,39 @@ impl App {
         self
     }
 
+    /// Fails startup when a registered tool's published schema and its handler
+    /// disagree about the arguments.
+    ///
+    /// Such a tool cannot be called successfully by anyone, so it is a
+    /// registration mistake worth reporting before the server starts serving
+    /// rather than on a peer's first call. See [`Tool::arg_name_conflict`].
+    fn validate_tool_arg_names(&self) {
+        if let Some(conflict) = self
+            .options
+            .tools
+            .as_ref()
+            .values()
+            .find_map(Tool::arg_name_conflict)
+        {
+            panic!("{conflict}");
+        }
+    }
+
     /// Maps an MCP tool call request to a specific function and returns a mutable reference to the
     /// [`Tool`] for further configuration
+    ///
+    /// # Argument names
+    ///
+    /// A call's `arguments` are read **by name**. Rust does not keep a
+    /// closure's parameter names, so a tool registered this way publishes and
+    /// reads the positional `arg0`, `arg1`, ... names. To give them the names
+    /// you wrote, use [`Tool::with_arg_names`], the [`crate::map_tool`] macro,
+    /// or the `#[tool]` attribute -- each declares the names and renames the
+    /// published schema together, so the two cannot disagree.
+    ///
+    /// Overriding the schema with [`Tool::with_input_schema`] does *not* by
+    /// itself change what the handler reads; a tool left in that state fails
+    /// [`App::run`] at startup rather than on a peer's first call.
     ///
     /// # Example
     /// ```no_run
@@ -593,7 +628,8 @@ impl App {
     ///
     /// app.map_tool("hello", |name: String| async move {
     ///     format!("Hello, {name}")
-    /// });
+    /// })
+    /// .with_arg_names(["name"]);
     ///
     /// # app.run().await;
     /// # }
@@ -602,7 +638,7 @@ impl App {
     where
         F: ToolHandler<Args, Output = R>,
         R: Into<CallToolResponse> + Send + 'static,
-        Args: TryFrom<CallToolRequestParams, Error = Error> + Send + Sync + 'static,
+        Args: FromHandlerArgs<CallToolRequestParams> + Send + Sync + 'static,
     {
         self.options.add_tool(Tool::new(name, handler))
     }
@@ -654,6 +690,14 @@ impl App {
 
     /// Maps an MCP get a prompt request to a specific function
     ///
+    /// # Argument names
+    ///
+    /// A request's `arguments` are read **by name**, and Rust does not keep a
+    /// closure's parameter names -- a prompt registered this way publishes and
+    /// reads the positional `arg0`, `arg1`, ... names until
+    /// [`Prompt::with_args`] gives them yours. [`crate::map_prompt`] and the
+    /// `#[prompt]` attribute do that for you.
+    ///
     /// # Example
     /// ```no_run
     /// use neva::{App, types::Role};
@@ -664,7 +708,8 @@ impl App {
     ///
     /// app.map_prompt("analyze-code", |lang: String| async move {
     ///     (format!("Language: {lang}"), Role::User)
-    /// });
+    /// })
+    /// .with_args(["lang"]);
     ///
     /// # app.run().await;
     /// # }
@@ -674,7 +719,7 @@ impl App {
         F: PromptHandler<Args, Output = R>,
         R: TryInto<GetPromptResult> + Send + 'static,
         R::Error: Into<Error>,
-        Args: TryFrom<GetPromptRequestParams, Error = Error> + Send + Sync + 'static,
+        Args: FromHandlerArgs<GetPromptRequestParams> + Send + Sync + 'static,
     {
         self.options.add_prompt(Prompt::new(name, handler))
     }
@@ -1958,6 +2003,141 @@ mod tests {
     fn it_enables_greeting_with_with_greeting() {
         let app = App::new().with_greeting();
         assert!(app.greeting);
+    }
+
+    /// The property names of a registered tool's `inputSchema`, sorted.
+    fn schema_props(app: &App, tool: &str) -> Vec<String> {
+        let tool = app.options.tools.as_ref().get(tool).expect("tool");
+        #[cfg(feature = "legacy-spec")]
+        let props = tool.input_schema.properties.as_ref().unwrap();
+        #[cfg(not(feature = "legacy-spec"))]
+        let props = tool.input_schema.as_value()["properties"]
+            .as_object()
+            .unwrap();
+
+        let mut names = props.keys().cloned().collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    #[test]
+    fn map_tool_macro_keeps_the_closures_parameter_names() {
+        let mut app = App::new();
+        crate::map_tool!(app, "greet", |name: String, age: i32| async move {
+            format!("{name} is {age}")
+        });
+
+        assert_eq!(schema_props(&app, "greet"), ["age", "name"]);
+
+        let names = &app.options.tools.as_ref().get("greet").unwrap().arg_names;
+        assert!(names.is_declared());
+        assert_eq!(names.get(0), "name");
+        assert_eq!(names.get(1), "age");
+    }
+
+    #[test]
+    fn map_tool_macro_skips_metadata_parameters() {
+        use crate::types::{Meta, ProgressToken};
+
+        let mut app = App::new();
+        crate::map_tool!(
+            app,
+            "greet",
+            |token: Meta<ProgressToken>, name: String| async move {
+                let _ = token;
+                name
+            }
+        );
+
+        // `token` is served from `_meta`: it is neither published nor named,
+        // so `name` is still the first argument slot.
+        assert_eq!(schema_props(&app, "greet"), ["name"]);
+        assert_eq!(
+            app.options
+                .tools
+                .as_ref()
+                .get("greet")
+                .unwrap()
+                .arg_names
+                .get(0),
+            "name"
+        );
+    }
+
+    #[test]
+    fn map_tool_macro_names_an_optional_argument() {
+        let mut app = App::new();
+        crate::map_tool!(app, "greet", |name: String, age: Option<i32>| async move {
+            format!("{name} {age:?}")
+        });
+
+        // An `Option<T>` parameter is an argument: it is named, published and
+        // occupies a slot -- it just need not be supplied.
+        assert_eq!(schema_props(&app, "greet"), ["age", "name"]);
+
+        let names = &app.options.tools.as_ref().get("greet").unwrap().arg_names;
+        assert_eq!(names.arity(), 2);
+        assert_eq!(names.get(1), "age");
+    }
+
+    #[test]
+    fn a_bare_closure_publishes_the_names_it_reads() {
+        let mut app = App::new();
+        app.map_tool("greet", |name: String, age: i32| async move {
+            format!("{name} is {age}")
+        });
+
+        let tool = app.options.tools.as_ref().get("greet").unwrap();
+
+        assert!(!tool.arg_names.is_declared());
+        assert_eq!(tool.arg_names.arity(), 2);
+        assert_eq!(schema_props(&app, "greet"), ["arg0", "arg1"]);
+    }
+
+    /// A hand-written schema with a single required `name` string property,
+    /// spelled for whichever schema model the build uses.
+    fn name_schema() -> crate::types::ToolInputSchema {
+        const JSON: &str = r#"{"type":"object","properties":{"name":{"type":"string"}}}"#;
+        #[cfg(feature = "legacy-spec")]
+        {
+            crate::types::tool::ToolSchema::from_json_str(JSON)
+        }
+        #[cfg(not(feature = "legacy-spec"))]
+        {
+            crate::types::schema_2020::InputSchema::from_json_str(JSON).unwrap_or_default()
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "publishes an inputSchema without the argument `arg0`")]
+    fn startup_rejects_a_schema_the_handler_cannot_read() {
+        let mut app = App::new();
+        app.map_tool("greet", |name: String| async move { name })
+            .with_input_schema(|_| name_schema());
+
+        app.validate_tool_arg_names();
+    }
+
+    #[test]
+    #[should_panic(expected = "declares 1 argument name(s) but its handler takes 2")]
+    fn startup_rejects_a_miscounted_declaration() {
+        let mut app = App::new();
+        app.map_tool("greet", |name: String, age: i32| async move {
+            format!("{name} is {age}")
+        })
+        .with_arg_names(["name"]);
+
+        app.validate_tool_arg_names();
+    }
+
+    #[test]
+    fn startup_accepts_a_declared_tool() {
+        let mut app = App::new();
+        app.map_tool("greet", |name: String| async move { name })
+            .with_input_schema(|_| name_schema())
+            .with_arg_names(["name"]);
+
+        app.validate_tool_arg_names();
     }
 
     #[cfg(not(feature = "legacy-spec"))]

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -2253,6 +2253,32 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "prompt `analyze` publishes the argument `topic` twice")]
+    fn startup_rejects_a_prompt_with_duplicate_arg_names() {
+        use crate::types::Role;
+
+        let mut app = App::new();
+        app.map_prompt("analyze", |topic: String, tone: String| async move {
+            (format!("{topic}{tone}"), Role::User)
+        })
+        .with_args(["topic", "topic"]);
+
+        app.validate_arg_names();
+    }
+
+    #[test]
+    #[should_panic(expected = "tool `greet` declares the argument name `name` twice")]
+    fn startup_rejects_a_tool_with_duplicate_arg_names() {
+        let mut app = App::new();
+        app.map_tool("greet", |first: String, last: String| async move {
+            format!("{first}{last}")
+        })
+        .with_arg_names(["name", "name"]);
+
+        app.validate_arg_names();
+    }
+
+    #[test]
     fn startup_accepts_a_prompt_that_publishes_every_arg() {
         use crate::types::Role;
 

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -2267,6 +2267,31 @@ mod tests {
         app.validate_arg_names();
     }
 
+    /// `not` composes the other way round: it says what an instance must fail.
+    /// A name under it is one no peer may send, so it cannot be the one that
+    /// makes the top-level map incomplete, and the check still applies.
+    #[test]
+    #[should_panic(expected = "declares the argument `q` but publishes an inputSchema without it")]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn startup_checks_a_schema_whose_only_composition_is_not() {
+        let mut app = App::new();
+        app.map_tool("search", |q: String| async move { q })
+            .with_input_schema(|_| {
+                crate::types::schema_2020::InputSchema::from_json_str(
+                    r#"{
+                        "type": "object",
+                        "properties": { "query": { "type": "string" } },
+                        "not": { "required": ["forbidden"] },
+                        "additionalProperties": false
+                    }"#,
+                )
+                .unwrap_or_default()
+            })
+            .with_arg_names(["q"]);
+
+        app.validate_arg_names();
+    }
+
     /// `additionalProperties: false` closes the schema; the map is exhaustive
     /// and the check applies as plainly as it does without the keyword.
     #[test]

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -313,6 +313,9 @@ impl App {
         self.options
             .add_middleware(make_mw(Self::message_middleware));
 
+        // Read before `self.options` moves into the runtime below.
+        let greeted = self.greeting;
+
         let mut transport = self.options.transport();
         let cancellation_token = transport.start();
         self.wait_for_shutdown_signal(cancellation_token.clone());
@@ -352,6 +355,12 @@ impl App {
                     }
                 }
             }
+        }
+
+        // Closes what the banner opened. Only for a greeted server: one that
+        // asked for no banner asked for a quiet terminal.
+        if greeted {
+            greeter::print_farewell(std::env::var_os("NO_COLOR").is_none());
         }
     }
 
@@ -2182,6 +2191,67 @@ mod tests {
                 {
                     crate::types::schema_2020::InputSchema::from_json_str(JSON).unwrap_or_default()
                 }
+            })
+            .with_arg_names(["q"]);
+
+        app.validate_arg_names();
+    }
+
+    /// A schema may name an argument by pattern rather than list it, and the
+    /// top-level map is then not the whole story either.
+    #[test]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn startup_accepts_a_schema_with_pattern_properties() {
+        let mut app = App::new();
+        app.map_tool("search", |q: String, page: i32| async move {
+            format!("{q}{page}")
+        })
+        .with_input_schema(|_| {
+            crate::types::schema_2020::InputSchema::from_json_str(
+                r#"{
+                    "type": "object",
+                    "properties": { "page": { "type": "number" } },
+                    "patternProperties": { "^q$": { "type": "string" } },
+                    "required": ["page", "q"]
+                }"#,
+            )
+            .unwrap_or_default()
+        })
+        .with_arg_names(["q", "page"]);
+
+        app.validate_arg_names();
+    }
+
+    /// `additionalProperties` left open admits names the map never listed.
+    #[test]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn startup_accepts_a_schema_left_open_to_further_properties() {
+        let mut app = App::new();
+        app.map_tool("search", |q: String| async move { q })
+            .with_input_schema(|_| {
+                crate::types::schema_2020::InputSchema::from_json_str(
+                    r#"{"type":"object","properties":{},"additionalProperties":{"type":"string"}}"#,
+                )
+                .unwrap_or_default()
+            })
+            .with_arg_names(["q"]);
+
+        app.validate_arg_names();
+    }
+
+    /// `additionalProperties: false` is the spelling that *closes* the schema,
+    /// so the map really is exhaustive and the check still applies.
+    #[test]
+    #[should_panic(expected = "declares the argument `q` but publishes an inputSchema without it")]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn startup_still_checks_a_closed_schema() {
+        let mut app = App::new();
+        app.map_tool("search", |q: String| async move { q })
+            .with_input_schema(|_| {
+                crate::types::schema_2020::InputSchema::from_json_str(
+                    r#"{"type":"object","properties":{"query":{"type":"string"}},"additionalProperties":false}"#,
+                )
+                .unwrap_or_default()
             })
             .with_arg_names(["q"]);
 

--- a/neva/src/app.rs
+++ b/neva/src/app.rs
@@ -251,7 +251,7 @@ impl App {
 
         // Must follow register_methods() for the same reason the greeting does:
         // macro-registered tools are not in the collection before it.
-        self.validate_tool_arg_names();
+        self.validate_arg_names();
 
         // ORDERING CONSTRAINT: must execute after register_methods() so macro-registered
         // tools/prompts are present; must execute before self.options.transport() consumes
@@ -584,20 +584,29 @@ impl App {
         self
     }
 
-    /// Fails startup when a registered tool's published schema and its handler
-    /// disagree about the arguments.
+    /// Fails startup when a registered tool or prompt and its handler disagree
+    /// about the arguments.
     ///
-    /// Such a tool cannot be called successfully by anyone, so it is a
+    /// Such a primitive cannot be called successfully by anyone, so it is a
     /// registration mistake worth reporting before the server starts serving
-    /// rather than on a peer's first call. See [`Tool::arg_name_conflict`].
-    fn validate_tool_arg_names(&self) {
-        if let Some(conflict) = self
+    /// rather than on a peer's first call. See [`Tool::arg_name_conflict`] and
+    /// [`Prompt::arg_name_conflict`].
+    fn validate_arg_names(&self) {
+        let conflict = self
             .options
             .tools
             .as_ref()
             .values()
             .find_map(Tool::arg_name_conflict)
-        {
+            .or_else(|| {
+                self.options
+                    .prompts
+                    .as_ref()
+                    .values()
+                    .find_map(Prompt::arg_name_conflict)
+            });
+
+        if let Some(conflict) = conflict {
             panic!("{conflict}");
         }
     }
@@ -2143,7 +2152,7 @@ mod tests {
         app.map_tool("greet", |name: String| async move { name })
             .with_input_schema(|_| name_schema());
 
-        app.validate_tool_arg_names();
+        app.validate_arg_names();
     }
 
     #[test]
@@ -2155,7 +2164,7 @@ mod tests {
         })
         .with_arg_names(["name"]);
 
-        app.validate_tool_arg_names();
+        app.validate_arg_names();
     }
 
     #[test]
@@ -2176,7 +2185,7 @@ mod tests {
             })
             .with_arg_names(["q"]);
 
-        app.validate_tool_arg_names();
+        app.validate_arg_names();
     }
 
     /// A schema that describes its arguments through `$ref` or a composition
@@ -2199,7 +2208,65 @@ mod tests {
             })
             .with_arg_names(["q"]);
 
-        app.validate_tool_arg_names();
+        app.validate_arg_names();
+    }
+
+    /// A schema may describe some arguments in its top-level `properties` and
+    /// the rest through composition. The map alone is then not the whole
+    /// story, and reading it as if it were would fail a well-formed tool.
+    #[test]
+    #[cfg(not(feature = "legacy-spec"))]
+    fn startup_accepts_a_schema_with_composed_properties() {
+        let mut app = App::new();
+        app.map_tool("search", |q: String, page: i32| async move {
+            format!("{q}{page}")
+        })
+        .with_input_schema(|_| {
+            crate::types::schema_2020::InputSchema::from_json_str(
+                r#"{
+                    "type": "object",
+                    "properties": { "q": { "type": "string" } },
+                    "allOf": [
+                        { "properties": { "page": { "type": "number" } } }
+                    ]
+                }"#,
+            )
+            .unwrap_or_default()
+        })
+        .with_arg_names(["q", "page"]);
+
+        app.validate_arg_names();
+    }
+
+    #[test]
+    #[should_panic(expected = "prompt `analyze` publishes 1 argument(s) but its handler takes 2")]
+    fn startup_rejects_a_prompt_that_publishes_too_few_args() {
+        use crate::types::Role;
+
+        let mut app = App::new();
+        app.map_prompt("analyze", |topic: String, tone: String| async move {
+            (format!("{topic}{tone}"), Role::User)
+        })
+        .with_args(["topic"]);
+
+        app.validate_arg_names();
+    }
+
+    #[test]
+    fn startup_accepts_a_prompt_that_publishes_every_arg() {
+        use crate::types::Role;
+
+        let mut app = App::new();
+        app.map_prompt("analyze", |topic: String, tone: String| async move {
+            (format!("{topic}{tone}"), Role::User)
+        })
+        .with_args(["topic", "tone"]);
+
+        let prompt = app.options.prompts.as_ref().get("analyze").unwrap();
+        assert_eq!(prompt.arg_names.arity(), 2);
+        assert_eq!(prompt.arg_names.get(1), "tone");
+
+        app.validate_arg_names();
     }
 
     #[test]
@@ -2209,7 +2276,7 @@ mod tests {
             .with_input_schema(|_| name_schema())
             .with_arg_names(["name"]);
 
-        app.validate_tool_arg_names();
+        app.validate_arg_names();
     }
 
     #[cfg(not(feature = "legacy-spec"))]

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -792,7 +792,7 @@ impl Context {
             Some(prompt) => {
                 #[cfg(feature = "http-server")]
                 self.validate_claims(prompt.roles.as_deref(), prompt.permissions.as_deref())?;
-                prompt.call(params.with_context(self).into()).await
+                prompt.call(params.with_context(self)).await
             }
         }
     }
@@ -807,7 +807,7 @@ impl Context {
             Some(tool) => {
                 #[cfg(feature = "http-server")]
                 self.validate_claims(tool.roles.as_deref(), tool.permissions.as_deref())?;
-                tool.call(params.with_context(self).into()).await
+                tool.call(params.with_context(self)).await
             }
         }
     }
@@ -858,7 +858,7 @@ impl Context {
                         tokio::select! {
                             result = tool.call(params
                                 .with_task(&task_id)
-                                .with_context(ctx).into()) => {
+                                .with_context(ctx)) => {
                                 // The outcome is stored *before* the status
                                 // flips, so a `tasks/get` that observes a
                                 // terminal status always sees the matching
@@ -903,7 +903,7 @@ impl Context {
                         "Tool required task augmented call",
                     ))
                 } else {
-                    tool.call(params.with_context(self).into())
+                    tool.call(params.with_context(self))
                         .await
                         .map(Either::Right)
                 }

--- a/neva/src/app/context.rs
+++ b/neva/src/app/context.rs
@@ -706,6 +706,14 @@ impl Context {
 
     /// Adds a new prompt and notifies clients
     pub async fn add_prompt(&mut self, prompt: Prompt) -> Result<(), Error> {
+        // A prompt registered up front gets this same check at startup. One
+        // added while the server runs has no startup left to fail, so it is
+        // refused here rather than published in a shape no peer could
+        // successfully use.
+        if let Some(conflict) = prompt.arg_name_conflict() {
+            return Err(Error::new(ErrorCode::InternalError, conflict));
+        }
+
         self.options
             .prompts
             .insert(prompt.name.clone(), prompt)
@@ -736,6 +744,12 @@ impl Context {
 
     /// Adds a new prompt and notifies clients
     pub async fn add_tool(&mut self, tool: Tool) -> Result<(), Error> {
+        // See `add_prompt`: a tool added after startup has no startup check
+        // left to fail, so a schema its handler cannot read is refused here.
+        if let Some(conflict) = tool.arg_name_conflict() {
+            return Err(Error::new(ErrorCode::InternalError, conflict));
+        }
+
         self.options.tools.insert(tool.name.clone(), tool).await?;
 
         if self.options.is_tools_list_changed_supported() {
@@ -2222,5 +2236,82 @@ mod subscription_sink_tests {
             .expect("stdio always has somewhere to write");
 
         assert!(pump.is_some(), "stdio needs a pump task");
+    }
+}
+
+/// A tool or prompt registered up front is checked for argument conflicts at
+/// startup. One added while the server is running has no startup left to fail,
+/// so the same check has to run at insertion -- otherwise it is published in a
+/// shape no peer could successfully call.
+#[cfg(all(test, feature = "http-server"))]
+mod runtime_registration_tests {
+    use super::*;
+    use crate::types::{Prompt, Role, Tool};
+
+    fn ctx() -> Context {
+        Context {
+            session_id: None,
+            headers: HeaderMap::new(),
+            claims: None,
+            pending: RequestQueue::new(Duration::from_secs(5)),
+            sender: TransportProtoSender::None,
+            // Runtime state: the collections must accept insertions, which is
+            // the whole point of the paths under test.
+            options: McpOptions::default().into_runtime(),
+            timeout: Duration::from_secs(5),
+            #[cfg(not(feature = "legacy-spec"))]
+            exec: ExecMode::None,
+            #[cfg(feature = "di")]
+            scope: None,
+        }
+    }
+
+    fn name_schema() -> crate::types::ToolInputSchema {
+        const JSON: &str = r#"{"type":"object","properties":{"name":{"type":"string"}}}"#;
+        #[cfg(feature = "legacy-spec")]
+        {
+            crate::types::tool::ToolSchema::from_json_str(JSON)
+        }
+        #[cfg(not(feature = "legacy-spec"))]
+        {
+            crate::types::schema_2020::InputSchema::from_json_str(JSON).unwrap_or_default()
+        }
+    }
+
+    #[tokio::test]
+    async fn it_refuses_a_tool_whose_schema_its_handler_cannot_read() {
+        let mut tool = Tool::new("greet", |name: String| async move { name });
+        tool.with_input_schema(|_| name_schema());
+
+        let err = ctx().add_tool(tool).await.expect_err("must be refused");
+
+        assert!(
+            err.to_string().contains("publishes an inputSchema without"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_refuses_a_prompt_that_publishes_too_few_args() {
+        let mut prompt = Prompt::new("analyze", |topic: String, tone: String| async move {
+            (format!("{topic}{tone}"), Role::User)
+        });
+        prompt.with_args(["topic"]);
+
+        let err = ctx().add_prompt(prompt).await.expect_err("must be refused");
+
+        assert!(
+            err.to_string().contains("publishes 1 argument(s)"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_accepts_a_consistent_tool() {
+        let mut tool = Tool::new("greet", |name: String| async move { name });
+        tool.with_input_schema(|_| name_schema())
+            .with_arg_names(["name"]);
+
+        ctx().add_tool(tool).await.expect("must be accepted");
     }
 }

--- a/neva/src/app/greeter.rs
+++ b/neva/src/app/greeter.rs
@@ -110,9 +110,51 @@ impl<'a> Greeter<'a> {
     }
 }
 
+/// Renders the line that closes a greeted server's session.
+///
+/// Its counterpart is [`Greeter::render`], and it goes to the same place for
+/// the same reason: on the stdio transport **stdout is the protocol channel**,
+/// so anything written there is a JSON-RPC frame to the peer. A parting word
+/// belongs on stderr, where hosts collect a server's logs.
+///
+/// It is a line of its own at both ends. Ctrl+C echoes `^C` into the terminal
+/// with no newline either side of it, so without the leading one the farewell
+/// starts mid-line (`^Cneva: server stopped`), and without the trailing one a
+/// shell redrawing its prompt from a half-written line marks the gap -- zsh
+/// prints a reverse `%` -- which reads as though the server left something
+/// behind.
+pub(super) fn render_farewell(use_color: bool) -> String {
+    let (cyan, reset) = if use_color { (CYAN, RESET) } else { ("", "") };
+    format!("\n{cyan}neva{reset}: server stopped\n")
+}
+
+/// Writes the farewell to stderr; write errors are silently discarded.
+pub(super) fn print_farewell(use_color: bool) {
+    eprint!("{}", render_farewell(use_color));
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The farewell stands on its own line. Ctrl+C echoes a bare `^C` into the
+    /// terminal, so a farewell without the leading newline starts mid-line and
+    /// one without the trailing newline leaves the shell redrawing its prompt
+    /// from a half-written line.
+    #[test]
+    fn farewell_is_a_line_of_its_own() {
+        for use_color in [true, false] {
+            let farewell = render_farewell(use_color);
+            assert!(farewell.starts_with('\n'), "got: {farewell:?}");
+            assert!(farewell.ends_with('\n'), "got: {farewell:?}");
+        }
+    }
+
+    #[test]
+    fn farewell_omits_ansi_when_use_color_false() {
+        assert!(!render_farewell(false).contains('\x1b'));
+        assert!(render_farewell(true).contains('\x1b'));
+    }
 
     fn make_greeter<'a>(
         server_name: &'a str,

--- a/neva/src/app/handler.rs
+++ b/neva/src/app/handler.rs
@@ -5,7 +5,7 @@ use crate::app::options::RuntimeMcpOptions;
 use crate::error::{Error, ErrorCode};
 use crate::shared::BoxFuture;
 use crate::types::{
-    CallToolRequestParams, CompleteRequestParams, GetPromptRequestParams, IntoResponse,
+    ArgNames, CallToolRequestParams, CompleteRequestParams, GetPromptRequestParams, IntoResponse,
     ListResourcesRequestParams, ReadResourceRequestParams, Request, RequestId, Response,
 };
 use std::future::Future;
@@ -14,32 +14,25 @@ use std::sync::Arc;
 /// Represents a specific registered handler
 pub(crate) type RequestHandler<T> = Arc<dyn Handler<T> + Send + Sync>;
 
+/// Parameters handed to a registered handler.
+///
+/// The `Tool` and `Prompt` variants carry the [`ArgNames`] of the primitive
+/// they were dispatched to, because extraction reads the request's
+/// `arguments` map by name and only the registered [`crate::types::Tool`] /
+/// [`crate::types::prompt::Prompt`] knows what its handler's arguments are
+/// called.
 #[derive(Debug)]
 pub enum HandlerParams {
     Request(Context, Request),
-    Tool(CallToolRequestParams),
+    Tool(CallToolRequestParams, ArgNames),
     Resource(ReadResourceRequestParams),
-    Prompt(GetPromptRequestParams),
-}
-
-impl From<CallToolRequestParams> for HandlerParams {
-    #[inline]
-    fn from(params: CallToolRequestParams) -> Self {
-        Self::Tool(params)
-    }
+    Prompt(GetPromptRequestParams, ArgNames),
 }
 
 impl From<ReadResourceRequestParams> for HandlerParams {
     #[inline]
     fn from(params: ReadResourceRequestParams) -> Self {
         Self::Resource(params)
-    }
-}
-
-impl From<GetPromptRequestParams> for HandlerParams {
-    #[inline]
-    fn from(params: GetPromptRequestParams) -> Self {
-        Self::Prompt(params)
     }
 }
 

--- a/neva/src/app/options.rs
+++ b/neva/src/app/options.rs
@@ -1075,7 +1075,7 @@ mod tests {
             meta: None,
         };
 
-        let result = prompt.call(req.into()).await.unwrap();
+        let result = prompt.call(req).await.unwrap();
 
         let msg = result.messages.first().unwrap();
 
@@ -1099,7 +1099,7 @@ mod tests {
             meta: None,
         };
 
-        let result = prompt.call(req.into()).await;
+        let result = prompt.call(req).await;
 
         assert!(result.is_err())
     }

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -273,6 +273,13 @@ pub mod __macro_support {
         /// Returns `true` when a call must supply the argument -- that is,
         /// when `Self` is not an `Option<T>`.
         fn is_required() -> bool;
+
+        /// The JSON type the argument is published as: `"string"`,
+        /// `"number"`, `"boolean"`, `"array"`, `"object"` or `"none"`.
+        ///
+        /// `"object"` is the signal that the property needs a `JsonSchema`
+        /// probe rather than an inline primitive subschema.
+        fn category() -> &'static str;
     }
 
     #[cfg(feature = "server")]
@@ -285,6 +292,19 @@ pub mod __macro_support {
         #[inline]
         fn is_required() -> bool {
             !T::is_optional()
+        }
+
+        #[inline]
+        fn category() -> &'static str {
+            use crate::types::PropertyType;
+            match T::category() {
+                PropertyType::String => "string",
+                PropertyType::Number => "number",
+                PropertyType::Bool => "boolean",
+                PropertyType::Array => "array",
+                PropertyType::Object => "object",
+                PropertyType::None => "none",
+            }
         }
     }
 }

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -269,6 +269,10 @@ pub mod __macro_support {
     pub trait IsArgument {
         /// Returns `true` when `Self` occupies an argument slot.
         fn is_argument() -> bool;
+
+        /// Returns `true` when a call must supply the argument -- that is,
+        /// when `Self` is not an `Option<T>`.
+        fn is_required() -> bool;
     }
 
     #[cfg(feature = "server")]
@@ -276,6 +280,11 @@ pub mod __macro_support {
         #[inline]
         fn is_argument() -> bool {
             T::category() != crate::types::PropertyType::None
+        }
+
+        #[inline]
+        fn is_required() -> bool {
+            !T::is_optional()
         }
     }
 }
@@ -348,11 +357,17 @@ macro_rules! map_tool {
 macro_rules! map_prompt {
     ($app:expr, $name:expr, |$($arg:ident : $ty:ty),* $(,)?| $body:expr) => {
         $app.map_prompt($name, move |$($arg: $ty),*| $body)
-            .with_args($crate::__arg_names!($($arg : $ty),*))
+            .with_args($crate::__prompt_args!($($arg : $ty),*))
     };
 }
 
 /// Collects the names of the value-carrying parameters. Not public API.
+///
+/// The filtering is by *resolved* type rather than by how the parameter was
+/// spelled, so a type alias for a metadata parameter (`type Token =
+/// Meta<ProgressToken>`) is dropped here exactly as `ToolHandler::args` drops
+/// it. A syntactic test could not see through the alias, and the two lists
+/// disagreeing is precisely what `App::run` refuses to start on.
 #[cfg(feature = "server")]
 #[doc(hidden)]
 #[macro_export]
@@ -365,6 +380,29 @@ macro_rules! __arg_names {
             }
         )*
         names
+    }};
+}
+
+/// Collects the value-carrying parameters as prompt arguments, carrying
+/// whether each must be supplied. Not public API.
+///
+/// See [`__arg_names`] for why the classification is by resolved type.
+#[cfg(feature = "server")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __prompt_args {
+    ($($arg:ident : $ty:ty),* $(,)?) => {{
+        type __PromptArg = $crate::types::prompt::PromptArgument;
+        let mut args: ::std::vec::Vec<__PromptArg> = ::std::vec::Vec::new();
+        $(
+            if <$ty as $crate::__macro_support::IsArgument>::is_argument() {
+                args.push(__PromptArg::named(
+                    ::core::stringify!($arg),
+                    <$ty as $crate::__macro_support::IsArgument>::is_required(),
+                ));
+            }
+        )*
+        args
     }};
 }
 

--- a/neva/src/lib.rs
+++ b/neva/src/lib.rs
@@ -249,12 +249,123 @@ pub mod json {
 }
 
 /// Internal re-exports used by `neva_macros`-generated code. Not public API.
-#[cfg(not(feature = "legacy-spec"))]
 #[doc(hidden)]
 pub mod __macro_support {
+    #[cfg(not(feature = "legacy-spec"))]
     pub use crate::types::schema_2020::{
         SchemaProbe, ViaFallback, ViaJsonSchema, object_schema, primitive_subschema,
     };
+
+    /// Whether a handler parameter type is a value-carrying argument rather
+    /// than a parameter served from the request's metadata.
+    ///
+    /// Used by [`crate::map_tool`] / [`crate::map_prompt`] to drop `Context`,
+    /// `Meta<_>` and `Dc<_>` parameters from the declared argument names, the
+    /// same way they are dropped from the generated schema.
+    ///
+    /// Blanket-implemented for every extractable type; there is nothing to
+    /// implement by hand.
+    #[cfg(feature = "server")]
+    pub trait IsArgument {
+        /// Returns `true` when `Self` occupies an argument slot.
+        fn is_argument() -> bool;
+    }
+
+    #[cfg(feature = "server")]
+    impl<T: crate::types::helpers::TypeCategory> IsArgument for T {
+        #[inline]
+        fn is_argument() -> bool {
+            T::category() != crate::types::PropertyType::None
+        }
+    }
+}
+
+/// Registers a tool from a closure, keeping the closure's parameter names.
+///
+/// [`App::map_tool`] takes a plain closure, and Rust does not preserve a
+/// closure's parameter names -- such a tool falls back to publishing and
+/// reading the positional `arg0`, `arg1`, ... arguments. This macro reads the
+/// names off the closure at expansion time and declares them via
+/// [`crate::types::Tool::with_arg_names`], so the tool advertises the names
+/// you wrote and extraction reads by them.
+///
+/// Parameters served from the request's metadata -- `Context`, `Meta<_>`, a
+/// DI-injected `Dc<T>` -- are skipped, exactly as they are skipped in the
+/// generated schema.
+///
+/// Expands to the [`App::map_tool`] call itself, so the returned
+/// `&mut Tool` can be configured further as usual.
+///
+/// # Example
+/// ```no_run
+/// use neva::{App, map_tool};
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let mut app = App::new();
+///
+/// map_tool!(app, "greet", |name: String, age: i32| async move {
+///     format!("Hello, {name}! You are {age}.")
+/// })
+/// .with_description("Greets a person");
+///
+/// # app.run().await;
+/// # }
+/// ```
+#[cfg(feature = "server")]
+#[macro_export]
+macro_rules! map_tool {
+    ($app:expr, $name:expr, |$($arg:ident : $ty:ty),* $(,)?| $body:expr) => {
+        $app.map_tool($name, move |$($arg: $ty),*| $body)
+            .with_arg_names($crate::__arg_names!($($arg : $ty),*))
+    };
+}
+
+/// Registers a prompt from a closure, keeping the closure's parameter names.
+///
+/// The prompt counterpart of [`crate::map_tool`]: the names are declared via
+/// [`crate::types::prompt::Prompt::with_args`], which is both what
+/// `prompts/list` publishes and what extraction reads by.
+///
+/// # Example
+/// ```no_run
+/// use neva::{App, map_prompt, types::Role};
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let mut app = App::new();
+///
+/// map_prompt!(app, "analyze", |lang: String, code: String| async move {
+///     (format!("Analyze this {lang} code: {code}"), Role::User)
+/// })
+/// .with_description("Analyzes a code snippet");
+///
+/// # app.run().await;
+/// # }
+/// ```
+#[cfg(feature = "server")]
+#[macro_export]
+macro_rules! map_prompt {
+    ($app:expr, $name:expr, |$($arg:ident : $ty:ty),* $(,)?| $body:expr) => {
+        $app.map_prompt($name, move |$($arg: $ty),*| $body)
+            .with_args($crate::__arg_names!($($arg : $ty),*))
+    };
+}
+
+/// Collects the names of the value-carrying parameters. Not public API.
+#[cfg(feature = "server")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __arg_names {
+    ($($arg:ident : $ty:ty),* $(,)?) => {{
+        let mut names: ::std::vec::Vec<&'static str> = ::std::vec::Vec::new();
+        $(
+            if <$ty as $crate::__macro_support::IsArgument>::is_argument() {
+                names.push(::core::stringify!($arg));
+            }
+        )*
+        names
+    }};
 }
 
 pub mod prelude {

--- a/neva/src/transport/stdio.rs
+++ b/neva/src/transport/stdio.rs
@@ -5,13 +5,19 @@ use crate::transport::{Receiver as TransportReceiver, Sender as TransportSender,
 use crate::types::Message;
 use futures_util::TryFutureExt;
 use tokio::{
-    io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter},
+    io::{AsyncWrite, AsyncWriteExt, BufWriter},
     sync::mpsc::{self, Receiver, Sender},
 };
+
+// The async reader serves a child process's piped stdout, which only a client
+// has. A server reads its own stdin, and does that on a thread of its own --
+// see `StdIoReceiver::start_blocking`.
+#[cfg(feature = "client")]
+use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader};
 use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "server")]
-use tokio::io::{Stdin, Stdout};
+use tokio::io::Stdout;
 
 #[cfg(feature = "client")]
 use self::options::StdIoOptions;
@@ -218,6 +224,39 @@ fn parse_line(line: &str) -> Line {
     }
 }
 
+/// What a receive loop does with the line it just read.
+///
+/// The two loops below read over different I/O -- a client awaits a child's
+/// piped stdout, a server blocks on its own stdin -- but what a line *means*
+/// is the same either way, so it is decided once here and each loop only
+/// carries it out with the sends its own flavour has.
+enum Step {
+    /// Nothing to forward; read the next line.
+    Skip,
+    /// Hand to the dispatch layer.
+    Forward(Message),
+    /// Answer the peer directly through the transport's sender.
+    Answer(Message),
+    /// Report the read failure, then stop.
+    Fail(Error),
+    /// Input is finished.
+    Stop,
+}
+
+/// Classifies one read: how it went, and what the line it produced was.
+#[inline]
+fn next_step(read: std::io::Result<usize>, line: &str) -> Step {
+    match read {
+        Ok(0) => Step::Stop, // EOF
+        Ok(_) => match parse_line(line) {
+            Line::Drop => Step::Skip,
+            Line::Message(msg) => Step::Forward(msg),
+            Line::Reply(resp) => Step::Answer(resp),
+        },
+        Err(err) => Step::Fail(err.into()),
+    }
+}
+
 impl StdIoReceiver {
     /// Creates a new stdio transport receiver
     pub(crate) fn new() -> Self {
@@ -225,11 +264,16 @@ impl StdIoReceiver {
         Self { tx, rx }
     }
 
-    /// Starts a new thread that reads from stdin asynchronously.
+    /// Starts a task that reads `reader` asynchronously.
+    ///
+    /// Serves a client's view of a child process's piped stdout: a real async
+    /// pipe, so a pending read is a task the runtime can simply drop, and
+    /// cancellation lands on the next line boundary or sooner.
     ///
     /// `replies` is the transport's own sender: an unreadable inbound
     /// request is answered with a JSON-RPC parse error from here, since
     /// it never reaches the dispatch layer that would normally reply.
+    #[cfg(feature = "client")]
     pub(crate) fn start<T: AsyncRead + Unpin + Send + 'static>(
         &self,
         mut reader: BufReader<T>,
@@ -241,39 +285,77 @@ impl StdIoReceiver {
             let mut line = String::new();
             loop {
                 line.clear();
-                tokio::select! {
+                let read = tokio::select! {
                     biased;
                     _ = token.cancelled() => break,
-                    read_line = reader.read_line(&mut line) => {
-                        match read_line {
-                            Ok(0) => break, // EOF
-                            Ok(_) => match parse_line(&line) {
-                                Line::Drop => continue,
-                                Line::Message(msg) => {
-                                    if let Err(_e) = tx.send(Ok(msg)).await {
-                                        #[cfg(feature = "tracing")]
-                                        tracing::error!(logger = "neva", "Failed to send request: {:?}", _e);
-                                        break;
-                                    }
-                                }
-                                Line::Reply(resp) => {
-                                    if let Err(_e) = replies.send(resp).await {
-                                        #[cfg(feature = "tracing")]
-                                        tracing::error!(logger = "neva", "Failed to reply with a parse error: {:?}", _e);
-                                        break;
-                                    }
-                                }
-                            }
-                            Err(err) => {
-                                let err = Err(err.into());
-                                if let Err(_e) = tx.send(err).await {
-                                    #[cfg(feature = "tracing")]
-                                    tracing::error!(logger = "neva", "Failed to send error request: {:?}", _e);
-                                }
-                                break;
-                            }
-                        };
+                    read = reader.read_line(&mut line) => read,
+                };
+                let sent = match next_step(read, &line) {
+                    Step::Skip => continue,
+                    Step::Stop => break,
+                    Step::Forward(msg) => tx.send(Ok(msg)).await.is_ok(),
+                    Step::Answer(resp) => replies.send(resp).await.is_ok(),
+                    Step::Fail(err) => {
+                        let _ = tx.send(Err(err)).await;
+                        break;
                     }
+                };
+                if !sent {
+                    break;
+                }
+            }
+        });
+    }
+
+    /// Starts a dedicated OS thread that reads `reader` with blocking I/O.
+    ///
+    /// Used for the server's own `stdin`, which -- unlike a child process's
+    /// piped stdout -- has no async form. [`tokio::io::stdin`] emulates one by
+    /// parking each read on the runtime's *blocking pool*, and a read parked
+    /// there when the shutdown signal arrives is never interrupted: the peer
+    /// simply is not writing. Dropping the runtime waits for that pool, so a
+    /// server that shut down cleanly would still hang the process until the
+    /// peer happened to send another line. Ctrl+C looked like it did nothing.
+    ///
+    /// A thread of our own is not the runtime's to wait for, so returning from
+    /// `main` ends the process while this thread is still parked in `read`.
+    /// Cancellation is still observed between lines, for a host that keeps
+    /// running after the server stops.
+    ///
+    /// End of input leaves the dispatch loop waiting, exactly as it did
+    /// before: the receiver still holds a sender of its own, so the channel
+    /// never closes. That is a separate shortcoming of the stdio shutdown
+    /// path -- ending it properly means draining the handlers still in flight
+    /// so their answers are not thrown away -- and is deliberately not
+    /// conflated with the Ctrl+C fix here.
+    #[cfg(feature = "server")]
+    pub(crate) fn start_blocking<T: std::io::BufRead + Send + 'static>(
+        &self,
+        mut reader: T,
+        replies: Sender<Message>,
+        token: CancellationToken,
+    ) {
+        let tx = self.tx.clone();
+        std::thread::spawn(move || {
+            let mut line = String::new();
+            loop {
+                line.clear();
+                if token.is_cancelled() {
+                    break;
+                }
+                let read = reader.read_line(&mut line);
+                let sent = match next_step(read, &line) {
+                    Step::Skip => continue,
+                    Step::Stop => break,
+                    Step::Forward(msg) => tx.blocking_send(Ok(msg)).is_ok(),
+                    Step::Answer(resp) => replies.blocking_send(resp).is_ok(),
+                    Step::Fail(err) => {
+                        let _ = tx.blocking_send(Err(err));
+                        break;
+                    }
+                };
+                if !sent {
+                    break;
                 }
             }
         });
@@ -362,10 +444,16 @@ impl StdIoServer {
         }
     }
 
-    /// Initializes and Returns references to `stdin` and `stdout`
-    pub(crate) fn init() -> (BufReader<Stdin>, BufWriter<Stdout>) {
+    /// Initializes and Returns handles to `stdin` and `stdout`.
+    ///
+    /// `stdin` is the std one, read on a thread of our own: see
+    /// [`StdIoReceiver::start_blocking`] for why tokio's cannot be used here.
+    /// `stdout` stays async -- a write parks on the blocking pool only for as
+    /// long as the write takes, so it is never the thing left outstanding at
+    /// shutdown.
+    pub(crate) fn init() -> (std::io::BufReader<std::io::Stdin>, BufWriter<Stdout>) {
         (
-            BufReader::new(tokio::io::stdin()),
+            std::io::BufReader::new(std::io::stdin()),
             BufWriter::new(tokio::io::stdout()),
         )
     }
@@ -425,7 +513,7 @@ impl Transport for StdIoServer {
         let (reader, writer) = StdIoServer::init();
 
         self.receiver
-            .start(reader, self.sender.tx.clone(), token.clone());
+            .start_blocking(reader, self.sender.tx.clone(), token.clone());
         self.sender.start(writer, token.clone());
 
         #[cfg(feature = "tracing")]
@@ -463,6 +551,10 @@ mod parse_line_tests {
     /// The regression the fix is really about: the bad line must not end
     /// the stream -- the pending request completes *and* the following
     /// lines keep arriving.
+    // Drives the async reader, which serves a child process's piped stdout and
+    // so is compiled only for a client. `blocking_reader_tests` covers the same
+    // routing on the server's own reader; both go through `next_step`.
+    #[cfg(feature = "client")]
     #[tokio::test]
     async fn a_bad_line_neither_ends_the_stream_nor_is_swallowed() {
         const INPUT: &[u8] = concat!(
@@ -495,6 +587,7 @@ mod parse_line_tests {
     /// End-to-end through the reader task: a malformed inbound request is
     /// written back out the transport's sender, and never surfaces to the
     /// receive loop that would have swallowed it.
+    #[cfg(feature = "client")]
     #[tokio::test]
     async fn a_malformed_request_is_written_back_to_the_peer() {
         const INPUT: &[u8] = concat!(
@@ -675,5 +768,84 @@ mod tests {
             .unwrap();
 
         assert!(output.stdout.is_empty(), "Process still running");
+    }
+}
+
+/// The server's stdin is read on a thread of neva's own rather than through
+/// [`tokio::io::stdin`], so that a read still parked when the peer goes quiet
+/// cannot hold the process open. These pin the behaviour that depends on it.
+#[cfg(all(test, feature = "server"))]
+mod blocking_reader_tests {
+    use super::*;
+    use std::time::Duration;
+
+    /// The reader forwards what it parses, on a thread the runtime does not
+    /// own -- the whole point being that shutdown never waits for it.
+    #[tokio::test]
+    async fn it_forwards_lines_read_from_a_blocking_source() {
+        let mut receiver = StdIoReceiver::new();
+        let (replies, _replies_rx) = mpsc::channel(8);
+        let input = b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n".to_vec();
+
+        receiver.start_blocking(
+            std::io::BufReader::new(std::io::Cursor::new(input)),
+            replies,
+            CancellationToken::new(),
+        );
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), receiver.recv())
+            .await
+            .expect("the reader must forward the line")
+            .expect("a readable message");
+
+        let Message::Request(req) = msg else {
+            panic!("expected a request");
+        };
+        assert_eq!(req.method, "tools/list");
+    }
+
+    /// An unreadable request is answered rather than dropped or pushed into
+    /// the receive loop -- the same routing the async reader does.
+    #[tokio::test]
+    async fn it_answers_an_unreadable_request_out_of_band() {
+        let receiver = StdIoReceiver::new();
+        let (replies, mut replies_rx) = mpsc::channel(8);
+        let input = b"{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":}\n".to_vec();
+
+        receiver.start_blocking(
+            std::io::BufReader::new(std::io::Cursor::new(input)),
+            replies,
+            CancellationToken::new(),
+        );
+
+        let reply = tokio::time::timeout(Duration::from_secs(5), replies_rx.recv())
+            .await
+            .expect("a parse error must be answered")
+            .expect("a reply");
+
+        assert!(matches!(reply, Message::Response(_)));
+    }
+
+    /// Cancellation is observed between lines, so a host that keeps running
+    /// after the server stops is not left with a thread reading into a
+    /// channel nobody drains.
+    #[tokio::test]
+    async fn it_stops_reading_once_cancelled() {
+        let mut receiver = StdIoReceiver::new();
+        let (replies, _replies_rx) = mpsc::channel(8);
+        let token = CancellationToken::new();
+        token.cancel();
+
+        receiver.start_blocking(
+            std::io::BufReader::new(std::io::Cursor::new(
+                b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}\n".to_vec(),
+            )),
+            replies,
+            token,
+        );
+
+        // Nothing is forwarded: the loop checks the token before its first read.
+        let got = tokio::time::timeout(Duration::from_millis(300), receiver.recv()).await;
+        assert!(got.is_err(), "a cancelled reader must forward nothing");
     }
 }

--- a/neva/src/transport/stdio.rs
+++ b/neva/src/transport/stdio.rs
@@ -318,16 +318,31 @@ impl StdIoReceiver {
     /// peer happened to send another line. Ctrl+C looked like it did nothing.
     ///
     /// A thread of our own is not the runtime's to wait for, so returning from
-    /// `main` ends the process while this thread is still parked in `read`.
-    /// Cancellation is still observed between lines, for a host that keeps
-    /// running after the server stops.
+    /// `main` ends the process while this thread is still parked in `read` --
+    /// which is also what [`tokio::io::stdin`]'s own documentation recommends
+    /// for interactive input, for this reason.
     ///
-    /// End of input leaves the dispatch loop waiting, exactly as it did
-    /// before: the receiver still holds a sender of its own, so the channel
-    /// never closes. That is a separate shortcoming of the stdio shutdown
-    /// path -- ending it properly means draining the handlers still in flight
-    /// so their answers are not thrown away -- and is deliberately not
-    /// conflated with the Ctrl+C fix here.
+    /// # What this does not solve
+    ///
+    /// A read already in progress still cannot be interrupted; tokio says as
+    /// much of its own stdin ("it is impossible to cancel that read"), and no
+    /// portable, safe API changes that. Cancellation is therefore observed
+    /// *between* lines. For a server that owns its process this is invisible:
+    /// nothing outlives the parked read. For a host that keeps running after
+    /// `App::run` returns it is not -- the parked thread stays attached to
+    /// stdin and swallows the next line before noticing it has nowhere to put
+    /// it, so a restarted server, or the host reading stdin itself, loses that
+    /// line.
+    ///
+    /// End of input has the mirror problem: the receiver still holds a sender
+    /// of its own, so the channel never closes and the dispatch loop waits on
+    /// input that can no longer come.
+    ///
+    /// Both belong to the same missing piece -- an stdio transport that can be
+    /// *shut down* rather than merely abandoned: drain the handlers still in
+    /// flight so their answers are not thrown away, close the stream, and hand
+    /// stdin back. Neither is introduced here, and neither is conflated with
+    /// the Ctrl+C fix.
     #[cfg(feature = "server")]
     pub(crate) fn start_blocking<T: std::io::BufRead + Send + 'static>(
         &self,

--- a/neva/src/types.rs
+++ b/neva/src/types.rs
@@ -38,6 +38,8 @@ pub use content::{
     ToolUse,
 };
 pub use cursor::{Cursor, Page, Pagination};
+#[cfg(feature = "server")]
+pub use helpers::extract::{ArgNames, FromHandlerArgs};
 pub use helpers::{Json, Meta, PropertyType};
 pub use reference::Reference;
 pub use request::{Request, RequestId, RequestParamsMeta};

--- a/neva/src/types/helpers.rs
+++ b/neva/src/types/helpers.rs
@@ -136,10 +136,29 @@ mod sealed {
     pub(crate) trait TypeCategorySealed {}
 }
 
-/// A trait that helps to determine a category of an object type
+/// A trait that helps to determine a category of an object type.
+///
+/// [`PropertyType::None`] marks a type that is not a handler *argument* at
+/// all but is served from the request's metadata -- [`Meta`], `Context`, a
+/// DI-injected `Dc<T>`. Such a parameter takes no schema property and consumes
+/// no argument slot.
+///
+/// The trait is sealed: it is implemented for the types neva can extract, and
+/// cannot be implemented outside this crate.
 #[cfg(feature = "server")]
 pub(crate) trait TypeCategory: sealed::TypeCategorySealed {
+    /// Returns the schema category of `Self`.
     fn category() -> PropertyType;
+
+    /// Whether a call may leave this argument out.
+    ///
+    /// True for `Option<T>`, which is published as the `T` property but kept
+    /// out of the schema's `required` list; an absent value resolves to `None`
+    /// instead of failing the call.
+    #[inline]
+    fn is_optional() -> bool {
+        false
+    }
 }
 
 /// Wraps JSON-typed data

--- a/neva/src/types/helpers/extract.rs
+++ b/neva/src/types/helpers/extract.rs
@@ -198,6 +198,21 @@ impl ArgNames {
         }
     }
 
+    /// The first name declared more than once, if any.
+    ///
+    /// Two slots reading the same key is not a mistake that announces itself:
+    /// the schema collapses to one property, and both parameters quietly
+    /// receive the same value rather than the call failing.
+    #[inline]
+    pub(crate) fn duplicate(&self) -> Option<&str> {
+        let names = self.names.as_deref()?;
+        let mut seen = std::collections::HashSet::with_capacity(names.len());
+        names
+            .iter()
+            .map(|name| &**name)
+            .find(|name| !seen.insert(*name))
+    }
+
     /// Returns `true` when no names were declared.
     ///
     /// # Examples

--- a/neva/src/types/helpers/extract.rs
+++ b/neva/src/types/helpers/extract.rs
@@ -3,6 +3,7 @@
 use crate::Context;
 use crate::error::{Error, ErrorCode};
 use crate::shared::{ArcSlice, ArcStr};
+use crate::types::helpers::TypeCategory;
 use crate::types::request::RequestParamsMeta;
 use crate::types::{Meta, ProgressToken};
 use serde::de::DeserializeOwned;
@@ -393,8 +394,14 @@ impl RequestArgument for Context {
 /// consumes the next name and reads the value a peer sent under it. An absent
 /// key is offered to the type as `null`, so an `Option<T>` argument resolves
 /// to `None` instead of failing.
+///
+/// Whether an argument may be omitted is decided by its *type*
+/// ([`TypeCategory::is_optional`]), never by whether a synthetic `null`
+/// happens to deserialize into it: `serde_json::Value` and `()` accept `null`
+/// quite happily, and inferring optionality from that would let a required
+/// argument through as `Null` against the schema that declares it required.
 #[inline]
-pub(crate) fn extract_arg<T: RequestArgument<Error = Error>>(
+pub(crate) fn extract_arg<T: RequestArgument<Error = Error> + TypeCategory>(
     meta: &Option<RequestParamsMeta>,
     args: Option<&HashMap<String, Value>>,
     names: &ArgNames,
@@ -412,12 +419,11 @@ pub(crate) fn extract_arg<T: RequestArgument<Error = Error>>(
                         format!("invalid value for argument `{name}`: {err}"),
                     )
                 }),
-                None => T::extract(Payload::Args(Value::Null)).map_err(|_| {
-                    Error::new(
-                        ErrorCode::InvalidParams,
-                        format!("missing required argument `{name}`"),
-                    )
-                }),
+                None if T::is_optional() => T::extract(Payload::Args(Value::Null)),
+                None => Err(Error::new(
+                    ErrorCode::InvalidParams,
+                    format!("missing required argument `{name}`"),
+                )),
             }
         }
     }
@@ -432,7 +438,7 @@ impl<P: HandlerArgs> FromHandlerArgs<P> for () {
 
 macro_rules! impl_from_handler_args {
     ($($T:ident),+) => {
-        impl<P: HandlerArgs, $($T: RequestArgument<Error = Error>),+> FromHandlerArgs<P> for ($($T,)+) {
+        impl<P: HandlerArgs, $($T: RequestArgument<Error = Error> + TypeCategory),+> FromHandlerArgs<P> for ($($T,)+) {
             #[inline]
             fn from_args(params: P, names: &ArgNames) -> Result<Self, Error> {
                 let (args, meta) = params.into_parts();

--- a/neva/src/types/helpers/extract.rs
+++ b/neva/src/types/helpers/extract.rs
@@ -2,13 +2,216 @@
 
 use crate::Context;
 use crate::error::{Error, ErrorCode};
+use crate::shared::{ArcSlice, ArcStr};
 use crate::types::request::RequestParamsMeta;
 use crate::types::{Meta, ProgressToken};
 use serde::de::DeserializeOwned;
-use std::collections::hash_map::Iter;
+use serde_json::Value;
+use std::collections::HashMap;
 
 #[cfg(feature = "tasks")]
 use crate::types::RelatedTaskMetadata;
+
+/// Fallback names for a handler whose argument names are not known.
+///
+/// A handler accepts at most five value-carrying arguments, so the table is
+/// never indexed past its end; the extra slots only keep [`ArgNames::get`]
+/// total.
+const POSITIONAL: [&str; 8] = [
+    "arg0", "arg1", "arg2", "arg3", "arg4", "arg5", "arg6", "arg7",
+];
+
+/// The fallback name of the `index`-th argument slot.
+#[inline]
+pub(crate) fn positional_name(index: usize) -> &'static str {
+    match POSITIONAL.get(index) {
+        Some(name) => name,
+        None => "",
+    }
+}
+
+/// The slot `name` is the fallback name of, if it is one.
+#[inline]
+pub(crate) fn positional_slot(name: &str) -> Option<usize> {
+    POSITIONAL.iter().position(|positional| *positional == name)
+}
+
+/// The names of a tool or prompt handler's arguments, in declaration order.
+///
+/// Arguments are read from the request's `arguments` map **by name**: the
+/// *n*-th value-carrying parameter of the handler is looked up under the
+/// *n*-th name here. Parameters that come from request metadata instead --
+/// [`Meta`], [`Context`], or a DI-injected `Dc<T>` -- carry no name and do not
+/// consume a slot.
+///
+/// The names are also exactly the property names the handler's generated
+/// `inputSchema` (or prompt `arguments` list) advertises, which is what keeps
+/// what a peer is told to send and what the handler reads from drifting apart.
+///
+/// A handler registered without declared names -- a bare closure passed to
+/// [`crate::App::map_tool`], whose parameter names Rust does not preserve --
+/// falls back to the positional `arg0`, `arg1`, ... form, and its generated
+/// schema advertises those same names.
+///
+/// # Examples
+///
+/// ```
+/// use neva::types::ArgNames;
+///
+/// let names = ArgNames::new(["age", "name"]);
+/// assert_eq!(names.get(0), "age");
+/// assert_eq!(names.get(1), "name");
+///
+/// // Undeclared, or past the end of what was declared: positional fallback.
+/// assert_eq!(ArgNames::default().get(1), "arg1");
+/// assert_eq!(names.get(2), "arg2");
+/// ```
+#[derive(Debug, Default, Clone)]
+pub struct ArgNames {
+    /// The declared names, if the handler's are known.
+    names: Option<ArcSlice<ArcStr>>,
+    /// How many argument slots the handler has, named or not.
+    arity: usize,
+}
+
+impl ArgNames {
+    /// Creates [`ArgNames`] from the handler's declared argument names.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neva::types::ArgNames;
+    ///
+    /// let names = ArgNames::new(["age", "name"]);
+    /// assert_eq!(names.len(), 2);
+    /// ```
+    #[inline]
+    pub fn new<I, S>(names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let names = names
+            .into_iter()
+            .map(|name| ArcStr::from(name.into()))
+            .collect::<Vec<_>>();
+        Self {
+            arity: names.len(),
+            names: Some(ArcSlice::from(names)),
+        }
+    }
+
+    /// Creates undeclared [`ArgNames`] for a handler with `arity` argument
+    /// slots, which read the positional `arg0`, `arg1`, ... names.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neva::types::ArgNames;
+    ///
+    /// let names = ArgNames::positional(2);
+    /// assert_eq!(names.get(0), "arg0");
+    /// assert!(!names.is_declared());
+    /// ```
+    #[inline]
+    pub fn positional(arity: usize) -> Self {
+        Self { names: None, arity }
+    }
+
+    /// Returns `true` when the handler's own argument names are known, rather
+    /// than the positional fallback being in use.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neva::types::ArgNames;
+    ///
+    /// assert!(ArgNames::new(["city"]).is_declared());
+    /// assert!(!ArgNames::positional(1).is_declared());
+    /// ```
+    #[inline]
+    pub fn is_declared(&self) -> bool {
+        self.names.is_some()
+    }
+
+    /// Returns how many argument slots the handler has, named or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neva::types::ArgNames;
+    ///
+    /// assert_eq!(ArgNames::positional(3).arity(), 3);
+    /// assert_eq!(ArgNames::new(["a", "b"]).arity(), 2);
+    /// ```
+    #[inline]
+    pub fn arity(&self) -> usize {
+        self.arity
+    }
+
+    /// Returns the name of the argument in the `index`-th slot, falling back
+    /// to the positional `argN` form when no name was declared for it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neva::types::ArgNames;
+    ///
+    /// assert_eq!(ArgNames::new(["city"]).get(0), "city");
+    /// assert_eq!(ArgNames::default().get(0), "arg0");
+    /// ```
+    #[inline]
+    pub fn get(&self, index: usize) -> &str {
+        self.names
+            .as_deref()
+            .and_then(|names| names.get(index))
+            .map_or_else(|| positional_name(index), |name| &**name)
+    }
+
+    /// Returns the number of declared names, or `0` if none were declared.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neva::types::ArgNames;
+    ///
+    /// assert_eq!(ArgNames::new(["a", "b"]).len(), 2);
+    /// assert_eq!(ArgNames::default().len(), 0);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.names.as_deref().map_or(0, <[ArcStr]>::len)
+    }
+
+    /// Declares `names` for the handler these [`ArgNames`] describe, keeping
+    /// the handler's own arity so a miscounted declaration stays detectable.
+    #[inline]
+    pub(crate) fn declare<I, S>(&self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            arity: self.arity,
+            ..Self::new(names)
+        }
+    }
+
+    /// Returns `true` when no names were declared.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neva::types::ArgNames;
+    ///
+    /// assert!(ArgNames::default().is_empty());
+    /// assert!(!ArgNames::new(["a"]).is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
 
 /// Represents a payload that needs the type to be extracted from
 pub(crate) enum Payload<'a> {
@@ -27,7 +230,7 @@ pub(crate) enum Source {
     Meta,
 }
 
-/// A trait that type needs to implement to be extractable from [`Request`]
+/// A trait that type needs to implement to be extractable from [`crate::types::Request`]
 pub(crate) trait RequestArgument: Sized {
     type Error;
 
@@ -39,6 +242,42 @@ pub(crate) trait RequestArgument: Sized {
     fn source() -> Source {
         Source::Args
     }
+}
+
+/// The parts of a request's params that argument extraction reads.
+///
+/// Implemented by `tools/call` and `prompts/get` params so both share one set
+/// of tuple extraction impls.
+pub(crate) trait HandlerArgs {
+    /// Splits the params into its `arguments` map and its `_meta`.
+    fn into_parts(self) -> (Option<HashMap<String, Value>>, Option<RequestParamsMeta>);
+}
+
+/// Builds a handler's argument tuple from the params of a `tools/call` or
+/// `prompts/get` request.
+///
+/// This is the extraction counterpart of [`ArgNames`]: `P` carries the values
+/// a peer sent, `names` says which name each handler slot reads.
+///
+/// # Examples
+///
+/// ```
+/// use neva::types::{ArgNames, CallToolRequestParams, FromHandlerArgs};
+/// use serde_json::json;
+///
+/// // A peer may send the arguments in any order -- extraction is by name.
+/// let params = CallToolRequestParams::new("greet")
+///     .with_args([("age", json!(30)), ("name", json!("John"))]);
+///
+/// let (name, age) = <(String, i32)>::from_args(params, &ArgNames::new(["name", "age"]))?;
+///
+/// assert_eq!(name, "John");
+/// assert_eq!(age, 30);
+/// # Ok::<(), neva::error::Error>(())
+/// ```
+pub trait FromHandlerArgs<P>: Sized {
+    /// Extracts the handler's arguments from `params`.
+    fn from_args(params: P, names: &ArgNames) -> Result<Self, Error>;
 }
 
 impl<'a> Payload<'a> {
@@ -148,21 +387,104 @@ impl RequestArgument for Context {
     }
 }
 
+/// Extracts one handler argument.
+///
+/// Metadata-sourced types read `meta` and leave `slot` alone; everything else
+/// consumes the next name and reads the value a peer sent under it. An absent
+/// key is offered to the type as `null`, so an `Option<T>` argument resolves
+/// to `None` instead of failing.
 #[inline]
 pub(crate) fn extract_arg<T: RequestArgument<Error = Error>>(
     meta: &Option<RequestParamsMeta>,
-    iter: &mut Iter<'_, String, serde_json::Value>,
+    args: Option<&HashMap<String, Value>>,
+    names: &ArgNames,
+    slot: &mut usize,
 ) -> Result<T, Error> {
     match T::source() {
         Source::Meta => T::extract(Payload::Meta(meta)),
-        Source::Args => T::extract(Payload::Args(
-            iter.next()
-                .ok_or(Error::new(
-                    ErrorCode::InvalidParams,
-                    "Invalid param provided",
-                ))?
-                .1
-                .clone(),
-        )),
+        Source::Args => {
+            let name = names.get(*slot);
+            *slot += 1;
+            match args.and_then(|args| args.get(name)) {
+                Some(value) => T::extract(Payload::Args(value.clone())).map_err(|err| {
+                    Error::new(
+                        ErrorCode::InvalidParams,
+                        format!("invalid value for argument `{name}`: {err}"),
+                    )
+                }),
+                None => T::extract(Payload::Args(Value::Null)).map_err(|_| {
+                    Error::new(
+                        ErrorCode::InvalidParams,
+                        format!("missing required argument `{name}`"),
+                    )
+                }),
+            }
+        }
+    }
+}
+
+impl<P: HandlerArgs> FromHandlerArgs<P> for () {
+    #[inline]
+    fn from_args(_: P, _: &ArgNames) -> Result<Self, Error> {
+        Ok(())
+    }
+}
+
+macro_rules! impl_from_handler_args {
+    ($($T:ident),+) => {
+        impl<P: HandlerArgs, $($T: RequestArgument<Error = Error>),+> FromHandlerArgs<P> for ($($T,)+) {
+            #[inline]
+            fn from_args(params: P, names: &ArgNames) -> Result<Self, Error> {
+                let (args, meta) = params.into_parts();
+                let args = args.as_ref();
+                // Tuple elements are evaluated left to right, so `slot` walks
+                // the declared names in the handler's own parameter order.
+                let mut slot = 0;
+                let tuple = (
+                    $(
+                        extract_arg::<$T>(&meta, args, names, &mut slot)?,
+                    )+
+                );
+                Ok(tuple)
+            }
+        }
+    };
+}
+
+impl_from_handler_args! { T1 }
+impl_from_handler_args! { T1, T2 }
+impl_from_handler_args! { T1, T2, T3 }
+impl_from_handler_args! { T1, T2, T3, T4 }
+impl_from_handler_args! { T1, T2, T3, T4, T5 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_returns_declared_names() {
+        let names = ArgNames::new(["age", "name"]);
+
+        assert_eq!(names.get(0), "age");
+        assert_eq!(names.get(1), "name");
+        assert_eq!(names.len(), 2);
+        assert!(!names.is_empty());
+    }
+
+    #[test]
+    fn it_falls_back_to_positional_names() {
+        let names = ArgNames::default();
+
+        assert_eq!(names.get(0), "arg0");
+        assert_eq!(names.get(4), "arg4");
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn it_falls_back_past_the_declared_names() {
+        let names = ArgNames::new(["age"]);
+
+        assert_eq!(names.get(0), "age");
+        assert_eq!(names.get(1), "arg1");
     }
 }

--- a/neva/src/types/helpers/extract.rs
+++ b/neva/src/types/helpers/extract.rs
@@ -198,6 +198,19 @@ impl ArgNames {
         }
     }
 
+    /// The slot `name` belongs to, if it names one.
+    ///
+    /// The inverse of [`Self::get`]: the declared names when there are any,
+    /// the positional fallback otherwise.
+    #[inline]
+    pub(crate) fn slot_of(&self, name: &str) -> Option<usize> {
+        match self.names.as_deref() {
+            Some(names) => names.iter().position(|declared| &**declared == name),
+            None => positional_slot(name),
+        }
+        .filter(|slot| *slot < self.arity)
+    }
+
     /// The first name declared more than once, if any.
     ///
     /// Two slots reading the same key is not a mistake that announces itself:

--- a/neva/src/types/helpers/macros.rs
+++ b/neva/src/types/helpers/macros.rs
@@ -63,6 +63,22 @@ impl_type_category!(GetPromptRequestParams, PropertyType::None);
 impl_type_category!(Meta<T>, T, PropertyType::None);
 impl_type_category!(crate::Context, PropertyType::None);
 
+// An optional argument is the inner type's property, minus the obligation to
+// supply it. Implemented manually because the category is delegated rather
+// than fixed, and because `is_optional` is overridden.
+impl<T: TypeCategory> super::sealed::TypeCategorySealed for Option<T> {}
+impl<T: TypeCategory> TypeCategory for Option<T> {
+    #[inline]
+    fn category() -> PropertyType {
+        T::category()
+    }
+
+    #[inline]
+    fn is_optional() -> bool {
+        true
+    }
+}
+
 // DI extractor: injected from the request context, never a tool/prompt argument.
 // Implemented manually (not via `impl_type_category!`) because `Dc<T>` carries a
 // `T: Send + Sync` bound the macro form cannot express.

--- a/neva/src/types/prompt.rs
+++ b/neva/src/types/prompt.rs
@@ -502,9 +502,37 @@ impl Prompt {
         A: Into<PromptArgument>,
     {
         let args = args.into_iter().map(Into::into).collect::<Vec<_>>();
-        self.arg_names = arg_names(&args);
+        // `declare` keeps the handler's own arity rather than adopting the
+        // length of this list, so a list that does not cover every argument
+        // stays detectable instead of silently leaving the trailing parameters
+        // reading unpublished `argN` keys.
+        self.arg_names = self
+            .arg_names
+            .declare(args.iter().map(|arg| arg.name.as_str()));
+
         self.args = Some(args);
         self
+    }
+
+    /// Describes how the prompt's published argument list and its handler
+    /// disagree, if they do.
+    ///
+    /// The list is what peers are told to send *and* what extraction reads by,
+    /// so one that does not cover every argument the handler takes leaves the
+    /// trailing parameters reading keys no peer was ever asked for. Worth
+    /// catching at startup rather than on a peer's first request.
+    pub(crate) fn arg_name_conflict(&self) -> Option<String> {
+        let arity = self.arg_names.arity();
+        let declared = self.arg_names.len();
+
+        (self.arg_names.is_declared() && declared != arity).then(|| {
+            format!(
+                "prompt `{}` publishes {declared} argument(s) but its handler takes {arity}. \
+                 List every argument the handler reads, metadata parameters (`Context`, \
+                 `Meta<_>`, `Dc<_>`) excluded.",
+                self.name,
+            )
+        })
     }
 
     /// Sets the [`Prompt`] icons

--- a/neva/src/types/prompt.rs
+++ b/neva/src/types/prompt.rs
@@ -7,9 +7,9 @@ use crate::error::{Error, ErrorCode};
 use crate::shared;
 #[cfg(feature = "server")]
 use crate::shared::BoxFuture;
-#[cfg(feature = "server")]
-use crate::types::FromRequest;
 use crate::types::request::RequestParamsMeta;
+#[cfg(feature = "server")]
+use crate::types::{ArgNames, FromHandlerArgs, FromRequest};
 use crate::types::{Cursor, Icon};
 #[cfg(feature = "server")]
 use crate::types::{IntoResponse, Page, PropertyType, Request, RequestId, Response};
@@ -100,6 +100,15 @@ pub struct Prompt {
     #[serde(skip)]
     #[cfg(feature = "http-server")]
     pub(crate) permissions: Option<Vec<String>>,
+
+    /// The names the handler's arguments are read from `arguments` by.
+    ///
+    /// Server-side only, and always kept in step with [`Self::args`] -- the
+    /// argument list a peer sees is the one extraction reads by. See
+    /// [`Prompt::with_args`].
+    #[serde(skip)]
+    #[cfg(feature = "server")]
+    pub(crate) arg_names: ArgNames,
 }
 
 /// Describes an argument that a prompt can accept.
@@ -317,7 +326,11 @@ impl<T: Into<String>> From<(T, T, bool)> for PromptArgument {
 /// Describes a generic get prompt handler
 #[cfg(feature = "server")]
 pub trait PromptHandler<Args>: GenericHandler<Args> {
-    /// Returns a prompt arguments schema
+    /// Returns the handler's value-carrying arguments, in declaration order.
+    ///
+    /// Parameters extracted from request metadata ([`crate::types::Meta`],
+    /// [`Context`], DI) are not arguments and do not appear here, so the
+    /// position in this list is the slot [`ArgNames`] indexes.
     #[inline]
     fn args() -> Option<Vec<PromptArgument>> {
         None
@@ -330,7 +343,7 @@ where
     F: PromptHandler<Args, Output = R>,
     R: TryInto<GetPromptResult>,
     R::Error: Into<Error>,
-    Args: TryFrom<GetPromptRequestParams, Error = Error>,
+    Args: FromHandlerArgs<GetPromptRequestParams>,
 {
     func: F,
     _marker: std::marker::PhantomData<Args>,
@@ -342,7 +355,7 @@ where
     F: PromptHandler<Args, Output = R>,
     R: TryInto<GetPromptResult>,
     R::Error: Into<Error>,
-    Args: TryFrom<GetPromptRequestParams, Error = Error>,
+    Args: FromHandlerArgs<GetPromptRequestParams>,
 {
     /// Creates a new [`PromptFunc`] wrapped into [`Arc`]
     pub(crate) fn new(func: F) -> Arc<Self> {
@@ -360,15 +373,15 @@ where
     F: PromptHandler<Args, Output = R>,
     R: TryInto<GetPromptResult>,
     R::Error: Into<Error>,
-    Args: TryFrom<GetPromptRequestParams, Error = Error> + Send + Sync,
+    Args: FromHandlerArgs<GetPromptRequestParams> + Send + Sync,
 {
     #[inline]
     fn call(&self, params: HandlerParams) -> BoxFuture<'_, Result<GetPromptResult, Error>> {
-        let HandlerParams::Prompt(params) = params else {
+        let HandlerParams::Prompt(params, names) = params else {
             unreachable!()
         };
         Box::pin(async move {
-            let args = Args::try_from(params)?;
+            let args = Args::from_args(params, &names)?;
             self.func.call(args).await.try_into().map_err(Into::into)
         })
     }
@@ -421,7 +434,7 @@ impl Prompt {
         F: PromptHandler<Args, Output = R>,
         R: TryInto<GetPromptResult> + Send + 'static,
         R::Error: Into<Error>,
-        Args: TryFrom<GetPromptRequestParams, Error = Error> + Send + Sync + 'static,
+        Args: FromHandlerArgs<GetPromptRequestParams> + Send + Sync + 'static,
     {
         let handler = PromptFunc::new(handler);
         let args = F::args();
@@ -430,6 +443,7 @@ impl Prompt {
             title: None,
             descr: None,
             meta: None,
+            arg_names: args.as_deref().map(arg_names).unwrap_or_default(),
             args,
             handler: Some(handler),
             #[cfg(feature = "http-server")]
@@ -453,12 +467,43 @@ impl Prompt {
     }
 
     /// Sets arguments for the [`Prompt`]
+    ///
+    /// The list is both what a peer sees in `prompts/list` and what the
+    /// handler's arguments are extracted by: the *n*-th argument here names
+    /// the value the handler's *n*-th value-carrying parameter reads. Setting
+    /// it therefore cannot leave the published arguments and the handler
+    /// disagreeing.
+    ///
+    /// Parameters served from request metadata -- [`crate::types::Meta`],
+    /// [`Context`], a DI-injected `Dc<T>` -- are not arguments and are not
+    /// listed here. An `Option<T>` parameter is: list it with
+    /// [`PromptArgument::optional`] or [`PromptArgument::named`] so peers know
+    /// they may leave it out.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::{App, types::Role};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let mut app = App::new();
+    ///
+    /// app.map_prompt("analyze", |lang: String, code: String| async move {
+    ///     (format!("Analyze this {lang} code: {code}"), Role::User)
+    /// })
+    /// .with_args(["lang", "code"]);
+    ///
+    /// # app.run().await;
+    /// # }
+    /// ```
     pub fn with_args<T, A>(&mut self, args: T) -> &mut Self
     where
         T: IntoIterator<Item = A>,
         A: Into<PromptArgument>,
     {
-        self.args = Some(args.into_iter().map(Into::into).collect());
+        let args = args.into_iter().map(Into::into).collect::<Vec<_>>();
+        self.arg_names = arg_names(&args);
+        self.args = Some(args);
         self
     }
 
@@ -492,15 +537,29 @@ impl Prompt {
 
     /// Get prompt result
     #[inline]
-    pub(crate) async fn call(&self, params: HandlerParams) -> Result<GetPromptResult, Error> {
+    pub(crate) async fn call(
+        &self,
+        params: GetPromptRequestParams,
+    ) -> Result<GetPromptResult, Error> {
         match self.handler {
-            Some(ref handler) => handler.call(params).await,
+            Some(ref handler) => {
+                handler
+                    .call(HandlerParams::Prompt(params, self.arg_names.clone()))
+                    .await
+            }
             None => Err(Error::new(
                 ErrorCode::InternalError,
                 "Prompt handler not specified",
             )),
         }
     }
+}
+
+/// The extraction names of a prompt's declared arguments, in order.
+#[cfg(feature = "server")]
+#[inline]
+fn arg_names(args: &[PromptArgument]) -> ArgNames {
+    ArgNames::new(args.iter().map(|arg| arg.name.as_str()))
 }
 
 /// Prompt arguments helper
@@ -519,12 +578,35 @@ impl PromptArguments {
 
 #[cfg(feature = "server")]
 impl PromptArgument {
-    /// Creates a new [`PromptArgument`]
-    pub(crate) fn new<T>() -> Self {
+    /// Creates the [`PromptArgument`] for the `slot`-th argument of a handler
+    /// whose parameter names are not known -- a bare closure.
+    ///
+    /// The positional name is what the prompt publishes *and* what extraction
+    /// reads by; [`Prompt::with_args`] replaces both together.
+    pub(crate) fn positional(slot: usize, required: bool) -> Self {
+        Self::named(
+            crate::types::helpers::extract::positional_name(slot),
+            required,
+        )
+    }
+
+    /// Creates a [`PromptArgument`] with no description.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use neva::types::prompt::PromptArgument;
+    ///
+    /// let arg = PromptArgument::named("tone", false);
+    ///
+    /// assert_eq!(arg.name, "tone");
+    /// assert_eq!(arg.required, Some(false));
+    /// ```
+    pub fn named<T: Into<String>>(name: T, required: bool) -> Self {
         Self {
-            name: std::any::type_name::<T>().into(),
+            name: name.into(),
             descr: None,
-            required: Some(true),
+            required: Some(required),
         }
     }
 
@@ -557,15 +639,20 @@ macro_rules! impl_generic_prompt_handler ({ $($param:ident)* } => {
         #[inline]
         #[allow(unused_mut)]
         fn args() -> Option<Vec<PromptArgument>> {
-            let mut args = Vec::new();
+            let mut args: Vec<PromptArgument> = Vec::new();
             $(
             {
+                // Metadata-served parameters are not arguments: they are
+                // neither published nor do they consume an argument slot.
                 if $param::category() != PropertyType::None {
-                    args.push(PromptArgument::new::<$param>());
+                    args.push(PromptArgument::positional(
+                        args.len(),
+                        !$param::is_optional(),
+                    ));
                 }
             }
             )*
-            if args.len() == 0 {
+            if args.is_empty() {
                 None
             } else {
                 Some(args)

--- a/neva/src/types/prompt.rs
+++ b/neva/src/types/prompt.rs
@@ -522,14 +522,26 @@ impl Prompt {
     /// trailing parameters reading keys no peer was ever asked for. Worth
     /// catching at startup rather than on a peer's first request.
     pub(crate) fn arg_name_conflict(&self) -> Option<String> {
+        if !self.arg_names.is_declared() {
+            return None;
+        }
+
         let arity = self.arg_names.arity();
         let declared = self.arg_names.len();
-
-        (self.arg_names.is_declared() && declared != arity).then(|| {
-            format!(
+        if declared != arity {
+            return Some(format!(
                 "prompt `{}` publishes {declared} argument(s) but its handler takes {arity}. \
                  List every argument the handler reads, metadata parameters (`Context`, \
                  `Meta<_>`, `Dc<_>`) excluded.",
+                self.name,
+            ));
+        }
+
+        self.arg_names.duplicate().map(|duplicate| {
+            format!(
+                "prompt `{}` publishes the argument `{duplicate}` twice. Arguments are read \
+                 from a request by name, so two parameters sharing one name would both be \
+                 handed the same value.",
                 self.name,
             )
         })

--- a/neva/src/types/prompt/from_request.rs
+++ b/neva/src/types/prompt/from_request.rs
@@ -1,38 +1,69 @@
 use super::GetPromptRequestParams;
-use crate::error::Error;
-use crate::types::helpers::extract::{RequestArgument, extract_arg};
+use crate::types::helpers::extract::HandlerArgs;
+use crate::types::request::RequestParamsMeta;
+use serde_json::Value;
+use std::collections::HashMap;
 
-impl TryFrom<GetPromptRequestParams> for () {
-    type Error = Error;
-
+impl HandlerArgs for GetPromptRequestParams {
     #[inline]
-    fn try_from(_: GetPromptRequestParams) -> Result<Self, Self::Error> {
-        Ok(())
+    fn into_parts(self) -> (Option<HashMap<String, Value>>, Option<RequestParamsMeta>) {
+        (self.args, self.meta)
     }
 }
 
-macro_rules! impl_from_get_prompt_params {
-    ($($T: ident),*) => {
-        impl<$($T: RequestArgument<Error = Error>),+> TryFrom<GetPromptRequestParams> for ($($T,)+) {
-            type Error = Error;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ArgNames, FromHandlerArgs};
+    use serde_json::json;
 
-            #[inline]
-            fn try_from(params: GetPromptRequestParams) -> Result<Self, Self::Error> {
-                let args = params.args.unwrap_or_default();
-                let mut iter = args.iter();
-                let tuple = (
-                    $(
-                        extract_arg::<$T>(&params.meta, &mut iter)?,
-                    )*
-                );
-                Ok(tuple)
-            }
-        }
+    #[test]
+    fn it_publishes_an_optional_arg_as_not_required() {
+        use crate::types::prompt::Prompt;
+
+        let prompt = Prompt::new(
+            "analyze",
+            |topic: String, tone: Option<String>| async move {
+                (format!("{topic}/{tone:?}"), crate::types::Role::User)
+            },
+        );
+        let args = prompt.args.as_ref().unwrap();
+
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0].required, Some(true));
+        assert_eq!(args[1].required, Some(false));
+    }
+
+    #[test]
+    fn it_resolves_an_absent_optional_arg_to_none() {
+        let params = GetPromptRequestParams {
+            name: "analyze".into(),
+            args: Some(HashMap::from([("topic".into(), json!("rust"))])),
+            meta: None,
+        };
+
+        let (topic, tone): (String, Option<String>) =
+            FromHandlerArgs::from_args(params, &ArgNames::new(["topic", "tone"])).unwrap();
+
+        assert_eq!(topic, "rust");
+        assert_eq!(tone, None);
+    }
+
+    #[test]
+    fn it_extracts_args_by_declared_name() {
+        let params = GetPromptRequestParams {
+            name: "prompt".into(),
+            args: Some(HashMap::from([
+                ("tone".into(), json!("formal")),
+                ("topic".into(), json!("rust")),
+            ])),
+            meta: None,
+        };
+
+        let (topic, tone): (String, String) =
+            FromHandlerArgs::from_args(params, &ArgNames::new(["topic", "tone"])).unwrap();
+
+        assert_eq!(topic, "rust");
+        assert_eq!(tone, "formal");
     }
 }
-
-impl_from_get_prompt_params! { T1 }
-impl_from_get_prompt_params! { T1, T2 }
-impl_from_get_prompt_params! { T1, T2, T3 }
-impl_from_get_prompt_params! { T1, T2, T3, T4 }
-impl_from_get_prompt_params! { T1, T2, T3, T4, T5 }

--- a/neva/src/types/schema_2020.rs
+++ b/neva/src/types/schema_2020.rs
@@ -308,6 +308,9 @@ pub fn primitive_subschema(ty: &str) -> Value {
 /// property pairs and a list of required property names. Used by the `#[tool]`
 /// macro so generated code only ever names `neva::` paths. Uses the
 /// unconditional `From<Value>` (no `server` feature required).
+///
+/// A tool whose arguments are all optional gets no `required` key at all
+/// rather than an empty array, matching what the non-macro path publishes.
 #[cfg(not(feature = "legacy-spec"))]
 #[doc(hidden)]
 pub fn object_schema(properties: Vec<(String, Value)>, required: Vec<String>) -> InputSchema {
@@ -318,10 +321,12 @@ pub fn object_schema(properties: Vec<(String, Value)>, required: Vec<String>) ->
     let mut root = serde_json::Map::with_capacity(3);
     root.insert("type".to_string(), Value::String("object".to_string()));
     root.insert("properties".to_string(), Value::Object(props));
-    root.insert(
-        "required".to_string(),
-        Value::Array(required.into_iter().map(Value::String).collect()),
-    );
+    if !required.is_empty() {
+        root.insert(
+            "required".to_string(),
+            Value::Array(required.into_iter().map(Value::String).collect()),
+        );
+    }
     InputSchema::from(Value::Object(root))
 }
 

--- a/neva/src/types/schema_2020.rs
+++ b/neva/src/types/schema_2020.rs
@@ -135,7 +135,7 @@ impl InputSchema {
     /// ```
     #[inline]
     pub fn from_value(value: Value) -> Self {
-        Self(value)
+        Self(value).with_object_type()
     }
 
     /// Parses an [`InputSchema`] from a JSON string.
@@ -158,7 +158,7 @@ impl InputSchema {
     #[inline]
     pub fn from_json_str(json: &str) -> Result<Self, crate::error::Error> {
         let value: Value = serde_json::from_str(json)?;
-        Ok(Self(value))
+        Ok(Self(value).with_object_type())
     }
 
     /// Creates an [`InputSchema`] from a type that implements
@@ -194,16 +194,44 @@ impl InputSchema {
     /// tool without going through the `schema_for!` macro.
     #[inline]
     pub fn from_schemars(schema: schemars::Schema) -> Self {
-        Self(schema.to_value())
+        Self(schema.to_value()).with_object_type()
     }
 }
 
 impl From<Value> for InputSchema {
-    /// Wraps any [`serde_json::Value`] as an [`InputSchema`]. The value
-    /// is stored verbatim.
+    /// Wraps any [`serde_json::Value`] as an [`InputSchema`], supplying the
+    /// `"type": "object"` discriminator MCP requires when the document is an
+    /// object schema that omitted it. An explicit `type` is left as written,
+    /// and a boolean schema has no key to add.
     #[inline]
     fn from(value: Value) -> Self {
-        Self(value)
+        Self(value).with_object_type()
+    }
+}
+
+impl InputSchema {
+    /// Supplies the `"type": "object"` discriminator when the document is an
+    /// object schema that left it out.
+    ///
+    /// MCP requires a tool's `inputSchema` and `outputSchema` to be *object*
+    /// schemas, and a conforming client validates that: a hand-written schema
+    /// that lists `properties` but never says `"type": "object"` makes the
+    /// whole `tools/list` result fail validation, taking the tools that were
+    /// fine down with it. Rather than publish a document neva's own docs call
+    /// invalid, the discriminator every such schema meant to carry is filled
+    /// in.
+    ///
+    /// An explicit `type` is left alone, whatever it says -- this fills a gap,
+    /// it does not overrule the author -- and a boolean schema (`true` /
+    /// `false`) is not an object to add a key to.
+    #[inline]
+    fn with_object_type(mut self) -> Self {
+        if let Value::Object(schema) = &mut self.0
+            && !schema.contains_key("type")
+        {
+            schema.insert("type".to_string(), Value::String("object".to_string()));
+        }
+        self
     }
 }
 
@@ -213,7 +241,7 @@ impl From<schemars::Schema> for InputSchema {
     /// its underlying JSON [`Value`].
     #[inline]
     fn from(schema: schemars::Schema) -> Self {
-        Self(schema.to_value())
+        Self(schema.to_value()).with_object_type()
     }
 }
 
@@ -350,6 +378,48 @@ macro_rules! __tool_arg_subschema {
 
 #[cfg(test)]
 mod tests {
+    /// MCP requires a tool's `inputSchema`/`outputSchema` to be an *object*
+    /// schema, and a conforming client validates it: MCP Inspector rejects a
+    /// whole `tools/list` result over one schema that lists `properties` but
+    /// never says so. A hand-written schema that left the discriminator out
+    /// gets it supplied rather than published as-is.
+    #[test]
+    fn it_supplies_the_object_type_a_hand_written_schema_omitted() {
+        let schema = InputSchema::from(json!({
+            "properties": { "name": { "type": "string" } },
+            "required": ["name"]
+        }));
+
+        assert_eq!(schema.as_value()["type"], "object");
+        assert_eq!(schema.as_value()["required"][0], "name");
+    }
+
+    #[cfg(feature = "server")]
+    #[test]
+    fn it_supplies_the_object_type_when_parsed_from_a_string() {
+        let schema = InputSchema::from_json_str(r#"{"properties":{"q":{"type":"string"}}}"#)
+            .expect("valid JSON");
+
+        assert_eq!(schema.as_value()["type"], "object");
+    }
+
+    /// Filling a gap is not the same as overruling the author: an explicit
+    /// type stays exactly as written, whatever it says.
+    #[test]
+    fn it_leaves_an_explicit_type_alone() {
+        for declared in ["string", "array", "object"] {
+            let schema = InputSchema::from(json!({ "type": declared }));
+            assert_eq!(schema.as_value()["type"], declared);
+        }
+    }
+
+    /// A boolean schema is not an object, so there is no key to add.
+    #[test]
+    fn it_leaves_a_boolean_schema_alone() {
+        assert_eq!(InputSchema::from(json!(true)).as_value(), &json!(true));
+        assert_eq!(InputSchema::from(json!(false)).as_value(), &json!(false));
+    }
+
     use super::*;
     use serde_json::json;
 

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -12,7 +12,9 @@ use std::fmt::{Debug, Formatter};
 use {
     super::helpers::TypeCategory,
     crate::shared::BoxFuture,
-    crate::types::{FromRequest, IntoResponse, Page, Request, RequestId, Response},
+    crate::types::{
+        ArgNames, FromHandlerArgs, FromRequest, IntoResponse, Page, Request, RequestId, Response,
+    },
     crate::{
         Context,
         app::handler::{FromHandlerParams, GenericHandler, Handler, HandlerParams, RequestHandler},
@@ -131,6 +133,14 @@ pub struct Tool {
     #[serde(skip)]
     #[cfg(feature = "server")]
     handler: Option<RequestHandler<CallToolResponse>>,
+
+    /// The names the handler's arguments are read from `arguments` by.
+    ///
+    /// Server-side only: it is the property names of [`Self::input_schema`]
+    /// that a peer sees. See [`Tool::with_arg_names`].
+    #[serde(skip)]
+    #[cfg(feature = "server")]
+    pub(crate) arg_names: ArgNames,
 }
 
 /// Execution-related properties for a tool.
@@ -272,6 +282,24 @@ pub struct SchemaProperty {
     /// A Human-readable description of a property
     #[serde(rename = "description", skip_serializing_if = "Option::is_none")]
     pub descr: Option<String>,
+}
+
+/// One value-carrying argument of a tool handler.
+///
+/// Produced by [`ToolHandler::args`] in the handler's own parameter order and
+/// turned into the tool's `inputSchema`: the property under the argument's
+/// name, listed in `required` unless the parameter is an `Option<T>`.
+#[cfg(feature = "server")]
+#[derive(Debug, Clone)]
+pub struct ToolArg {
+    /// The schema property published for the argument.
+    pub property: SchemaProperty,
+
+    /// Whether a call must supply the argument.
+    ///
+    /// `false` for an `Option<T>` parameter, which resolves to `None` when a
+    /// call leaves it out.
+    pub required: bool,
 }
 
 /// Additional properties describing a Tool to clients.
@@ -436,11 +464,14 @@ impl From<String> for TaskSupport {
 impl ToolSchema {
     /// Creates a new [`ToolSchema`] object
     #[inline]
-    pub(crate) fn new(props: Option<HashMap<String, SchemaProperty>>) -> Self {
+    pub(crate) fn new(
+        props: Option<HashMap<String, SchemaProperty>>,
+        required: Option<Vec<String>>,
+    ) -> Self {
         Self {
             r#type: PropertyType::Object,
             properties: props,
-            required: None,
+            required,
         }
     }
 
@@ -665,10 +696,16 @@ impl FromHandlerParams for ListToolsRequestParams {
 /// Describes a generic MCP Tool handler
 #[cfg(feature = "server")]
 pub trait ToolHandler<Args>: GenericHandler<Args> {
-    /// Returns a tool arguments schema
+    /// Returns the handler's value-carrying arguments, in declaration order.
+    ///
+    /// Parameters extracted from request metadata ([`crate::types::Meta`],
+    /// [`Context`], DI) are not arguments and do not appear here, so the
+    /// position in this list is the slot [`crate::types::ArgNames`] indexes.
+    /// An `Option<T>` parameter *is* an argument -- it occupies a slot and is
+    /// published -- it is simply not required.
     #[inline]
-    fn args() -> Option<HashMap<String, SchemaProperty>> {
-        None
+    fn args() -> Vec<ToolArg> {
+        Vec::new()
     }
 }
 
@@ -677,7 +714,7 @@ pub(crate) struct ToolFunc<F, R, Args>
 where
     F: ToolHandler<Args, Output = R>,
     R: Into<CallToolResponse>,
-    Args: TryFrom<CallToolRequestParams, Error = Error>,
+    Args: FromHandlerArgs<CallToolRequestParams>,
 {
     func: F,
     _marker: std::marker::PhantomData<Args>,
@@ -688,7 +725,7 @@ impl<F, R, Args> ToolFunc<F, R, Args>
 where
     F: ToolHandler<Args, Output = R>,
     R: Into<CallToolResponse>,
-    Args: TryFrom<CallToolRequestParams, Error = Error>,
+    Args: FromHandlerArgs<CallToolRequestParams>,
 {
     /// Creates a new [`ToolFunc`] wrapped into [`Arc`]
     pub(crate) fn new(func: F) -> Arc<Self> {
@@ -705,15 +742,15 @@ impl<F, R, Args> Handler<CallToolResponse> for ToolFunc<F, R, Args>
 where
     F: ToolHandler<Args, Output = R>,
     R: Into<CallToolResponse>,
-    Args: TryFrom<CallToolRequestParams, Error = Error> + Send + Sync,
+    Args: FromHandlerArgs<CallToolRequestParams> + Send + Sync,
 {
     #[inline]
     fn call(&self, params: HandlerParams) -> BoxFuture<'_, Result<CallToolResponse, Error>> {
-        let HandlerParams::Tool(params) = params else {
+        let HandlerParams::Tool(params, names) = params else {
             unreachable!()
         };
         Box::pin(async move {
-            let args = Args::try_from(params)?;
+            let args = Args::from_args(params, &names)?;
             Ok(self.func.call(args).await.into())
         })
     }
@@ -783,43 +820,113 @@ impl Debug for Tool {
     }
 }
 
-/// Builds a [`crate::types::ToolInputSchema`] from the typed argument map
-/// produced by [`ToolHandler::args`].
+/// Builds a [`crate::types::ToolInputSchema`] from the ordered argument list
+/// produced by [`ToolHandler::args`], naming the *n*-th property after the
+/// *n*-th entry of `names`.
 ///
-/// Under `legacy-spec` this returns the typed legacy `ToolSchema`
-/// verbatim. In the default (MCP 2026-07-28) build the legacy
-/// `ToolSchema` struct is absent, so this constructs an
-/// [`crate::types::schema_2020::InputSchema`] directly from the
-/// `Option<HashMap<String, SchemaProperty>>` by serializing each
-/// [`SchemaProperty`] into a `serde_json::Value` and wrapping the result
-/// as a JSON Schema 2020-12 object schema. The same call site at
+/// Naming the properties from the very [`ArgNames`] extraction reads by is
+/// what keeps the published schema and the handler in agreement: a peer is
+/// told to send exactly the keys the handler will look for.
+///
+/// Under `legacy-spec` this returns the typed legacy `ToolSchema`. In the
+/// default (MCP 2026-07-28) build the legacy `ToolSchema` struct is absent, so
+/// this constructs an [`crate::types::schema_2020::InputSchema`] by
+/// serializing each [`SchemaProperty`] into a `serde_json::Value` and wrapping
+/// the result as a JSON Schema 2020-12 object schema. The same call site at
 /// [`Tool::new`] compiles under either feature set.
 #[cfg(feature = "server")]
 #[inline]
 fn build_input_schema_from_args(
-    args: Option<HashMap<String, SchemaProperty>>,
+    args: &[ToolArg],
+    names: &ArgNames,
 ) -> crate::types::ToolInputSchema {
     #[cfg(feature = "legacy-spec")]
     {
-        ToolSchema::new(args)
+        if args.is_empty() {
+            return ToolSchema::new(None, None);
+        }
+        let props = args
+            .iter()
+            .enumerate()
+            .map(|(idx, arg)| (names.get(idx).to_owned(), arg.property.clone()))
+            .collect::<HashMap<_, _>>();
+        let required = args
+            .iter()
+            .enumerate()
+            .filter(|(_, arg)| arg.required)
+            .map(|(idx, _)| names.get(idx).to_owned())
+            .collect::<Vec<_>>();
+        let required = (!required.is_empty()).then_some(required);
+        ToolSchema::new(Some(props), required)
     }
     #[cfg(not(feature = "legacy-spec"))]
     {
         use serde_json::{Map, Value, json};
-        let properties = args
-            .as_ref()
-            .map(|m| {
-                let mut obj = Map::with_capacity(m.len());
-                for (k, v) in m {
-                    let v_json =
-                        serde_json::to_value(v).unwrap_or_else(|_| Value::Object(Map::new()));
-                    obj.insert(k.clone(), v_json);
-                }
-                Value::Object(obj)
-            })
-            .unwrap_or_else(|| Value::Object(Map::new()));
-        let value = json!({ "type": "object", "properties": properties });
+        let mut properties = Map::with_capacity(args.len());
+        let mut required = Vec::with_capacity(args.len());
+        for (idx, arg) in args.iter().enumerate() {
+            let name = names.get(idx);
+            let prop =
+                serde_json::to_value(&arg.property).unwrap_or_else(|_| Value::Object(Map::new()));
+            properties.insert(name.to_owned(), prop);
+            if arg.required {
+                required.push(Value::String(name.to_owned()));
+            }
+        }
+        let value = if required.is_empty() {
+            json!({ "type": "object", "properties": properties })
+        } else {
+            json!({ "type": "object", "properties": properties, "required": required })
+        };
         crate::types::schema_2020::InputSchema::from(value)
+    }
+}
+
+/// Renames the auto-generated positional properties of `schema` to `names`.
+///
+/// Only the `argN` keys [`build_input_schema_from_args`] produced are touched,
+/// so a hand-written schema (which has none) passes through untouched.
+#[cfg(feature = "server")]
+#[inline]
+fn rename_positional_props(schema: &mut crate::types::ToolInputSchema, names: &ArgNames) {
+    use crate::types::helpers::extract::{positional_name, positional_slot};
+
+    #[cfg(feature = "legacy-spec")]
+    {
+        if let Some(props) = schema.properties.as_mut() {
+            for slot in 0..names.len() {
+                if let Some(prop) = props.remove(positional_name(slot)) {
+                    props.insert(names.get(slot).to_owned(), prop);
+                }
+            }
+        }
+        if let Some(required) = schema.required.as_mut() {
+            for name in required.iter_mut() {
+                if let Some(slot) = positional_slot(name) {
+                    *name = names.get(slot).to_owned();
+                }
+            }
+        }
+    }
+    #[cfg(not(feature = "legacy-spec"))]
+    {
+        let Some(schema) = schema.0.as_object_mut() else {
+            return;
+        };
+        if let Some(props) = schema.get_mut("properties").and_then(Value::as_object_mut) {
+            for slot in 0..names.len() {
+                if let Some(prop) = props.remove(positional_name(slot)) {
+                    props.insert(names.get(slot).to_owned(), prop);
+                }
+            }
+        }
+        if let Some(required) = schema.get_mut("required").and_then(Value::as_array_mut) {
+            for name in required.iter_mut() {
+                if let Some(slot) = name.as_str().and_then(positional_slot) {
+                    *name = Value::String(names.get(slot).to_owned());
+                }
+            }
+        }
     }
 }
 
@@ -830,10 +937,12 @@ impl Tool {
     where
         F: ToolHandler<Args, Output = R>,
         R: Into<CallToolResponse> + Send + 'static,
-        Args: TryFrom<CallToolRequestParams, Error = Error> + Send + Sync + 'static,
+        Args: FromHandlerArgs<CallToolRequestParams> + Send + Sync + 'static,
     {
         let handler = ToolFunc::new(handler);
-        let input_schema = build_input_schema_from_args(F::args());
+        let args = F::args();
+        let arg_names = ArgNames::positional(args.len());
+        let input_schema = build_input_schema_from_args(&args, &arg_names);
         Self {
             name: name.into(),
             title: None,
@@ -843,6 +952,7 @@ impl Tool {
             meta: None,
             annotations: None,
             handler: Some(handler),
+            arg_names,
             icons: None,
             #[cfg(feature = "http-server")]
             roles: None,
@@ -882,6 +992,57 @@ impl Tool {
         F: FnOnce(crate::types::ToolInputSchema) -> crate::types::ToolInputSchema,
     {
         self.input_schema = config(Default::default());
+        self
+    }
+
+    /// Declares the names of the handler's arguments, in the order the handler
+    /// takes them.
+    ///
+    /// Arguments are extracted from a call's `arguments` map **by name**, and
+    /// a tool registered from a bare closure has no names to extract by --
+    /// Rust does not keep a closure's parameter names. Such a tool therefore
+    /// publishes the positional `arg0`, `arg1`, ... properties and reads those
+    /// same keys. This method replaces both at once: the auto-generated
+    /// `inputSchema` properties are renamed and extraction starts reading the
+    /// new names, so what a peer is told to send cannot drift from what the
+    /// handler looks for.
+    ///
+    /// Only the value-carrying parameters are named. Parameters served from
+    /// request metadata -- [`crate::types::Meta`], [`Context`], a DI-injected
+    /// `Dc<T>` -- are skipped here exactly as they are skipped in the schema.
+    /// An `Option<T>` parameter *is* named: it occupies an argument slot and
+    /// is published like any other, it is simply not in `required`.
+    ///
+    /// Tools declared with the `#[tool]` macro call this for you with the
+    /// function's own parameter names; there is nothing to do for those.
+    ///
+    /// > **Note:** a schema supplied through [`Self::with_input_schema`] is
+    /// > taken verbatim and never renamed -- name its properties as you name
+    /// > them here. The two calls may appear in either order.
+    ///
+    /// # Example
+    /// ```no_run
+    /// use neva::App;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let mut app = App::new();
+    ///
+    /// app.map_tool("greet", |name: String, age: i32| async move {
+    ///     format!("Hello, {name}! You are {age}.")
+    /// })
+    /// .with_arg_names(["name", "age"]);
+    ///
+    /// # app.run().await;
+    /// # }
+    /// ```
+    pub fn with_arg_names<T, I>(&mut self, names: T) -> &mut Self
+    where
+        T: IntoIterator<Item = I>,
+        I: Into<String>,
+    {
+        self.arg_names = self.arg_names.declare(names);
+        rename_positional_props(&mut self.input_schema, &self.arg_names);
         self
     }
 
@@ -943,11 +1104,80 @@ impl Tool {
         self
     }
 
+    /// Describes how the tool's published `inputSchema` and its handler
+    /// disagree about the arguments, if they do.
+    ///
+    /// The two are generated together and cannot drift on their own. They can
+    /// be pulled apart by hand: replacing the schema with
+    /// [`Self::with_input_schema`] renames what peers are told to send without
+    /// touching what the handler reads, and a miscounted
+    /// [`Self::with_arg_names`] leaves trailing arguments unnamed. Both make
+    /// every call to the tool fail, so they are worth catching at startup
+    /// rather than on a peer's first call.
+    pub(crate) fn arg_name_conflict(&self) -> Option<String> {
+        let arity = self.arg_names.arity();
+        if arity == 0 {
+            return None;
+        }
+        if self.arg_names.is_declared() {
+            let declared = self.arg_names.len();
+            return (declared != arity).then(|| {
+                format!(
+                    "tool `{}` declares {declared} argument name(s) but its handler takes \
+                     {arity}. Name every argument the handler reads, metadata parameters \
+                     (`Context`, `Meta<_>`, `Dc<_>`) excluded.",
+                    self.name,
+                )
+            });
+        }
+
+        let missing = (0..arity)
+            .map(crate::types::helpers::extract::positional_name)
+            .find(|name| !self.schema_declares(name))?;
+
+        Some(format!(
+            "tool `{}` publishes an inputSchema without the argument `{missing}` that its \
+             handler reads. A tool registered from a closure has no argument names -- Rust \
+             does not keep a closure's parameter names -- so it reads the positional `arg0`, \
+             `arg1`, ... keys, and replacing its schema renamed only what peers are told to \
+             send. Declare the names with `.with_arg_names([...])`, or register the tool with \
+             the `map_tool!` macro or the `#[tool]` attribute.",
+            self.name,
+        ))
+    }
+
+    /// Whether the published input schema offers a property called `name`.
+    #[inline]
+    fn schema_declares(&self, name: &str) -> bool {
+        #[cfg(feature = "legacy-spec")]
+        {
+            self.input_schema
+                .properties
+                .as_ref()
+                .is_some_and(|props| props.contains_key(name))
+        }
+        #[cfg(not(feature = "legacy-spec"))]
+        {
+            self.input_schema
+                .as_value()
+                .get("properties")
+                .and_then(Value::as_object)
+                .is_some_and(|props| props.contains_key(name))
+        }
+    }
+
     /// Invoke a tool
     #[inline]
-    pub(crate) async fn call(&self, params: HandlerParams) -> Result<CallToolResponse, Error> {
+    pub(crate) async fn call(
+        &self,
+        params: CallToolRequestParams,
+    ) -> Result<CallToolResponse, Error> {
         match self.handler {
-            Some(ref handler) => handler.call(params).await,
+            Some(ref handler) => {
+                handler
+                    .call(HandlerParams::Tool(params, self.arg_names.clone()))
+                    .await
+            }
             None => Err(Error::new(
                 ErrorCode::InternalError,
                 "Tool handler not specified",
@@ -1069,24 +1299,22 @@ macro_rules! impl_generic_tool_handler ({ $($param:ident)* } => {
     {
         #[inline]
         #[allow(unused_mut)]
-        fn args() -> Option<HashMap<String, SchemaProperty>> {
-            let mut args = HashMap::new();
+        fn args() -> Vec<ToolArg> {
+            let mut args = Vec::new();
             $(
             {
-                let prop = SchemaProperty::new::<$param>();
-                if prop.r#type != PropertyType::None {
-                    args.insert(
-                        prop.r#type.to_string(),
-                        prop
-                    );
+                let property = SchemaProperty::new::<$param>();
+                // Metadata-served parameters are not arguments: they take no
+                // schema property and consume no argument slot.
+                if property.r#type != PropertyType::None {
+                    args.push(ToolArg {
+                        property,
+                        required: !<$param as TypeCategory>::is_optional(),
+                    });
                 }
             };
             )*
-            if args.len() == 0 {
-                None
-            } else {
-                Some(args)
-            }
+            args
         }
     }
 });
@@ -1102,29 +1330,209 @@ impl_generic_tool_handler! { T1 T2 T3 T4 T5 }
 #[cfg(feature = "server")]
 mod tests {
     use super::*;
+    use serde_json::json;
 
-    #[tokio::test]
-    async fn it_creates_and_calls_tool() {
-        let tool = Tool::new("sum", |a: i32, b: i32| async move { a + b });
-
-        let params = CallToolRequestParams {
+    fn call_params(args: [(&str, Value); 2]) -> CallToolRequestParams {
+        CallToolRequestParams {
             name: "sum".into(),
             meta: None,
             #[cfg(feature = "tasks")]
             task: None,
-            args: Some(HashMap::from([
-                ("a".into(), serde_json::to_value(5).unwrap()),
-                ("b".into(), serde_json::to_value(2).unwrap()),
-            ])),
-        };
+            args: Some(args.into_iter().map(|(k, v)| (k.to_owned(), v)).collect()),
+        }
+    }
 
-        let resp = tool.call(params.into()).await.unwrap();
+    /// The property names of an `inputSchema`, sorted.
+    fn schema_props(tool: &Tool) -> Vec<String> {
+        #[cfg(feature = "legacy-spec")]
+        let props = tool.input_schema.properties.as_ref().unwrap();
+        #[cfg(not(feature = "legacy-spec"))]
+        let props = tool.input_schema.as_value()["properties"]
+            .as_object()
+            .unwrap();
+
+        let mut names = props.keys().cloned().collect::<Vec<_>>();
+        names.sort();
+        names
+    }
+
+    #[tokio::test]
+    async fn it_creates_and_calls_tool() {
+        // A closure keeps no parameter names, so the tool publishes the
+        // positional ones and reads exactly those.
+        let tool = Tool::new("sum", |a: i32, b: i32| async move { a + b });
+
+        assert_eq!(schema_props(&tool), ["arg0", "arg1"]);
+
+        let params = call_params([("arg0", json!(5)), ("arg1", json!(2))]);
+        let resp = tool.call(params).await.unwrap();
         let json = serde_json::to_string(&resp).unwrap();
 
         assert_eq!(
             json,
             r#"{"content":[{"type":"text","text":"7"}],"isError":false}"#
         );
+    }
+
+    #[tokio::test]
+    async fn it_calls_a_tool_with_declared_arg_names() {
+        let mut tool = Tool::new("sum", |a: i32, b: i32| async move { a - b });
+        tool.with_arg_names(["a", "b"]);
+
+        // Declaring the names renames the published properties too, so a peer
+        // is told to send the keys the handler actually reads.
+        assert_eq!(schema_props(&tool), ["a", "b"]);
+
+        let params = call_params([("b", json!(2)), ("a", json!(5))]);
+        let resp = tool.call(params).await.unwrap();
+        let json = serde_json::to_string(&resp).unwrap();
+
+        assert_eq!(
+            json,
+            r#"{"content":[{"type":"text","text":"3"}],"isError":false}"#
+        );
+    }
+
+    #[tokio::test]
+    async fn it_does_not_swap_same_typed_args_of_different_types() {
+        // The bug this extraction path replaces: with two differently typed
+        // arguments, a map iteration order that put `name` first made the
+        // call fail outright.
+        let mut tool = Tool::new("greet", |name: String, age: i32| async move {
+            format!("{name} is {age}")
+        });
+        tool.with_arg_names(["name", "age"]);
+
+        for args in [
+            [("name", json!("John")), ("age", json!(30))],
+            [("age", json!(30)), ("name", json!("John"))],
+        ] {
+            let resp = tool.call(call_params(args)).await.unwrap();
+            let json = serde_json::to_string(&resp).unwrap();
+
+            assert_eq!(
+                json,
+                r#"{"content":[{"type":"text","text":"John is 30"}],"isError":false}"#
+            );
+        }
+    }
+
+    /// The `required` list of an `inputSchema`, sorted.
+    fn schema_required(tool: &Tool) -> Vec<String> {
+        #[cfg(feature = "legacy-spec")]
+        let required = tool.input_schema.required.clone().unwrap_or_default();
+        #[cfg(not(feature = "legacy-spec"))]
+        let required = tool.input_schema.as_value()["required"]
+            .as_array()
+            .map(|items| {
+                items
+                    .iter()
+                    .filter_map(|item| item.as_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let mut required: Vec<String> = required;
+        required.sort();
+        required
+    }
+
+    #[tokio::test]
+    async fn it_publishes_an_optional_arg_as_not_required() {
+        let mut tool = Tool::new("greet", |name: String, age: Option<i32>| async move {
+            match age {
+                Some(age) => format!("{name} is {age}"),
+                None => format!("{name} is ageless"),
+            }
+        });
+        tool.with_arg_names(["name", "age"]);
+
+        // An optional argument is a property like any other -- a peer has to be
+        // told it exists to be able to send it -- it is just not required.
+        assert_eq!(schema_props(&tool), ["age", "name"]);
+        assert_eq!(schema_required(&tool), ["name"]);
+
+        let supplied = call_params([("name", json!("John")), ("age", json!(30))]);
+        let resp = tool.call(supplied).await.unwrap();
+        assert!(serde_json::to_string(&resp).unwrap().contains("John is 30"));
+
+        let omitted = CallToolRequestParams {
+            name: "greet".into(),
+            meta: None,
+            #[cfg(feature = "tasks")]
+            task: None,
+            args: Some(HashMap::from([("name".to_owned(), json!("John"))])),
+        };
+        let resp = tool.call(omitted).await.unwrap();
+        assert!(
+            serde_json::to_string(&resp)
+                .unwrap()
+                .contains("John is ageless")
+        );
+    }
+
+    #[tokio::test]
+    async fn it_reads_an_explicit_null_as_an_absent_optional_arg() {
+        let mut tool = Tool::new(
+            "greet",
+            |age: Option<i32>| async move { format!("{age:?}") },
+        );
+        tool.with_arg_names(["age"]);
+
+        let resp = tool
+            .call(CallToolRequestParams {
+                name: "greet".into(),
+                meta: None,
+                #[cfg(feature = "tasks")]
+                task: None,
+                args: Some(HashMap::from([("age".to_owned(), Value::Null)])),
+            })
+            .await
+            .unwrap();
+
+        assert!(serde_json::to_string(&resp).unwrap().contains("None"));
+    }
+
+    #[test]
+    fn an_all_optional_tool_requires_nothing() {
+        let tool = Tool::new("greet", |name: Option<String>| async move {
+            name.unwrap_or_default()
+        });
+
+        assert_eq!(schema_props(&tool), ["arg0"]);
+        assert!(schema_required(&tool).is_empty());
+    }
+
+    #[test]
+    fn it_gives_same_typed_args_distinct_schema_properties() {
+        // Keying the generated schema by type name collapsed both `i32`
+        // arguments into a single `number` property.
+        let tool = Tool::new("sum", |a: i32, b: i32| async move { a + b });
+
+        assert_eq!(schema_props(&tool).len(), 2);
+    }
+
+    #[test]
+    fn it_leaves_a_hand_written_schema_untouched() {
+        let mut tool = Tool::new("sum", |a: i32, b: i32| async move { a + b });
+        tool.with_input_schema(|_| {
+            #[cfg(feature = "legacy-spec")]
+            {
+                ToolSchema::from_json_str(
+                    r#"{"type":"object","properties":{"a":{"type":"number"},"b":{"type":"number"}}}"#,
+                )
+            }
+            #[cfg(not(feature = "legacy-spec"))]
+            {
+                crate::types::schema_2020::InputSchema::from(json!({
+                    "type": "object",
+                    "properties": { "a": { "type": "number" }, "b": { "type": "number" } }
+                }))
+            }
+        })
+        .with_arg_names(["a", "b"]);
+
+        assert_eq!(schema_props(&tool), ["a", "b"]);
     }
 
     #[test]

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -882,6 +882,48 @@ fn build_input_schema_from_args(
     }
 }
 
+/// Whether the schema can accept property names its top-level `properties`
+/// map does not list.
+///
+/// The startup check compares the handler's argument names against that map,
+/// which is only sound while the map is the whole story. Two families of
+/// keyword make it not:
+///
+/// * composition -- `$ref` and friends pull in properties defined elsewhere;
+/// * property matching -- `patternProperties` names properties by regex,
+///   `propertyNames` constrains names without listing any, and
+///   `additionalProperties` / `unevaluatedProperties` admit whatever is left
+///   over unless they are `false`, which is the one spelling that *closes* the
+///   schema and leaves the map exhaustive.
+///
+/// Deciding either properly means evaluating the schema, which is far more
+/// than a startup sanity check should carry -- so a schema that uses them is
+/// left alone rather than failed on a guess.
+#[cfg(all(feature = "server", not(feature = "legacy-spec")))]
+fn admits_properties_elsewhere(schema: &serde_json::Map<String, Value>) -> bool {
+    const COMPOSES: [&str; 9] = [
+        "$ref",
+        "allOf",
+        "anyOf",
+        "oneOf",
+        "not",
+        "if",
+        "then",
+        "else",
+        "dependentSchemas",
+    ];
+    /// Name properties without listing them, at any value.
+    const MATCHES_NAMES: [&str; 2] = ["patternProperties", "propertyNames"];
+    /// Admit further properties unless set to `false`.
+    const OPEN_UNLESS_FALSE: [&str; 2] = ["additionalProperties", "unevaluatedProperties"];
+
+    COMPOSES.iter().any(|kw| schema.contains_key(*kw))
+        || MATCHES_NAMES.iter().any(|kw| schema.contains_key(*kw))
+        || OPEN_UNLESS_FALSE
+            .iter()
+            .any(|kw| schema.get(*kw).is_some_and(|v| v != &Value::Bool(false)))
+}
+
 /// Renames the generated properties of `schema` from the names the arguments
 /// are currently read by to the names they are about to be read by.
 ///
@@ -1210,23 +1252,8 @@ impl Tool {
 
         #[cfg(not(feature = "legacy-spec"))]
         let props = {
-            /// Keywords that can contribute properties from outside the
-            /// top-level map. Their presence means the map is only part of
-            /// what the schema publishes.
-            const COMPOSES: [&str; 9] = [
-                "$ref",
-                "allOf",
-                "anyOf",
-                "oneOf",
-                "not",
-                "if",
-                "then",
-                "else",
-                "dependentSchemas",
-            ];
-
             let schema = self.input_schema.as_value().as_object()?;
-            if COMPOSES.iter().any(|kw| schema.contains_key(*kw)) {
+            if admits_properties_elsewhere(schema) {
                 return None;
             }
             schema.get("properties").and_then(Value::as_object)?

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -1178,10 +1178,11 @@ impl Tool {
     /// rather than on a peer's first call.
     pub(crate) fn arg_name_conflict(&self) -> Option<String> {
         let arity = self.arg_names.arity();
-        if arity == 0 {
-            return None;
-        }
 
+        // A declaration is checked against the handler whatever the arity is.
+        // Zero is a real count, not an absence of one: names given to a
+        // handler that reads none are as much a miscount as too few names for
+        // one that reads several, and describe a tool just as broken.
         if self.arg_names.is_declared() {
             let declared = self.arg_names.len();
             if declared != arity {
@@ -1200,6 +1201,12 @@ impl Tool {
                     self.name,
                 ));
             }
+        }
+
+        // Past here every check reads an argument, so a handler that takes
+        // none has nothing left to disagree with the schema about.
+        if arity == 0 {
+            return None;
         }
 
         // Whichever names the handler reads by -- declared or positional --

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -882,30 +882,35 @@ fn build_input_schema_from_args(
     }
 }
 
-/// Renames the auto-generated positional properties of `schema` to `names`.
+/// Renames the generated properties of `schema` from the names the arguments
+/// are currently read by to the names they are about to be read by.
 ///
-/// Only the `argN` keys [`build_input_schema_from_args`] produced are touched,
-/// so a hand-written schema (which has none) passes through untouched.
+/// Renaming *from the current names* rather than from the positional form is
+/// what lets [`Tool::with_arg_names`] be called more than once -- which
+/// `map_tool!` already does once on the caller's behalf. After the first call
+/// there are no `argN` properties left to find, and looking for them would
+/// leave the schema on the old names while the handler moved to the new ones.
 ///
-/// The rename happens in two passes -- take every positional property out,
-/// then put them all back under their declared names -- because a declared
-/// name may itself be a positional key: a handler is perfectly entitled to a
+/// Only keys `from` actually names are touched, so a hand-written schema
+/// (which has none of them) passes through untouched.
+///
+/// The rename happens in two passes -- take every source property out, then
+/// put them all back under their new names -- because a new name may be a
+/// source key for a *later* slot: a handler is perfectly entitled to a
 /// parameter called `arg1`. Renaming in place would drop that parameter's
-/// property on top of a source slot not yet moved.
+/// property on top of a source not yet moved.
 #[cfg(feature = "server")]
 #[inline]
-fn rename_positional_props(schema: &mut crate::types::ToolInputSchema, names: &ArgNames) {
-    use crate::types::helpers::extract::{positional_name, positional_slot};
-
+fn rename_args(schema: &mut crate::types::ToolInputSchema, from: &ArgNames, to: &ArgNames) {
     #[cfg(feature = "legacy-spec")]
     {
         if let Some(props) = schema.properties.as_mut() {
-            let taken = (0..names.len())
-                .map(|slot| props.remove(positional_name(slot)))
+            let taken = (0..to.len())
+                .map(|slot| props.remove(from.get(slot)))
                 .collect::<Vec<_>>();
             for (slot, prop) in taken.into_iter().enumerate() {
                 if let Some(prop) = prop {
-                    props.insert(names.get(slot).to_owned(), prop);
+                    props.insert(to.get(slot).to_owned(), prop);
                 }
             }
         }
@@ -913,8 +918,8 @@ fn rename_positional_props(schema: &mut crate::types::ToolInputSchema, names: &A
             // Each entry is visited once and tested against the name it came
             // in with, so a rewritten entry is never re-read as a source.
             for name in required.iter_mut() {
-                if let Some(slot) = positional_slot(name) {
-                    *name = names.get(slot).to_owned();
+                if let Some(slot) = from.slot_of(name) {
+                    *name = to.get(slot).to_owned();
                 }
             }
         }
@@ -925,19 +930,19 @@ fn rename_positional_props(schema: &mut crate::types::ToolInputSchema, names: &A
             return;
         };
         if let Some(props) = schema.get_mut("properties").and_then(Value::as_object_mut) {
-            let taken = (0..names.len())
-                .map(|slot| props.remove(positional_name(slot)))
+            let taken = (0..to.len())
+                .map(|slot| props.remove(from.get(slot)))
                 .collect::<Vec<_>>();
             for (slot, prop) in taken.into_iter().enumerate() {
                 if let Some(prop) = prop {
-                    props.insert(names.get(slot).to_owned(), prop);
+                    props.insert(to.get(slot).to_owned(), prop);
                 }
             }
         }
         if let Some(required) = schema.get_mut("required").and_then(Value::as_array_mut) {
             for name in required.iter_mut() {
-                if let Some(slot) = name.as_str().and_then(positional_slot) {
-                    *name = Value::String(names.get(slot).to_owned());
+                if let Some(slot) = name.as_str().and_then(|name| from.slot_of(name)) {
+                    *name = Value::String(to.get(slot).to_owned());
                 }
             }
         }
@@ -1055,8 +1060,9 @@ impl Tool {
         T: IntoIterator<Item = I>,
         I: Into<String>,
     {
-        self.arg_names = self.arg_names.declare(names);
-        rename_positional_props(&mut self.input_schema, &self.arg_names);
+        let declared = self.arg_names.declare(names);
+        rename_args(&mut self.input_schema, &self.arg_names, &declared);
+        self.arg_names = declared;
         self
     }
 
@@ -1598,6 +1604,41 @@ mod tests {
         tool.with_arg_names(["other", "arg0"]);
 
         assert_eq!(schema_props(&tool), ["arg0", "other"]);
+        assert!(tool.arg_name_conflict().is_none());
+    }
+
+    #[tokio::test]
+    async fn it_renames_again_when_names_are_redeclared() {
+        // `map_tool!` already declares names on the caller's behalf, so a
+        // second `with_arg_names` is an ordinary thing to do. By then there
+        // are no positional properties left to rename from -- the rename has
+        // to start from the names currently in force.
+        let mut tool = Tool::new(
+            "greet",
+            |a: String, b: i32| async move { format!("{a}{b}") },
+        );
+        tool.with_arg_names(["name", "age"]);
+        tool.with_arg_names(["who", "years"]);
+
+        assert_eq!(schema_props(&tool), ["who", "years"]);
+        assert_eq!(schema_required(&tool), ["who", "years"]);
+        assert!(tool.arg_name_conflict().is_none());
+
+        let resp = tool
+            .call(call_params([("years", json!(30)), ("who", json!("John"))]))
+            .await
+            .unwrap();
+
+        assert!(serde_json::to_string(&resp).unwrap().contains("John30"));
+    }
+
+    #[test]
+    fn it_swaps_declared_names_without_losing_a_property() {
+        let mut tool = Tool::new("f", |a: String, b: String| async move { format!("{a}{b}") });
+        tool.with_arg_names(["first", "second"]);
+        tool.with_arg_names(["second", "first"]);
+
+        assert_eq!(schema_props(&tool), ["first", "second"]);
         assert!(tool.arg_name_conflict().is_none());
     }
 

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -902,14 +902,18 @@ fn build_input_schema_from_args(
 /// Following either properly means evaluating the schema, which is far more
 /// than a startup sanity check should carry, so a schema that uses them is
 /// left alone rather than failed on a guess.
+///
+/// `not` is the one composition keyword missing from that list, because it
+/// composes in the opposite direction: a subschema under `not` describes what
+/// an instance must *fail*, so a name appearing there is one a peer is being
+/// told to avoid, never one it could be sent.
 #[cfg(all(feature = "server", not(feature = "legacy-spec")))]
 fn advertises_properties_elsewhere(schema: &serde_json::Map<String, Value>) -> bool {
-    const ADVERTISES: [&str; 10] = [
+    const ADVERTISES: [&str; 9] = [
         "$ref",
         "allOf",
         "anyOf",
         "oneOf",
-        "not",
         "if",
         "then",
         "else",

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -141,6 +141,17 @@ pub struct Tool {
     #[serde(skip)]
     #[cfg(feature = "server")]
     pub(crate) arg_names: ArgNames,
+
+    /// Whether [`Self::input_schema`] came from the caller rather than from
+    /// the handler's signature.
+    ///
+    /// [`Tool::with_arg_names`] rewrites the property names of a schema it
+    /// generated itself, and must not touch one it did not write: every key
+    /// there was chosen deliberately, including any that happens to look
+    /// positional.
+    #[serde(skip)]
+    #[cfg(feature = "server")]
+    custom_schema: bool,
 }
 
 /// Execution-related properties for a tool.
@@ -1014,6 +1025,7 @@ impl Tool {
             annotations: None,
             handler: Some(handler),
             arg_names,
+            custom_schema: false,
             icons: None,
             #[cfg(feature = "http-server")]
             roles: None,
@@ -1053,6 +1065,7 @@ impl Tool {
         F: FnOnce(crate::types::ToolInputSchema) -> crate::types::ToolInputSchema,
     {
         self.input_schema = config(Default::default());
+        self.custom_schema = true;
         self
     }
 
@@ -1103,7 +1116,13 @@ impl Tool {
         I: Into<String>,
     {
         let declared = self.arg_names.declare(names);
-        rename_args(&mut self.input_schema, &self.arg_names, &declared);
+        // Only a schema this crate generated is rewritten. A hand-written one
+        // is the caller's text, and every key in it was chosen on purpose --
+        // renaming a property that merely looks positional would silently
+        // overwrite whatever they named it after.
+        if !self.custom_schema {
+            rename_args(&mut self.input_schema, &self.arg_names, &declared);
+        }
         self.arg_names = declared;
         self
     }
@@ -1710,6 +1729,52 @@ mod tests {
         .with_arg_names(["a", "b"]);
 
         assert_eq!(schema_props(&tool), ["a", "b"]);
+    }
+
+    /// A hand-written schema is left alone even where it uses a name that
+    /// looks like one this crate generates. `arg0` there is the caller's own
+    /// property, not a leftover to rewrite, and renaming it would drop the
+    /// definition they gave the argument it collides with.
+    #[test]
+    fn it_leaves_a_positional_looking_property_of_a_hand_written_schema_alone() {
+        let mut tool = Tool::new("sum", |a: i32, b: i32| async move { a + b });
+        tool.with_input_schema(|_| {
+            const JSON: &str = r#"{
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "age": { "type": "number" },
+                    "arg0": { "type": "boolean" }
+                }
+            }"#;
+            #[cfg(feature = "legacy-spec")]
+            {
+                ToolSchema::from_json_str(JSON)
+            }
+            #[cfg(not(feature = "legacy-spec"))]
+            {
+                crate::types::schema_2020::InputSchema::from_json_str(JSON).unwrap_or_default()
+            }
+        })
+        .with_arg_names(["name", "age"]);
+
+        assert_eq!(schema_props(&tool), ["age", "arg0", "name"]);
+
+        // The caller's own definition of `name` must survive: renaming `arg0`
+        // onto it would leave the boolean behind.
+        #[cfg(feature = "legacy-spec")]
+        {
+            let props = tool.input_schema.properties.as_ref().unwrap();
+            assert_eq!(props["name"].r#type, PropertyType::String);
+            assert_eq!(props["arg0"].r#type, PropertyType::Bool);
+        }
+        #[cfg(not(feature = "legacy-spec"))]
+        {
+            let props = &tool.input_schema.as_value()["properties"];
+            assert_eq!(props["name"]["type"], "string");
+            assert_eq!(props["arg0"]["type"], "boolean");
+        }
+        assert!(tool.arg_name_conflict().is_none());
     }
 
     #[test]

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -886,6 +886,12 @@ fn build_input_schema_from_args(
 ///
 /// Only the `argN` keys [`build_input_schema_from_args`] produced are touched,
 /// so a hand-written schema (which has none) passes through untouched.
+///
+/// The rename happens in two passes -- take every positional property out,
+/// then put them all back under their declared names -- because a declared
+/// name may itself be a positional key: a handler is perfectly entitled to a
+/// parameter called `arg1`. Renaming in place would drop that parameter's
+/// property on top of a source slot not yet moved.
 #[cfg(feature = "server")]
 #[inline]
 fn rename_positional_props(schema: &mut crate::types::ToolInputSchema, names: &ArgNames) {
@@ -894,13 +900,18 @@ fn rename_positional_props(schema: &mut crate::types::ToolInputSchema, names: &A
     #[cfg(feature = "legacy-spec")]
     {
         if let Some(props) = schema.properties.as_mut() {
-            for slot in 0..names.len() {
-                if let Some(prop) = props.remove(positional_name(slot)) {
+            let taken = (0..names.len())
+                .map(|slot| props.remove(positional_name(slot)))
+                .collect::<Vec<_>>();
+            for (slot, prop) in taken.into_iter().enumerate() {
+                if let Some(prop) = prop {
                     props.insert(names.get(slot).to_owned(), prop);
                 }
             }
         }
         if let Some(required) = schema.required.as_mut() {
+            // Each entry is visited once and tested against the name it came
+            // in with, so a rewritten entry is never re-read as a source.
             for name in required.iter_mut() {
                 if let Some(slot) = positional_slot(name) {
                     *name = names.get(slot).to_owned();
@@ -914,8 +925,11 @@ fn rename_positional_props(schema: &mut crate::types::ToolInputSchema, names: &A
             return;
         };
         if let Some(props) = schema.get_mut("properties").and_then(Value::as_object_mut) {
-            for slot in 0..names.len() {
-                if let Some(prop) = props.remove(positional_name(slot)) {
+            let taken = (0..names.len())
+                .map(|slot| props.remove(positional_name(slot)))
+                .collect::<Vec<_>>();
+            for (slot, prop) in taken.into_iter().enumerate() {
+                if let Some(prop) = prop {
                     props.insert(names.get(slot).to_owned(), prop);
                 }
             }
@@ -1127,6 +1141,14 @@ impl Tool {
                     "tool `{}` declares {declared} argument name(s) but its handler takes \
                      {arity}. Name every argument the handler reads, metadata parameters \
                      (`Context`, `Meta<_>`, `Dc<_>`) excluded.",
+                    self.name,
+                ));
+            }
+            if let Some(duplicate) = self.arg_names.duplicate() {
+                return Some(format!(
+                    "tool `{}` declares the argument name `{duplicate}` twice. Arguments are \
+                     read from a call by name, so two parameters sharing one name would both \
+                     be handed the same value.",
                     self.name,
                 ));
             }
@@ -1551,6 +1573,45 @@ mod tests {
         let tool = Tool::new("sum", |a: i32, b: i32| async move { a + b });
 
         assert_eq!(schema_props(&tool).len(), 2);
+    }
+
+    #[test]
+    fn it_renames_a_parameter_that_is_itself_named_after_a_slot() {
+        // Nothing stops a handler from calling a parameter `arg1`. Renaming
+        // the generated properties one at a time would drop `arg1`'s property
+        // onto the slot the *next* parameter still has to be moved out of.
+        let mut tool = Tool::new("f", |arg1: String, other: String| async move {
+            format!("{arg1}{other}")
+        });
+        tool.with_arg_names(["arg1", "other"]);
+
+        assert_eq!(schema_props(&tool), ["arg1", "other"]);
+        assert_eq!(schema_required(&tool), ["arg1", "other"]);
+        assert!(tool.arg_name_conflict().is_none());
+    }
+
+    #[test]
+    fn it_renames_when_a_declared_name_reuses_a_later_slot() {
+        let mut tool = Tool::new("f", |other: String, arg0: String| async move {
+            format!("{other}{arg0}")
+        });
+        tool.with_arg_names(["other", "arg0"]);
+
+        assert_eq!(schema_props(&tool), ["arg0", "other"]);
+        assert!(tool.arg_name_conflict().is_none());
+    }
+
+    #[test]
+    fn it_rejects_a_duplicate_declared_name() {
+        let mut tool = Tool::new("f", |a: String, b: String| async move { format!("{a}{b}") });
+        tool.with_arg_names(["value", "value"]);
+
+        let conflict = tool.arg_name_conflict().expect("must be reported");
+
+        assert!(
+            conflict.contains("declares the argument name `value` twice"),
+            "unexpected conflict: {conflict}"
+        );
     }
 
     #[test]

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -1136,10 +1136,13 @@ impl Tool {
         // the schema has to ask peers for those very keys, or a call built
         // faithfully from the schema still misses every argument.
         //
-        // Only checked against a schema that lists its properties at the top
-        // level: one assembled from `$ref` or a composition keyword describes
-        // its arguments somewhere this cannot follow, and guessing there would
-        // fail a tool that is perfectly well-formed.
+        // Only checked against a schema that describes every argument in one
+        // top-level `properties` map. A schema that composes -- `$ref`,
+        // `allOf`, `oneOf`, a conditional branch -- may well publish an
+        // argument somewhere this cannot follow, and a heuristic that guessed
+        // there would fail tools that are perfectly well-formed. Resolving
+        // composition properly means a full JSON Schema evaluator, which is
+        // far more than a startup sanity check should carry.
         let properties = self.schema_properties()?;
         let missing = (0..arity)
             .map(|slot| self.arg_names.get(slot))
@@ -1167,17 +1170,39 @@ impl Tool {
     }
 
     /// A predicate over the property names the input schema publishes, or
-    /// `None` when the schema does not list properties at the top level.
+    /// `None` when the schema does not describe all of them in one top-level
+    /// `properties` map.
     #[inline]
     fn schema_properties(&self) -> Option<impl Fn(&str) -> bool + '_> {
+        // The legacy schema is a closed struct of `type`/`properties`/
+        // `required` -- it cannot compose, so its map is always the whole
+        // story.
         #[cfg(feature = "legacy-spec")]
         let props = self.input_schema.properties.as_ref()?;
+
         #[cfg(not(feature = "legacy-spec"))]
-        let props = self
-            .input_schema
-            .as_value()
-            .get("properties")
-            .and_then(Value::as_object)?;
+        let props = {
+            /// Keywords that can contribute properties from outside the
+            /// top-level map. Their presence means the map is only part of
+            /// what the schema publishes.
+            const COMPOSES: [&str; 9] = [
+                "$ref",
+                "allOf",
+                "anyOf",
+                "oneOf",
+                "not",
+                "if",
+                "then",
+                "else",
+                "dependentSchemas",
+            ];
+
+            let schema = self.input_schema.as_value().as_object()?;
+            if COMPOSES.iter().any(|kw| schema.contains_key(*kw)) {
+                return None;
+            }
+            schema.get("properties").and_then(Value::as_object)?
+        };
 
         Some(move |name: &str| props.contains_key(name))
     }

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -882,26 +882,29 @@ fn build_input_schema_from_args(
     }
 }
 
-/// Whether the schema can accept property names its top-level `properties`
-/// map does not list.
+/// Whether the schema can put a property *name* in front of a peer that its
+/// top-level `properties` map does not list.
 ///
-/// The startup check compares the handler's argument names against that map,
-/// which is only sound while the map is the whole story. Two families of
-/// keyword make it not:
+/// This is the question the startup check needs answered, and it is narrower
+/// than "is the schema open". A peer builds its call from what the schema
+/// *advertises*: permitting further names is not the same as naming one, and
+/// an argument nothing names is one no schema-driven caller can ever send.
+/// So `additionalProperties`, `unevaluatedProperties` and `propertyNames` are
+/// not exemptions however they are set -- they widen what is accepted while
+/// naming nothing -- and a tool whose argument only they would admit is still
+/// worth reporting.
+///
+/// What does advertise a name from outside the map:
 ///
 /// * composition -- `$ref` and friends pull in properties defined elsewhere;
-/// * property matching -- `patternProperties` names properties by regex,
-///   `propertyNames` constrains names without listing any, and
-///   `additionalProperties` / `unevaluatedProperties` admit whatever is left
-///   over unless they are `false`, which is the one spelling that *closes* the
-///   schema and leaves the map exhaustive.
+/// * `patternProperties` -- names properties by regex rather than literally.
 ///
-/// Deciding either properly means evaluating the schema, which is far more
-/// than a startup sanity check should carry -- so a schema that uses them is
+/// Following either properly means evaluating the schema, which is far more
+/// than a startup sanity check should carry, so a schema that uses them is
 /// left alone rather than failed on a guess.
 #[cfg(all(feature = "server", not(feature = "legacy-spec")))]
-fn admits_properties_elsewhere(schema: &serde_json::Map<String, Value>) -> bool {
-    const COMPOSES: [&str; 9] = [
+fn advertises_properties_elsewhere(schema: &serde_json::Map<String, Value>) -> bool {
+    const ADVERTISES: [&str; 10] = [
         "$ref",
         "allOf",
         "anyOf",
@@ -911,17 +914,10 @@ fn admits_properties_elsewhere(schema: &serde_json::Map<String, Value>) -> bool 
         "then",
         "else",
         "dependentSchemas",
+        "patternProperties",
     ];
-    /// Name properties without listing them, at any value.
-    const MATCHES_NAMES: [&str; 2] = ["patternProperties", "propertyNames"];
-    /// Admit further properties unless set to `false`.
-    const OPEN_UNLESS_FALSE: [&str; 2] = ["additionalProperties", "unevaluatedProperties"];
 
-    COMPOSES.iter().any(|kw| schema.contains_key(*kw))
-        || MATCHES_NAMES.iter().any(|kw| schema.contains_key(*kw))
-        || OPEN_UNLESS_FALSE
-            .iter()
-            .any(|kw| schema.get(*kw).is_some_and(|v| v != &Value::Bool(false)))
+    ADVERTISES.iter().any(|kw| schema.contains_key(*kw))
 }
 
 /// Renames the generated properties of `schema` from the names the arguments
@@ -1253,7 +1249,7 @@ impl Tool {
         #[cfg(not(feature = "legacy-spec"))]
         let props = {
             let schema = self.input_schema.as_value().as_object()?;
-            if admits_properties_elsewhere(schema) {
+            if advertises_properties_elsewhere(schema) {
                 return None;
             }
             schema.get("properties").and_then(Value::as_object)?

--- a/neva/src/types/tool.rs
+++ b/neva/src/types/tool.rs
@@ -1119,51 +1119,67 @@ impl Tool {
         if arity == 0 {
             return None;
         }
+
         if self.arg_names.is_declared() {
             let declared = self.arg_names.len();
-            return (declared != arity).then(|| {
-                format!(
+            if declared != arity {
+                return Some(format!(
                     "tool `{}` declares {declared} argument name(s) but its handler takes \
                      {arity}. Name every argument the handler reads, metadata parameters \
                      (`Context`, `Meta<_>`, `Dc<_>`) excluded.",
                     self.name,
-                )
-            });
+                ));
+            }
         }
 
+        // Whichever names the handler reads by -- declared or positional --
+        // the schema has to ask peers for those very keys, or a call built
+        // faithfully from the schema still misses every argument.
+        //
+        // Only checked against a schema that lists its properties at the top
+        // level: one assembled from `$ref` or a composition keyword describes
+        // its arguments somewhere this cannot follow, and guessing there would
+        // fail a tool that is perfectly well-formed.
+        let properties = self.schema_properties()?;
         let missing = (0..arity)
-            .map(crate::types::helpers::extract::positional_name)
-            .find(|name| !self.schema_declares(name))?;
+            .map(|slot| self.arg_names.get(slot))
+            .find(|name| !properties(name))?;
 
-        Some(format!(
-            "tool `{}` publishes an inputSchema without the argument `{missing}` that its \
-             handler reads. A tool registered from a closure has no argument names -- Rust \
-             does not keep a closure's parameter names -- so it reads the positional `arg0`, \
-             `arg1`, ... keys, and replacing its schema renamed only what peers are told to \
-             send. Declare the names with `.with_arg_names([...])`, or register the tool with \
-             the `map_tool!` macro or the `#[tool]` attribute.",
-            self.name,
-        ))
+        Some(if self.arg_names.is_declared() {
+            format!(
+                "tool `{}` declares the argument `{missing}` but publishes an inputSchema \
+                 without it. A peer sends what the schema asks for, so the two have to name \
+                 the same arguments: either rename the schema property, or pass the schema's \
+                 own names to `.with_arg_names([...])`.",
+                self.name,
+            )
+        } else {
+            format!(
+                "tool `{}` publishes an inputSchema without the argument `{missing}` that its \
+                 handler reads. A tool registered from a closure has no argument names -- Rust \
+                 does not keep a closure's parameter names -- so it reads the positional `arg0`, \
+                 `arg1`, ... keys, and replacing its schema renamed only what peers are told to \
+                 send. Declare the names with `.with_arg_names([...])`, or register the tool with \
+                 the `map_tool!` macro or the `#[tool]` attribute.",
+                self.name,
+            )
+        })
     }
 
-    /// Whether the published input schema offers a property called `name`.
+    /// A predicate over the property names the input schema publishes, or
+    /// `None` when the schema does not list properties at the top level.
     #[inline]
-    fn schema_declares(&self, name: &str) -> bool {
+    fn schema_properties(&self) -> Option<impl Fn(&str) -> bool + '_> {
         #[cfg(feature = "legacy-spec")]
-        {
-            self.input_schema
-                .properties
-                .as_ref()
-                .is_some_and(|props| props.contains_key(name))
-        }
+        let props = self.input_schema.properties.as_ref()?;
         #[cfg(not(feature = "legacy-spec"))]
-        {
-            self.input_schema
-                .as_value()
-                .get("properties")
-                .and_then(Value::as_object)
-                .is_some_and(|props| props.contains_key(name))
-        }
+        let props = self
+            .input_schema
+            .as_value()
+            .get("properties")
+            .and_then(Value::as_object)?;
+
+        Some(move |name: &str| props.contains_key(name))
     }
 
     /// Invoke a tool

--- a/neva/src/types/tool/from_request.rs
+++ b/neva/src/types/tool/from_request.rs
@@ -1,146 +1,176 @@
 use super::CallToolRequestParams;
-use crate::error::Error;
-use crate::types::helpers::extract::{RequestArgument, extract_arg};
+use crate::types::helpers::extract::HandlerArgs;
+use crate::types::request::RequestParamsMeta;
+use serde_json::Value;
+use std::collections::HashMap;
 
-impl TryFrom<CallToolRequestParams> for () {
-    type Error = Error;
-
+impl HandlerArgs for CallToolRequestParams {
     #[inline]
-    fn try_from(_: CallToolRequestParams) -> Result<Self, Self::Error> {
-        Ok(())
+    fn into_parts(self) -> (Option<HashMap<String, Value>>, Option<RequestParamsMeta>) {
+        (self.args, self.meta)
     }
 }
-
-macro_rules! impl_from_call_tool_params {
-    ($($T: ident),*) => {
-        impl<$($T: RequestArgument<Error = Error>),+> TryFrom<CallToolRequestParams> for ($($T,)+) {
-            type Error = Error;
-
-            #[inline]
-            fn try_from(params: CallToolRequestParams) -> Result<Self, Self::Error> {
-                let args = params.args.unwrap_or_default();
-                let mut iter = args.iter();
-                let tuple = (
-                    $(
-                        extract_arg::<$T>(&params.meta, &mut iter)?,
-                    )*
-                );
-                Ok(tuple)
-            }
-        }
-    };
-}
-
-impl_from_call_tool_params! { T1 }
-impl_from_call_tool_params! { T1, T2 }
-impl_from_call_tool_params! { T1, T2, T3 }
-impl_from_call_tool_params! { T1, T2, T3, T4 }
-impl_from_call_tool_params! { T1, T2, T3, T4, T5 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{Meta, ProgressToken, request::RequestParamsMeta};
-    use serde_json::{Value, json};
-    use std::collections::HashMap;
+    use crate::types::{ArgNames, FromHandlerArgs, Meta, ProgressToken};
+    use serde_json::json;
 
-    #[test]
-    fn it_extracts_args() {
-        let params = CallToolRequestParams {
-            args: Some(HashMap::from([("arg".into(), json!({ "test": 1 }))])),
-            meta: None,
+    fn params(args: Option<HashMap<String, Value>>) -> CallToolRequestParams {
+        CallToolRequestParams {
             name: "tool".into(),
+            args,
+            meta: None,
             #[cfg(feature = "tasks")]
             task: None,
-        };
+        }
+    }
 
-        let arg: (Value,) = params.try_into().unwrap();
+    fn meta(meta: RequestParamsMeta) -> CallToolRequestParams {
+        CallToolRequestParams {
+            name: "tool".into(),
+            args: None,
+            meta: Some(meta),
+            #[cfg(feature = "tasks")]
+            task: None,
+        }
+    }
+
+    #[test]
+    fn it_extracts_a_single_arg() {
+        let params = params(Some(HashMap::from([("arg0".into(), json!({ "test": 1 }))])));
+
+        let arg: (Value,) = FromHandlerArgs::from_args(params, &ArgNames::default()).unwrap();
 
         assert_eq!(arg.0, json!({ "test": 1 }));
     }
 
     #[test]
-    #[allow(clippy::useless_conversion)]
-    fn it_extracts_params() {
-        let params = CallToolRequestParams {
-            args: Some(HashMap::from([("arg".into(), json!(22))])),
-            meta: None,
-            name: "tool".into(),
-            #[cfg(feature = "tasks")]
-            task: None,
-        };
+    fn it_extracts_args_by_declared_name() {
+        let params = params(Some(HashMap::from([
+            ("age".into(), json!(30)),
+            ("name".into(), json!("John")),
+        ])));
 
-        let arg: CallToolRequestParams = params.try_into().unwrap();
+        let (name, age): (String, i32) =
+            FromHandlerArgs::from_args(params, &ArgNames::new(["name", "age"])).unwrap();
 
-        assert_eq!(arg.name, "tool");
-        assert_eq!(arg.args, Some(HashMap::from([("arg".into(), json!(22))])));
+        assert_eq!(name, "John");
+        assert_eq!(age, 30);
+    }
+
+    #[test]
+    fn it_extracts_same_typed_args_without_swapping_them() {
+        // The regression this whole path exists for: two arguments of the same
+        // type are told apart by name, never by their order in the map.
+        let params = params(Some(HashMap::from([
+            ("last".into(), json!("Doe")),
+            ("first".into(), json!("John")),
+        ])));
+
+        let (first, last): (String, String) =
+            FromHandlerArgs::from_args(params, &ArgNames::new(["first", "last"])).unwrap();
+
+        assert_eq!(first, "John");
+        assert_eq!(last, "Doe");
+    }
+
+    #[test]
+    fn it_extracts_positional_args_when_no_names_declared() {
+        let params = params(Some(HashMap::from([
+            ("arg1".into(), json!("John")),
+            ("arg0".into(), json!(30)),
+        ])));
+
+        let (age, name): (i32, String) =
+            FromHandlerArgs::from_args(params, &ArgNames::default()).unwrap();
+
+        assert_eq!(age, 30);
+        assert_eq!(name, "John");
+    }
+
+    #[test]
+    fn it_resolves_an_absent_optional_arg_to_none() {
+        let params = params(Some(HashMap::from([("name".into(), json!("John"))])));
+
+        let (name, age): (String, Option<i32>) =
+            FromHandlerArgs::from_args(params, &ArgNames::new(["name", "age"])).unwrap();
+
+        assert_eq!(name, "John");
+        assert_eq!(age, None);
+    }
+
+    #[test]
+    fn it_reports_a_missing_arg_by_name() {
+        let params = params(Some(HashMap::from([("name".into(), json!("John"))])));
+
+        let err = <(String, i32)>::from_args(params, &ArgNames::new(["name", "age"])).unwrap_err();
+
+        assert_eq!(err.code, crate::error::ErrorCode::InvalidParams);
+        assert!(
+            err.to_string().contains("missing required argument `age`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn it_reports_a_mistyped_arg_by_name() {
+        let params = params(Some(HashMap::from([("age".into(), json!("thirty"))])));
+
+        let err = <(i32,)>::from_args(params, &ArgNames::new(["age"])).unwrap_err();
+
+        assert_eq!(err.code, crate::error::ErrorCode::InvalidParams);
+        assert!(
+            err.to_string().contains("invalid value for argument `age`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn it_extracts_no_args() {
+        let extracted: () = FromHandlerArgs::from_args(params(None), &ArgNames::default()).unwrap();
+
+        assert_eq!(extracted, ());
     }
 
     #[test]
     fn it_extracts_meta() {
-        let params = CallToolRequestParams {
-            name: "tool".into(),
-            meta: Some(RequestParamsMeta {
-                progress_token: None,
-                traceparent: None,
-                baggage: None,
-                tracestate: None,
-                client_info: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                input_responses: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                request_state: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                protocol_version: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                client_capabilities: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                log_level: None,
-                context: None,
-                #[cfg(feature = "tasks")]
-                task: None,
-            }),
-            args: None,
-            #[cfg(feature = "tasks")]
-            task: None,
-        };
+        let params = meta(RequestParamsMeta::default());
 
-        let arg: (Meta<RequestParamsMeta>,) = params.try_into().unwrap();
+        let arg: (Meta<RequestParamsMeta>,) =
+            FromHandlerArgs::from_args(params, &ArgNames::default()).unwrap();
 
         assert_eq!(arg.0.progress_token, None);
     }
 
     #[test]
     fn it_extracts_progress_token() {
-        let params = CallToolRequestParams {
-            name: "tool".into(),
-            meta: Some(RequestParamsMeta {
-                progress_token: Some(ProgressToken::Number(5)),
-                traceparent: None,
-                baggage: None,
-                tracestate: None,
-                client_info: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                input_responses: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                request_state: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                protocol_version: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                client_capabilities: None,
-                #[cfg(not(feature = "legacy-spec"))]
-                log_level: None,
-                context: None,
-                #[cfg(feature = "tasks")]
-                task: None,
-            }),
-            args: None,
-            #[cfg(feature = "tasks")]
-            task: None,
-        };
+        let params = meta(RequestParamsMeta {
+            progress_token: Some(ProgressToken::Number(5)),
+            ..Default::default()
+        });
 
-        let arg: (Meta<ProgressToken>,) = params.try_into().unwrap();
+        let arg: (Meta<ProgressToken>,) =
+            FromHandlerArgs::from_args(params, &ArgNames::default()).unwrap();
 
         assert_eq!(arg.0.0, ProgressToken::Number(5));
+    }
+
+    #[test]
+    fn it_does_not_let_a_meta_arg_consume_an_argument_slot() {
+        // `Meta<_>` comes from `_meta`, so the `String` after it still reads
+        // the *first* declared argument name.
+        let mut params = params(Some(HashMap::from([("name".into(), json!("John"))])));
+        params.meta = Some(RequestParamsMeta {
+            progress_token: Some(ProgressToken::Number(5)),
+            ..Default::default()
+        });
+
+        let (token, name): (Meta<ProgressToken>, String) =
+            FromHandlerArgs::from_args(params, &ArgNames::new(["name"])).unwrap();
+
+        assert_eq!(token.0, ProgressToken::Number(5));
+        assert_eq!(name, "John");
     }
 }

--- a/neva/src/types/tool/from_request.rs
+++ b/neva/src/types/tool/from_request.rs
@@ -115,6 +115,35 @@ mod tests {
     }
 
     #[test]
+    fn it_reports_a_missing_required_arg_that_would_accept_null() {
+        // `serde_json::Value` deserializes from `null` quite happily, so
+        // optionality cannot be inferred from a synthetic null failing: the
+        // argument is required and its absence has to be reported as such.
+        let params = params(Some(HashMap::new()));
+
+        let err = <(Value,)>::from_args(params, &ArgNames::new(["payload"])).unwrap_err();
+
+        assert_eq!(err.code, crate::error::ErrorCode::InvalidParams);
+        assert!(
+            err.to_string()
+                .contains("missing required argument `payload`"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn it_reads_an_explicit_null_for_a_null_accepting_required_arg() {
+        // Sent explicitly, `null` is a value the argument accepts -- only its
+        // *absence* is the error.
+        let params = params(Some(HashMap::from([("payload".into(), Value::Null)])));
+
+        let (payload,): (Value,) =
+            FromHandlerArgs::from_args(params, &ArgNames::new(["payload"])).unwrap();
+
+        assert_eq!(payload, Value::Null);
+    }
+
+    #[test]
     fn it_reports_a_mistyped_arg_by_name() {
         let params = params(Some(HashMap::from([("age".into(), json!("thirty"))])));
 

--- a/neva/tests/param_headers.rs
+++ b/neva/tests/param_headers.rs
@@ -28,7 +28,8 @@ async fn mirrored_headers_must_describe_the_call() {
                 }
             })
             .into()
-        });
+        })
+        .with_arg_names(["region"]);
 
     let handle = tokio::spawn(async move { app.run().await });
     tokio::time::sleep(std::time::Duration::from_millis(300)).await;
@@ -112,6 +113,8 @@ async fn a_header_without_the_argument_it_mirrors_is_rejected() {
     let mut app =
         App::new().with_options(|opt| opt.with_http(|http| http.bind(&addr).with_endpoint("/mcp")));
 
+    // The handler takes no argument at all, so there is nothing to name: the
+    // annotated `region` property exists only to be claimed by a header.
     app.map_tool("query", || async move { "ok".to_string() })
         .with_input_schema(|_| {
             serde_json::json!({
@@ -185,7 +188,8 @@ async fn a_batched_call_of_an_annotated_tool_still_runs() {
                 }
             })
             .into()
-        });
+        })
+        .with_arg_names(["region"]);
 
     let handle = tokio::spawn(async move { app.run().await });
 

--- a/neva/tests/tool_macro.rs
+++ b/neva/tests/tool_macro.rs
@@ -61,6 +61,27 @@ async fn search(q: String) -> String {
     q
 }
 
+// Two arguments of *different* types: the pair that used to fail outright when
+// a map iteration order handed them to the handler the wrong way round.
+#[neva::tool]
+async fn describe(name: String, age: i32) -> String {
+    format!("{name} is {age}")
+}
+
+// An optional argument: published as its inner type, kept out of `required`,
+// and `None` when the call leaves it out.
+#[neva::tool]
+async fn nickname(name: String, alias: Option<String>) -> String {
+    alias.unwrap_or(name)
+}
+
+// An optional structured argument still probes past both wrappers for a rich
+// subschema.
+#[neva::tool]
+async fn maybe_profile(profile: Option<Json<Profile>>) -> String {
+    profile.map(|p| p.0.name).unwrap_or_default()
+}
+
 // Struct return via `Json<T>` -> output schema derived from the return type.
 #[neva::tool]
 async fn make_greeting(name: String) -> Json<Greeting> {
@@ -164,6 +185,88 @@ async fn tool_macro_emits_json_schema_2020() {
     let greet = by_name("make_greeting");
     assert_eq!(greet["outputSchema"]["type"], serde_json::json!("object"));
     assert!(greet["outputSchema"]["properties"]["message"].is_object());
+
+    // 6. An optional argument is published like any other but is not required,
+    // and a structured one is still described past both wrappers.
+    let nickname = by_name("nickname");
+    assert_eq!(
+        nickname["inputSchema"]["properties"]["alias"]["type"],
+        serde_json::json!("string")
+    );
+    let req: Vec<String> =
+        serde_json::from_value(nickname["inputSchema"]["required"].clone()).unwrap();
+    assert_eq!(
+        req,
+        vec!["name".to_string()],
+        "`alias` must not be required"
+    );
+
+    let maybe = by_name("maybe_profile");
+    let profile_schema = &maybe["inputSchema"]["properties"]["profile"];
+    assert_eq!(profile_schema["type"], serde_json::json!("object"));
+    assert!(
+        profile_schema["properties"]["name"].is_object(),
+        "an Option<Json<T>> arg must still describe T: {profile_schema}"
+    );
+    assert!(
+        maybe["inputSchema"]["required"].is_null(),
+        "an all-optional tool requires nothing"
+    );
+
+    // 7. An optional argument the call leaves out arrives as `None`.
+    for (args, expected) in [
+        (serde_json::json!({ "name": "John" }), "John"),
+        (
+            serde_json::json!({ "name": "John", "alias": "Johnny" }),
+            "Johnny",
+        ),
+    ] {
+        let call_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": { "name": "nickname", "arguments": args, "_meta": meta() }
+        });
+        let resp = routed(client.post(&url), &call_body)
+            .json(&call_body)
+            .send()
+            .await
+            .expect("tools/call failed");
+        let body: serde_json::Value = resp.json().await.unwrap();
+
+        assert_eq!(
+            body.pointer("/result/content/0/text"),
+            Some(&serde_json::json!(expected)),
+            "unexpected response: {body}"
+        );
+    }
+
+    // 8. Arguments are read by name, so the order a peer happens to serialize
+    // them in cannot reach the handler. JSON object members are unordered and
+    // both spellings below are the same call.
+    for args in [
+        serde_json::json!({ "name": "John", "age": 30 }),
+        serde_json::json!({ "age": 30, "name": "John" }),
+    ] {
+        let call_body = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": { "name": "describe", "arguments": args, "_meta": meta() }
+        });
+        let resp = routed(client.post(&url), &call_body)
+            .json(&call_body)
+            .send()
+            .await
+            .expect("tools/call failed");
+        let body: serde_json::Value = resp.json().await.unwrap();
+
+        assert_eq!(
+            body.pointer("/result/content/0/text"),
+            Some(&serde_json::json!("John is 30")),
+            "unexpected response: {body}"
+        );
+    }
 
     handle.abort();
 }

--- a/neva/tests/tool_macro.rs
+++ b/neva/tests/tool_macro.rs
@@ -82,6 +82,19 @@ async fn maybe_profile(profile: Option<Json<Profile>>) -> String {
     profile.map(|p| p.0.name).unwrap_or_default()
 }
 
+// A metadata parameter reaching the signature through a type alias. The macro
+// cannot see through the alias, so both the schema and the declared argument
+// names have to be settled by trait resolution -- otherwise the tool publishes
+// a `token` argument its handler never reads, and `App::run` refuses to start
+// on the disagreement.
+type Progress = neva::types::Meta<neva::types::ProgressToken>;
+
+#[neva::tool]
+async fn aliased(token: Progress, city: String) -> String {
+    let _ = token;
+    city
+}
+
 // Struct return via `Json<T>` -> output schema derived from the return type.
 #[neva::tool]
 async fn make_greeting(name: String) -> Json<Greeting> {
@@ -213,7 +226,19 @@ async fn tool_macro_emits_json_schema_2020() {
         "an all-optional tool requires nothing"
     );
 
-    // 7. An optional argument the call leaves out arrives as `None`.
+    // 7. An aliased metadata parameter is neither published nor named.
+    let aliased = by_name("aliased");
+    let props = aliased["inputSchema"]["properties"].as_object().unwrap();
+    assert_eq!(
+        props.keys().collect::<Vec<_>>(),
+        vec!["city"],
+        "an aliased `Meta<_>` must not be published: {aliased}"
+    );
+    let req: Vec<String> =
+        serde_json::from_value(aliased["inputSchema"]["required"].clone()).unwrap();
+    assert_eq!(req, vec!["city".to_string()]);
+
+    // 8. An optional argument the call leaves out arrives as `None`.
     for (args, expected) in [
         (serde_json::json!({ "name": "John" }), "John"),
         (
@@ -241,7 +266,7 @@ async fn tool_macro_emits_json_schema_2020() {
         );
     }
 
-    // 8. Arguments are read by name, so the order a peer happens to serialize
+    // 9. Arguments are read by name, so the order a peer happens to serialize
     // them in cannot reach the handler. JSON object members are unordered and
     // both spellings below are the same call.
     for args in [

--- a/neva/tests/tool_macro.rs
+++ b/neva/tests/tool_macro.rs
@@ -88,11 +88,25 @@ async fn maybe_profile(profile: Option<Json<Profile>>) -> String {
 // a `token` argument its handler never reads, and `App::run` refuses to start
 // on the disagreement.
 type Progress = neva::types::Meta<neva::types::ProgressToken>;
+type Postcode = String;
+type MaybeFloor = Option<i32>;
 
 #[neva::tool]
-async fn aliased(token: Progress, city: String) -> String {
+async fn aliased(token: Progress, city: Postcode, floor: MaybeFloor) -> String {
     let _ = token;
-    city
+    format!("{city} {floor:?}")
+}
+
+// The same signature spelled out, to pin that an alias changes nothing about
+// what gets published.
+#[neva::tool]
+async fn spelled(
+    token: neva::types::Meta<neva::types::ProgressToken>,
+    city: String,
+    floor: Option<i32>,
+) -> String {
+    let _ = token;
+    format!("{city} {floor:?}")
 }
 
 // Struct return via `Json<T>` -> output schema derived from the return type.
@@ -226,17 +240,29 @@ async fn tool_macro_emits_json_schema_2020() {
         "an all-optional tool requires nothing"
     );
 
-    // 7. An aliased metadata parameter is neither published nor named.
+    // 7. A type alias is transparent: an aliased `Meta<_>` is neither
+    // published nor named, an aliased `Option<T>` is published as its `T` and
+    // is not required, and an aliased primitive keeps its primitive type. All
+    // of it has to be settled by trait resolution -- the macro cannot see
+    // through an alias -- so the two tools must publish the same schema.
     let aliased = by_name("aliased");
     let props = aliased["inputSchema"]["properties"].as_object().unwrap();
     assert_eq!(
         props.keys().collect::<Vec<_>>(),
-        vec!["city"],
+        vec!["city", "floor"],
         "an aliased `Meta<_>` must not be published: {aliased}"
     );
+    assert_eq!(props["city"]["type"], serde_json::json!("string"));
+    assert_eq!(props["floor"]["type"], serde_json::json!("number"));
     let req: Vec<String> =
         serde_json::from_value(aliased["inputSchema"]["required"].clone()).unwrap();
     assert_eq!(req, vec!["city".to_string()]);
+
+    assert_eq!(
+        aliased["inputSchema"],
+        by_name("spelled")["inputSchema"],
+        "an alias must publish exactly what the spelled-out type does"
+    );
 
     // 8. An optional argument the call leaves out arrives as `None`.
     for (args, expected) in [

--- a/neva_macros/src/server.rs
+++ b/neva_macros/src/server.rs
@@ -141,6 +141,28 @@ pub(super) fn get_arg_type(t: &Type) -> &str {
     }
 }
 
+/// The `ident: Type` pairs of a handler's parameters, in declaration order.
+///
+/// Handed to `neva::__arg_names!` / `neva::__prompt_args!`, which decide which
+/// of them are arguments from the resolved type -- see the call sites for why
+/// that decision cannot be made here.
+pub(super) fn param_idents_and_types(function: &ItemFn) -> Vec<(syn::Ident, syn::Type)> {
+    function
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            syn::FnArg::Typed(pat_type) => match &*pat_type.pat {
+                syn::Pat::Ident(pat_ident) => {
+                    Some((pat_ident.ident.clone(), (*pat_type.ty).clone()))
+                }
+                _ => None,
+            },
+            syn::FnArg::Receiver(_) => None,
+        })
+        .collect()
+}
+
 /// Describes a handler *parameter*: its schema category, and whether a call
 /// must supply it.
 ///

--- a/neva_macros/src/server.rs
+++ b/neva_macros/src/server.rs
@@ -141,6 +141,35 @@ pub(super) fn get_arg_type(t: &Type) -> &str {
     }
 }
 
+/// Describes a handler *parameter*: its schema category, and whether a call
+/// must supply it.
+///
+/// An `Option<T>` parameter is published as the `T` property and left out of
+/// `required`; an absent value resolves to `None` rather than failing the
+/// call. This is deliberately separate from [`get_arg_type`], which also reads
+/// *return* types -- there `Option<T>` keeps meaning "nothing to describe".
+#[inline]
+pub(super) fn get_param_type(t: &Type) -> (&str, bool) {
+    match get_option_inner(t) {
+        Some(inner) => (get_arg_type(inner), false),
+        None => (get_arg_type(t), true),
+    }
+}
+
+/// The `T` of an `Option<T>` parameter, if the type is one.
+#[inline]
+pub(super) fn get_option_inner(ty: &Type) -> Option<&Type> {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+        && segment.ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return Some(inner);
+    }
+    None
+}
+
 #[inline]
 pub(super) fn get_inner_type_from_generic(ty: &Type) -> Option<&Type> {
     if let Type::Path(type_path) = ty

--- a/neva_macros/src/server/prompt.rs
+++ b/neva_macros/src/server/prompt.rs
@@ -1,9 +1,9 @@
 //! Macros for MCP prompts
 
-use super::{get_bool_param, get_exprs_arr, get_param_type, get_params_arr, get_str_param};
+use super::{get_bool_param, get_exprs_arr, get_params_arr, get_str_param, param_idents_and_types};
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{FnArg, ItemFn, Meta, Pat, punctuated::Punctuated, token::Comma};
+use syn::{ItemFn, Meta, punctuated::Punctuated, token::Comma};
 
 pub(crate) fn expand(
     attr: &Punctuated<Meta, Comma>,
@@ -70,26 +70,18 @@ pub(crate) fn expand(
     let args_code = if let Some(args_json) = args {
         quote! { .with_args(neva::types::prompt::PromptArguments::from_json_str(#args_json)) }
     } else if !no_args {
-        let mut arg_entries = Vec::new();
-        for arg in &function.sig.inputs {
-            if let FnArg::Typed(pat_type) = arg
-                && let Pat::Ident(pat_ident) = &*pat_type.pat
-            {
-                let arg_name = pat_ident.ident.to_string();
-                // An `Option<T>` parameter is an argument the caller may leave
-                // out; it still occupies a slot and is still published.
-                let (arg_type, is_required) = get_param_type(&pat_type.ty);
-                if arg_type != "none" {
-                    arg_entries.push(quote! {
-                        neva::types::prompt::PromptArgument::named(#arg_name, #is_required)
-                    });
-                }
-            }
-        }
-        if !arg_entries.is_empty() {
-            quote! { .with_args([#(#arg_entries,)*]) }
-        } else {
+        // Which parameters are arguments, and which of those may be omitted,
+        // is decided by `neva::__prompt_args!` from the resolved type -- a
+        // metadata parameter or an `Option<T>` can reach the signature through
+        // a type alias this macro cannot see through. The published list is
+        // also what extraction reads by, so classifying it syntactically would
+        // shift every argument after the mis-classified one.
+        let params = param_idents_and_types(function);
+        if params.is_empty() {
             quote! {}
+        } else {
+            let pairs = params.iter().map(|(name, ty)| quote! { #name: #ty });
+            quote! { .with_args(neva::__prompt_args!(#(#pairs),*)) }
         }
     } else {
         quote! {}

--- a/neva_macros/src/server/prompt.rs
+++ b/neva_macros/src/server/prompt.rs
@@ -1,6 +1,6 @@
 //! Macros for MCP prompts
 
-use super::{get_arg_type, get_bool_param, get_exprs_arr, get_params_arr, get_str_param};
+use super::{get_bool_param, get_exprs_arr, get_param_type, get_params_arr, get_str_param};
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{FnArg, ItemFn, Meta, Pat, punctuated::Punctuated, token::Comma};
@@ -76,10 +76,12 @@ pub(crate) fn expand(
                 && let Pat::Ident(pat_ident) = &*pat_type.pat
             {
                 let arg_name = pat_ident.ident.to_string();
-                let arg_type = get_arg_type(&pat_type.ty);
-                if !arg_type.eq("none") {
+                // An `Option<T>` parameter is an argument the caller may leave
+                // out; it still occupies a slot and is still published.
+                let (arg_type, is_required) = get_param_type(&pat_type.ty);
+                if arg_type != "none" {
                     arg_entries.push(quote! {
-                        #arg_name
+                        neva::types::prompt::PromptArgument::named(#arg_name, #is_required)
                     });
                 }
             }

--- a/neva_macros/src/server/tool.rs
+++ b/neva_macros/src/server/tool.rs
@@ -21,8 +21,8 @@
 //!   configuration).
 
 use super::{
-    get_arg_type, get_bool_param, get_exprs_arr, get_inner_type_from_generic, get_params_arr,
-    get_str_param,
+    get_arg_type, get_bool_param, get_exprs_arr, get_inner_type_from_generic, get_option_inner,
+    get_param_type, get_params_arr, get_str_param,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -107,6 +107,36 @@ pub(crate) fn expand(
         quote! { .with_title(#title) }
     });
 
+    // The names of the value-carrying parameters, in declaration order.
+    //
+    // Arguments are extracted from a call's `arguments` map by name, and these
+    // are the only place the handler's own names survive to runtime -- Rust
+    // keeps no parameter names past compilation. Metadata-served parameters
+    // (`Context`, `Meta<_>`, `Dc<_>`, ...) are `none`-typed: they are neither
+    // published in the schema nor do they consume an argument slot, so they
+    // are skipped here for the same reason. An `Option<T>` parameter is an
+    // argument like any other -- it just need not be supplied.
+    let arg_names = function
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            FnArg::Typed(pat_type) => match &*pat_type.pat {
+                Pat::Ident(pat_ident) if get_param_type(&pat_type.ty).0 != "none" => {
+                    Some(pat_ident.ident.to_string())
+                }
+                _ => None,
+            },
+            FnArg::Receiver(_) => None,
+        })
+        .collect::<Vec<_>>();
+
+    let arg_names_code = if arg_names.is_empty() {
+        quote! {}
+    } else {
+        quote! { .with_arg_names([#(#arg_names),*]) }
+    };
+
     // If no schema is provided, generate it automatically from function arguments.
     let input_schema_code = if let Some(schema_json) = input_schema {
         if cfg!(not(feature = "legacy-spec")) {
@@ -135,11 +165,13 @@ pub(crate) fn expand(
                     && let Pat::Ident(pat_ident) = &*pat_type.pat
                 {
                     let arg_name = pat_ident.ident.to_string();
-                    let cat = get_arg_type(&pat_type.ty);
+                    let (cat, is_required) = get_param_type(&pat_type.ty);
                     if cat == "none" {
                         continue;
                     }
-                    let ty = &*pat_type.ty;
+                    // An `Option<T>` argument is described by its `T`, so the
+                    // subschema is probed past the `Option` first.
+                    let ty = get_option_inner(&pat_type.ty).unwrap_or(&pat_type.ty);
                     let prop_value = if cat == "object" {
                         // Structured args arrive wrapped (e.g. `Json<T>`); probe
                         // the inner type so a `JsonSchema`-deriving `T` yields a
@@ -151,7 +183,9 @@ pub(crate) fn expand(
                         quote! { neva::__macro_support::primitive_subschema(#json_type) }
                     };
                     prop_pairs.push(quote! { (#arg_name.to_string(), #prop_value) });
-                    required.push(arg_name);
+                    if is_required {
+                        required.push(arg_name);
+                    }
                 }
             }
             if prop_pairs.is_empty() {
@@ -173,12 +207,15 @@ pub(crate) fn expand(
                     && let Pat::Ident(pat_ident) = &*pat_type.pat
                 {
                     let arg_name = pat_ident.ident.to_string();
-                    let arg_type = get_arg_type(&pat_type.ty);
-                    if !arg_type.eq("none") {
-                        schema_entries.push(quote! {
-                            .with_required(#arg_name, #arg_type, #arg_type)
-                        });
+                    let (arg_type, is_required) = get_param_type(&pat_type.ty);
+                    if arg_type == "none" {
+                        continue;
                     }
+                    schema_entries.push(if is_required {
+                        quote! { .with_required(#arg_name, #arg_type, #arg_type) }
+                    } else {
+                        quote! { .with_prop(#arg_name, #arg_type, #arg_type) }
+                    });
                 }
             }
             if !schema_entries.is_empty() {
@@ -284,6 +321,7 @@ pub(crate) fn expand(
             app
                 #middleware_code
                 .map_tool(stringify!(#func_name), #func_name)
+                #arg_names_code
                 #title_code
                 #description_code
                 #input_schema_code

--- a/neva_macros/src/server/tool.rs
+++ b/neva_macros/src/server/tool.rs
@@ -155,33 +155,35 @@ pub(crate) fn expand(
                     && let Pat::Ident(pat_ident) = &*pat_type.pat
                 {
                     let arg_name = pat_ident.ident.to_string();
-                    let cat = get_param_type(&pat_type.ty).0;
-                    if cat == "none" {
+                    if get_param_type(&pat_type.ty).0 == "none" {
                         continue;
                     }
                     // An `Option<T>` argument is described by its `T`, so the
-                    // subschema is probed past the `Option` first.
+                    // subschema is probed past the `Option` first. Structured
+                    // args arrive wrapped (e.g. `Json<T>`); probe the inner
+                    // type so a `JsonSchema`-deriving `T` yields a rich
+                    // schema. Bare `Value` (no inner) probes itself.
                     let ty = get_option_inner(&pat_type.ty).unwrap_or(&pat_type.ty);
-                    let prop_value = if cat == "object" {
-                        // Structured args arrive wrapped (e.g. `Json<T>`); probe
-                        // the inner type so a `JsonSchema`-deriving `T` yields a
-                        // rich schema. Bare `Value` (no inner) probes itself.
-                        let probe_ty = get_inner_type_from_generic(ty).unwrap_or(ty);
-                        quote! { neva::__tool_arg_subschema!(#probe_ty) }
-                    } else {
-                        let json_type = if cat == "slice" { "array" } else { cat };
-                        quote! { neva::__macro_support::primitive_subschema(#json_type) }
-                    };
-                    // Whether the parameter is an argument at all, and whether
-                    // it is required, are settled from the resolved type for
-                    // the same reason the names are: a type alias hides both
-                    // `Meta<_>` and `Option<_>` from a syntactic test, and a
-                    // schema that disagrees with `ToolHandler::args` describes
-                    // a call the handler will not read.
+                    let probe_ty = get_inner_type_from_generic(ty).unwrap_or(ty);
+                    // Everything the schema says about the parameter -- whether
+                    // it is an argument, whether it is required, and which JSON
+                    // type it publishes -- is settled from the resolved type
+                    // for the same reason the names are: a type alias hides
+                    // `Meta<_>`, `Option<_>` and the underlying primitive alike
+                    // from a syntactic test, and a schema that disagrees with
+                    // `ToolHandler::args` describes a call the handler will not
+                    // read. The probe stays syntactic because no trait can name
+                    // the `T` inside an aliased `Json<T>`.
                     let param_ty = &*pat_type.ty;
                     entries.push(quote! {
                         if <#param_ty as neva::__macro_support::IsArgument>::is_argument() {
-                            props.push((#arg_name.to_string(), #prop_value));
+                            let category = <#param_ty as neva::__macro_support::IsArgument>::category();
+                            let subschema = if category == "object" {
+                                neva::__tool_arg_subschema!(#probe_ty)
+                            } else {
+                                neva::__macro_support::primitive_subschema(category)
+                            };
+                            props.push((#arg_name.to_string(), subschema));
                             if <#param_ty as neva::__macro_support::IsArgument>::is_required() {
                                 required.push(#arg_name.to_string());
                             }
@@ -208,20 +210,21 @@ pub(crate) fn expand(
                     && let Pat::Ident(pat_ident) = &*pat_type.pat
                 {
                     let arg_name = pat_ident.ident.to_string();
-                    let arg_type = get_param_type(&pat_type.ty).0;
-                    if arg_type == "none" {
+                    if get_param_type(&pat_type.ty).0 == "none" {
                         continue;
                     }
-                    // See the 2026-07-28 branch: which parameters are arguments,
-                    // and which of them are required, come from the resolved
-                    // type so the schema cannot disagree with the handler.
+                    // See the 2026-07-28 branch: whether the parameter is an
+                    // argument, whether it is required and which JSON type it
+                    // publishes all come from the resolved type, so the schema
+                    // cannot disagree with the handler.
                     let param_ty = &*pat_type.ty;
                     schema_entries.push(quote! {
                         let schema = if <#param_ty as neva::__macro_support::IsArgument>::is_argument() {
+                            let category = <#param_ty as neva::__macro_support::IsArgument>::category();
                             if <#param_ty as neva::__macro_support::IsArgument>::is_required() {
-                                schema.with_required(#arg_name, #arg_type, #arg_type)
+                                schema.with_required(#arg_name, category, category)
                             } else {
-                                schema.with_prop(#arg_name, #arg_type, #arg_type)
+                                schema.with_prop(#arg_name, category, category)
                             }
                         } else {
                             schema

--- a/neva_macros/src/server/tool.rs
+++ b/neva_macros/src/server/tool.rs
@@ -22,7 +22,7 @@
 
 use super::{
     get_arg_type, get_bool_param, get_exprs_arr, get_inner_type_from_generic, get_option_inner,
-    get_param_type, get_params_arr, get_str_param,
+    get_param_type, get_params_arr, get_str_param, param_idents_and_types,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -111,30 +111,21 @@ pub(crate) fn expand(
     //
     // Arguments are extracted from a call's `arguments` map by name, and these
     // are the only place the handler's own names survive to runtime -- Rust
-    // keeps no parameter names past compilation. Metadata-served parameters
-    // (`Context`, `Meta<_>`, `Dc<_>`, ...) are `none`-typed: they are neither
-    // published in the schema nor do they consume an argument slot, so they
-    // are skipped here for the same reason. An `Option<T>` parameter is an
-    // argument like any other -- it just need not be supplied.
-    let arg_names = function
-        .sig
-        .inputs
-        .iter()
-        .filter_map(|arg| match arg {
-            FnArg::Typed(pat_type) => match &*pat_type.pat {
-                Pat::Ident(pat_ident) if get_param_type(&pat_type.ty).0 != "none" => {
-                    Some(pat_ident.ident.to_string())
-                }
-                _ => None,
-            },
-            FnArg::Receiver(_) => None,
-        })
-        .collect::<Vec<_>>();
-
-    let arg_names_code = if arg_names.is_empty() {
+    // keeps no parameter names past compilation.
+    //
+    // Which parameters count is decided by `neva::__arg_names!` from the
+    // *resolved* type rather than here from its spelling: metadata-served
+    // parameters (`Context`, `Meta<_>`, `Dc<_>`) may reach the signature
+    // through a type alias, which this macro cannot see through but trait
+    // resolution can. Deciding it syntactically would name an argument
+    // `ToolHandler::args` does not count, and `App::run` refuses to start on
+    // exactly that disagreement.
+    let params = param_idents_and_types(function);
+    let arg_names_code = if params.is_empty() {
         quote! {}
     } else {
-        quote! { .with_arg_names([#(#arg_names),*]) }
+        let pairs = params.iter().map(|(name, ty)| quote! { #name: #ty });
+        quote! { .with_arg_names(neva::__arg_names!(#(#pairs),*)) }
     };
 
     // If no schema is provided, generate it automatically from function arguments.
@@ -158,14 +149,13 @@ pub(crate) fn expand(
             // so generated code never names `serde_json`. Primitive args use
             // `primitive_subschema`; object/custom args use
             // `__tool_arg_subschema!` (rich-or-fallback).
-            let mut prop_pairs = Vec::new();
-            let mut required = Vec::new();
+            let mut entries = Vec::new();
             for arg in &function.sig.inputs {
                 if let FnArg::Typed(pat_type) = arg
                     && let Pat::Ident(pat_ident) = &*pat_type.pat
                 {
                     let arg_name = pat_ident.ident.to_string();
-                    let (cat, is_required) = get_param_type(&pat_type.ty);
+                    let cat = get_param_type(&pat_type.ty).0;
                     if cat == "none" {
                         continue;
                     }
@@ -182,21 +172,32 @@ pub(crate) fn expand(
                         let json_type = if cat == "slice" { "array" } else { cat };
                         quote! { neva::__macro_support::primitive_subschema(#json_type) }
                     };
-                    prop_pairs.push(quote! { (#arg_name.to_string(), #prop_value) });
-                    if is_required {
-                        required.push(arg_name);
-                    }
+                    // Whether the parameter is an argument at all, and whether
+                    // it is required, are settled from the resolved type for
+                    // the same reason the names are: a type alias hides both
+                    // `Meta<_>` and `Option<_>` from a syntactic test, and a
+                    // schema that disagrees with `ToolHandler::args` describes
+                    // a call the handler will not read.
+                    let param_ty = &*pat_type.ty;
+                    entries.push(quote! {
+                        if <#param_ty as neva::__macro_support::IsArgument>::is_argument() {
+                            props.push((#arg_name.to_string(), #prop_value));
+                            if <#param_ty as neva::__macro_support::IsArgument>::is_required() {
+                                required.push(#arg_name.to_string());
+                            }
+                        }
+                    });
                 }
             }
-            if prop_pairs.is_empty() {
+            if entries.is_empty() {
                 quote! {}
             } else {
                 quote! {
                     .with_input_schema(|_| {
-                        neva::__macro_support::object_schema(
-                            ::std::vec![ #(#prop_pairs),* ],
-                            ::std::vec![ #(#required.to_string()),* ],
-                        )
+                        let mut props = ::std::vec::Vec::new();
+                        let mut required = ::std::vec::Vec::new();
+                        #(#entries)*
+                        neva::__macro_support::object_schema(props, required)
                     })
                 }
             }
@@ -207,22 +208,32 @@ pub(crate) fn expand(
                     && let Pat::Ident(pat_ident) = &*pat_type.pat
                 {
                     let arg_name = pat_ident.ident.to_string();
-                    let (arg_type, is_required) = get_param_type(&pat_type.ty);
+                    let arg_type = get_param_type(&pat_type.ty).0;
                     if arg_type == "none" {
                         continue;
                     }
-                    schema_entries.push(if is_required {
-                        quote! { .with_required(#arg_name, #arg_type, #arg_type) }
-                    } else {
-                        quote! { .with_prop(#arg_name, #arg_type, #arg_type) }
+                    // See the 2026-07-28 branch: which parameters are arguments,
+                    // and which of them are required, come from the resolved
+                    // type so the schema cannot disagree with the handler.
+                    let param_ty = &*pat_type.ty;
+                    schema_entries.push(quote! {
+                        let schema = if <#param_ty as neva::__macro_support::IsArgument>::is_argument() {
+                            if <#param_ty as neva::__macro_support::IsArgument>::is_required() {
+                                schema.with_required(#arg_name, #arg_type, #arg_type)
+                            } else {
+                                schema.with_prop(#arg_name, #arg_type, #arg_type)
+                            }
+                        } else {
+                            schema
+                        };
                     });
                 }
             }
             if !schema_entries.is_empty() {
                 quote! {
                     .with_input_schema(|schema| {
-                        schema
                         #(#schema_entries)*
+                        schema
                     })
                 }
             } else {


### PR DESCRIPTION
## Summary

Tool and prompt arguments are now extracted **by name** instead of by position.

Extraction walked `arguments` (a `HashMap`) with `Iterator::next` and handed the values to the handler in whatever order the map happened to iterate. Two arguments of different types failed the call outright; two of the same type were
silently swapped. JSON object members are unordered by definition, so no map type could have fixed this -- the *n*-th value-carrying parameter is now looked up under the *n*-th declared argument name.

Two things had to be fixed alongside it, because until now the published schema and the handler did not describe the same call:

* A tool registered from a closure keyed its schema properties by **type name**, so `|a: i32, b: i32|` advertised a single `number` property and the second argument had nowhere to travel in. Properties are now one per argument, named
  and listed in `required`.
* Rust does not keep a closure's parameter names, so the names have to come from somewhere. `#[tool]` / `#[prompt]` pass the function's own; `map_tool!` / `map_prompt!` read them off the closure; `Tool::with_arg_names` declares them
  by hand; anything else falls back to positional `arg0`, `arg1`, ... which the schema then advertises verbatim.

Also adds `Option<T>` arguments, which previously did not compile at all (no `TypeCategory` impl): published under their own name, kept out of `required`, resolved to `None` when a call omits them.

`App::run` now fails at startup when a tool's published schema and its handler disagree -- an overridden `with_input_schema` without `with_arg_names`, or a miscounted declaration. Such a tool could never be called successfully, and this reports it before serving rather than on a peer's first call.

## Type
- [x] Bug fix
- [x] Feature
- [ ] Enhancement
- [ ] Performance
- [ ] Documentation
- [ ] Refactor
- [ ] Security
- [x] Breaking change

## Checklist
- [x] I added/updated tests where it makes sense
- [x] I updated docs/examples if needed
- [ ] This change is backwards-compatible (or clearly marked as breaking)
- [x] I ran formatting/lints locally (if applicable)

**Breaking** (0.5.x, listed in `CHANGELOG.md`):

* `App::map_tool` / `Tool::new` take `Args: FromHandlerArgs<CallToolRequestParams>`, `App::map_prompt` / `Prompt::new` take `Args: FromHandlerArgs<GetPromptRequestParams>`, replacing the `TryFrom<...Params>` bounds. Handlers are unaffected; a hand-written `impl TryFrom<CallToolRequestParams> for MyArgs` needs porting.
* `HandlerParams::Tool` / `::Prompt` carry the primitive's `ArgNames`.
* `ToolHandler::args` returns `Vec<ToolArg>` (ordered, with a `required` flag).
* Wire: a tool registered from a bare closure advertises `arg0`, `arg1`, ... instead of the former type names. `#[tool]` tools are unaffected - they already published their parameter names, and now read by them.